### PR TITLE
[ECSoC26] feat(cycle-history): add timeline visualization

### DIFF
--- a/app/[locale]/page.js
+++ b/app/[locale]/page.js
@@ -15,6 +15,7 @@ import ChatAssistant from '@/components/dashboard/ChatAssistant'
 import DailyLogPanel from '@/components/dashboard/DailyLogPanel'
 import OnboardingModal from '@/components/dashboard/OnboardingModal'
 import PredictionCard from '@/components/dashboard/PredictionCard'
+import CycleHistoryCard from '@/components/dashboard/CycleHistoryCard'
 import { useOffline } from '@/lib/OfflineContext'
 import { useLocale, useTranslations } from 'next-intl'
 
@@ -439,6 +440,11 @@ const HerCycleApp = () => {
             activeLang={activeLang}
           />
           <PredictionCard cycleData={cycleData} activeLang={activeLang} />
+        </div>
+
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: '20px', marginTop: '32px', marginBottom: '48px' }}>
+          <CycleHistoryCard cycleData={cycleData} />
+          <div className="placeholder" />
         </div>
 
         <Footer />

--- a/components/dashboard/CycleHistoryCard.jsx
+++ b/components/dashboard/CycleHistoryCard.jsx
@@ -1,0 +1,54 @@
+import React, { useState } from 'react';
+import CycleHistoryFilters from './CycleHistoryFilters';
+import CycleHistoryItem from './CycleHistoryItem';
+
+export default function CycleHistoryCard({ cycleData }) {
+  const [filter, setFilter] = useState('All');
+  
+  const cycles = cycleData?.cycles || [];
+  
+  // Sort cycles by start_date descending
+  const sortedCycles = [...cycles].sort((a, b) => new Date(b.start_date) - new Date(a.start_date));
+  
+  // Group by year
+  const groupedCycles = sortedCycles.reduce((acc, cycle) => {
+    const year = new Date(cycle.start_date).getFullYear();
+    if (!acc[year]) acc[year] = [];
+    acc[year].push(cycle);
+    return acc;
+  }, {});
+
+  return (
+    <div className="panel glass" style={{ display: 'flex', flexDirection: 'column', height: '420px', overflow: 'hidden' }}>
+      <div style={{ marginBottom: '16px' }}>
+        <h3 style={{ margin: '0 0 4px 0', fontSize: '1.2rem', color: '#fff', fontWeight: 600 }}>Cycle History</h3>
+        <div style={{ opacity: 0.7, fontSize: '0.9rem', color: '#fff' }}>{cycles.length} recorded cycles</div>
+      </div>
+      
+      <CycleHistoryFilters currentFilter={filter} onFilterChange={setFilter} />
+      
+      <div 
+        style={{ 
+          flex: 1, 
+          overflowY: 'auto', 
+          paddingRight: '8px',
+          scrollbarWidth: 'thin',
+          scrollbarColor: 'rgba(255,255,255,0.2) transparent'
+        }}
+        className="custom-scrollbar"
+      >
+        {Object.keys(groupedCycles).sort((a, b) => b - a).map(year => (
+          <div key={year} style={{ marginBottom: '24px' }}>
+            <h5 style={{ margin: '0 0 12px 0', fontSize: '1rem', opacity: 0.8, color: '#fff', fontWeight: 500 }}>{year}</h5>
+            {groupedCycles[year].map(cycle => (
+              <CycleHistoryItem key={cycle.id || cycle.start_date} cycle={cycle} filter={filter} />
+            ))}
+          </div>
+        ))}
+        {cycles.length === 0 && (
+          <div style={{ opacity: 0.5, fontSize: '0.9rem', color: '#fff' }}>No cycle history available yet.</div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/dashboard/CycleHistoryFilters.jsx
+++ b/components/dashboard/CycleHistoryFilters.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+export default function CycleHistoryFilters({ currentFilter, onFilterChange }) {
+  const filters = ['All', 'Period', 'Ovulation'];
+
+  return (
+    <div style={{ display: 'flex', gap: '8px', marginBottom: '20px', flexWrap: 'wrap' }}>
+      {filters.map(filter => {
+        const active = currentFilter === filter;
+        return (
+          <button
+            key={filter}
+            type="button"
+            className={`symp-chip ${active ? 'active' : ''}`}
+            onClick={() => onFilterChange(filter)}
+            style={{ padding: '6px 16px', fontSize: '0.9rem' }}
+          >
+            {filter}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/components/dashboard/CycleHistoryItem.jsx
+++ b/components/dashboard/CycleHistoryItem.jsx
@@ -1,0 +1,70 @@
+import React from 'react';
+
+export default function CycleHistoryItem({ cycle, filter }) {
+  const start = new Date(cycle.start_date);
+  const end = cycle.end_date ? new Date(cycle.end_date) : new Date(start.getTime() + 4 * 24 * 60 * 60 * 1000);
+  
+  // Calculate period length in days
+  const periodLength = Math.max(1, Math.round((end - start) / (1000 * 60 * 60 * 24)) + 1);
+  const cycleLength = cycle.cycle_length || 28;
+
+  const startMonth = start.toLocaleString('default', { month: 'short' });
+  const startDate = start.getDate();
+  const endMonth = end.toLocaleString('default', { month: 'short' });
+  const endDate = end.getDate();
+
+  const dateRangeStr = `${startMonth} ${startDate} – ${endMonth} ${endDate}`;
+
+  return (
+    <div style={{ marginBottom: '16px', display: 'flex', flexDirection: 'column', gap: '8px' }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: '0.9rem', color: '#fff', alignItems: 'center' }}>
+        <span style={{ fontWeight: 500 }}>{dateRangeStr}</span>
+        <span style={{ opacity: 0.7, fontSize: '0.85rem' }}>{periodLength} day period • {cycleLength} day cycle</span>
+      </div>
+      
+      {/* Timeline Bar */}
+      <div style={{ 
+        position: 'relative', 
+        width: '100%', 
+        height: '10px', 
+        background: 'rgba(255, 255, 255, 0.08)', 
+        borderRadius: '5px', 
+        overflow: 'hidden' 
+      }}>
+        {/* Period Segment */}
+        {(filter === 'All' || filter === 'Period') && (
+          <div 
+            title="Period"
+            style={{ 
+              position: 'absolute', 
+              left: 0, 
+              top: 0, 
+              bottom: 0, 
+              width: `${Math.min(100, (periodLength / cycleLength) * 100)}%`, 
+              background: '#ff4757',
+              borderRadius: '5px',
+              zIndex: 2
+            }} 
+          />
+        )}
+
+        {/* Ovulation Segment */}
+        {(filter === 'All' || filter === 'Ovulation') && (
+          <div 
+            title="Ovulation Window"
+            style={{ 
+              position: 'absolute', 
+              left: `${Math.min(100, (11 / cycleLength) * 100)}%`, 
+              top: 0, 
+              bottom: 0, 
+              width: `${Math.min(100, (5 / cycleLength) * 100)}%`, 
+              background: '#00b894', 
+              borderRadius: '5px',
+              zIndex: 1
+            }} 
+          />
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Linked Issue

Fixes #43 

## Description

Implemented a new **Cycle History Timeline** feature on the dashboard to help users visualize their previously recorded menstrual cycles.

### Changes Made

- Added a new **Cycle History** dashboard card.
- Displays cycle history using data fetched from the existing `cycles` database table.
- Groups recorded cycles by year.
- Added filter chips:
  - All
  - Period
  - Ovulation
- Displays:
  - Period start and end dates
  - Period duration (calculated from existing data)
  - Cycle length
  - Visual timeline with period and ovulation indicators
- Designed the component to match the existing HerCycle glassmorphism UI.
- Added the feature below the existing "Log Your Day" section while preserving the existing dashboard layout.
- Implemented the feature without modifying the database schema or existing application functionality.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (clean code updates, no behavior modifications)
- [ ] Documentation update
- [ ] Performance optimization
- [ ] Security patch

## Testing

Tested locally using:

```bash
npm install
npm run dev
```

Verified that:

- Cycle history is fetched from the existing database.
- Timeline renders correctly for recorded cycles.
- Year grouping works as expected.
- Filter chips update the displayed timeline correctly.
- Existing dashboard functionality remains unaffected.
- Layout remains responsive across desktop and mobile.

## Screenshots

<img width="781" height="667" alt="image" src="https://github.com/user-attachments/assets/9a8ca639-8a4a-4314-9e1c-e7c6b110b66e" />

<img width="807" height="577" alt="image" src="https://github.com/user-attachments/assets/bb808575-6143-42cc-9c04-7dc66ae2cb21" />

<img width="742" height="598" alt="image" src="https://github.com/user-attachments/assets/12120ab4-58a4-4330-804b-216578470431" />
