### PR TITLE
[ECSoC26] fix(api): add pagination to log-day/all AND secure date validation bounds #82 & 

### DIFF
--- a/app/api/log-day/all/route.js
+++ b/app/api/log-day/all/route.js
@@ -4,7 +4,10 @@ import { getSupabaseAdmin } from '@/lib/supabase-admin'
 import { crudLimiter, getRateLimitIdentifier } from '@/lib/rateLimiter'
 import { logger } from '@/lib/logger'
 
-// GET /api/log-day/all — fetch all daily logs for the user (used by Insights page)
+const DEFAULT_LIMIT = 100
+const MAX_LIMIT = 365
+
+// GET /api/log-day/all?page=0&limit=100 — fetch paginated daily logs for the user
 export async function GET(request) {
   // ============ RATE LIMITING ============
   try {
@@ -26,20 +29,37 @@ export async function GET(request) {
       return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 })
     }
 
+    // Parse pagination params
+    const { searchParams } = new URL(request.url)
+    const page  = Math.max(0, parseInt(searchParams.get('page')  || '0', 10))
+    const limit = Math.min(MAX_LIMIT, Math.max(1, parseInt(searchParams.get('limit') || String(DEFAULT_LIMIT), 10)))
+    const from  = page * limit
+    const to    = from + limit - 1
+
     const supabaseAdmin = getSupabaseAdmin()
-    const { data, error } = await supabaseAdmin
+    const { data, error, count } = await supabaseAdmin
       .from('daily_logs')
-      .select('*')
+      .select('*', { count: 'exact' })
       .eq('user_id', userId)
       .order('date', { ascending: false })
+      .range(from, to)
 
     if (error) {
-      logger.error(`Database error fetching all daily logs for user ${userId}:`, error.message);
+      logger.error(`Database error fetching daily logs for user ${userId}:`, error.message);
       return NextResponse.json({ success: false, error: error.message }, { status: 500 })
     }
 
-    logger.info(`Successfully fetched all daily logs for user ${userId}`);
-    return NextResponse.json({ success: true, data: data || [] })
+    logger.info(`Successfully fetched daily logs (page=${page}, limit=${limit}) for user ${userId}`);
+    return NextResponse.json({
+      success: true,
+      data: data || [],
+      pagination: {
+        page,
+        limit,
+        total: count ?? null,
+        hasMore: count != null ? from + limit < count : (data || []).length === limit,
+      },
+    })
   } catch (error) {
     logger.error('Error fetching all logs:', error.message || error);
     return NextResponse.json({ success: false, error: `Failed to fetch all logs: ${error.message || error}` }, { status: 500 })

--- a/app/api/log-day/route.js
+++ b/app/api/log-day/route.js
@@ -6,7 +6,19 @@ import { logger } from '@/lib/logger'
 import { z } from 'zod'
 
 const logPostSchema = z.object({
-  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Must be in YYYY-MM-DD format'),
+  date: z.string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, 'Must be in YYYY-MM-DD format')
+    .refine((val) => {
+      const today = new Date()
+      today.setHours(23, 59, 59, 999) // allow the full current day
+      return new Date(val) <= today
+    }, { message: 'Log date cannot be in the future.' })
+    .refine((val) => {
+      const twoYearsAgo = new Date()
+      twoYearsAgo.setFullYear(twoYearsAgo.getFullYear() - 2)
+      twoYearsAgo.setHours(0, 0, 0, 0)
+      return new Date(val) >= twoYearsAgo
+    }, { message: 'Log date cannot be older than 2 years.' }),
   symptoms: z.array(z.string().max(100)).max(50),
   mood: z.string().max(50).nullable().optional(),
   flow: z.string().max(10).nullable().optional(),


### PR DESCRIPTION
## Linked Issues
Fixes #81
Fixes #82

## Description
Hey! This PR bundles two critical fixes for the `/api/log-day` routes:

**1. Pagination for `/all` (Issue #81)**
* Added a default limit of 100 and a hard max of 365 to prevent server memory exhaustion.
* Used Supabase `.range()` to safely enforce the boundaries and returned a `pagination` object with the exact row count.

**2. Date Validation Bounds (Issue #82)**
* Added strict `.refine()` checks to the `date` schema to reject future dates and dates older than 2 years.
* Ensured the validation output remains a plain `YYYY-MM-DD` string, ensuring zero breaking changes to the frontend UI.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature 
- [ ] Refactoring 
- [x] Performance optimization
- [x] Security patch

## Testing
* Tested pagination locally by passing different `page` and `limit` params.
* Tested validation locally via `curl` to verify rejection of future/distant-past dates. 
* Extensively clicked through the frontend UI to confirm nothing broke during submission.

## Checklist
- [x] This PR is submitted under ECSOC.

*Contributor for ECSoC & ELUSOC 2026* 🚀