### PR TITLE
[ECSoC26] fix: hide floating chat button on auth pages

### DIFF
--- a/components/layout/ChatFAB.jsx
+++ b/components/layout/ChatFAB.jsx
@@ -106,6 +106,10 @@ export default function ChatFAB() {
 
   const tNavbar = useTranslations('Navbar')
 
+  if (pathname?.includes('/auth') || pathname?.includes('/sign-in') || pathname?.includes('/sign-up') || pathname?.includes('/login')) {
+    return null
+  }
+
   return (
     <>
       {/* Floating Window */}


### PR DESCRIPTION
- #46 

fixed the floating chat window appearing on the auth pages.
