### PR TITLE
[ECSoC26] feat: add weight and BMI tracker

### DIFF
--- a/app/[locale]/insights/page.js
+++ b/app/[locale]/insights/page.js
@@ -13,6 +13,7 @@ import Navbar from '@/components/layout/Navbar'
 import Footer from '@/components/layout/Footer'
 import { useOffline } from '@/lib/OfflineContext'
 import { useTranslations } from 'next-intl'
+import WeightTrendChart from '@/components/dashboard/WeightTrendChart'
 
 // ─── Design tokens ────────────────────────────────────────────────────────────
 const PINK         = '#e8527e'
@@ -287,6 +288,7 @@ export default function InsightsPage() {
             </div>
           )}
 
+
           {/* ── Cycle Length Trend ── */}
           <SectionCard
             icon={<TrendingUp size={18} color={ACCENT} strokeWidth={1.5} />}
@@ -314,6 +316,8 @@ export default function InsightsPage() {
             )}
           </SectionCard>
 
+          <WeightTrendChart />
+          
           {/* ── Symptom Frequency ── */}
           <SectionCard
             icon={<Activity size={18} color={ACCENT} strokeWidth={1.5} />}

--- a/app/[locale]/track/page.js
+++ b/app/[locale]/track/page.js
@@ -10,6 +10,7 @@ import CycleCalendar from '@/components/dashboard/CycleCalendar'
 import DailyLogPanel from '@/components/dashboard/DailyLogPanel'
 import { useOffline } from '@/lib/OfflineContext'
 import { useTranslations, useLocale } from 'next-intl'
+import WeightTracker from '@/components/dashboard/WeightTracker'
 
 const TEXT_PRIMARY = '#ffffff'
 const TEXT_FAINT   = 'rgba(255,255,255,0.65)'
@@ -248,6 +249,10 @@ export default function TrackPage() {
                 {t('endPeriod')}
               </button>
             )}
+          </div>
+
+          <div style={{ marginTop: '1.5rem' }}>
+            <WeightTracker />
           </div>
 
           {/* Status banner when no cycles exist */}

--- a/app/api/weight/route.js
+++ b/app/api/weight/route.js
@@ -1,0 +1,142 @@
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+
+import { getAuthUserId } from '@/lib/clerk-server'
+import { getSupabaseAdmin } from '@/lib/supabase-admin'
+import { crudLimiter } from '@/lib/rateLimiter'
+import { logger } from '@/lib/logger'
+
+const dateSchema = z.string().regex(
+  /^\d{4}-\d{2}-\d{2}$/,
+  'Date must use YYYY-MM-DD format'
+)
+
+const weightEntrySchema = z.object({
+  recorded_date: dateSchema,
+  weight_kg: z.coerce.number().min(20).max(350),
+  waist_cm: z.coerce.number().min(30).max(250).nullable().optional(),
+  height_cm: z.coerce.number().min(100).max(250),
+})
+
+function calculateBMI(weightKg, heightCm) {
+  const heightMetres = heightCm / 100
+  return Number((weightKg / (heightMetres * heightMetres)).toFixed(2))
+}
+
+async function checkRateLimit(request, method) {
+  try {
+    await crudLimiter.check(request)
+    return null
+  } catch (error) {
+    logger.warn(`[Rate Limit] Weight ${method}: ${error.message}`)
+    return NextResponse.json(
+      { success: false, error: 'Too many requests, please slow down.' },
+      { status: 429 }
+    )
+  }
+}
+
+export async function GET(request) {
+  const rateLimitResponse = await checkRateLimit(request, 'GET')
+  if (rateLimitResponse) return rateLimitResponse
+
+  try {
+    const userId = await getAuthUserId()
+    if (!userId) {
+      return NextResponse.json(
+        { success: false, error: 'Unauthorized' },
+        { status: 401 }
+      )
+    }
+
+    const supabaseAdmin = getSupabaseAdmin()
+    const { data, error } = await supabaseAdmin
+      .from('weight_entries')
+      .select('*')
+      .eq('user_id', userId)
+      .order('recorded_date', { ascending: true })
+      .limit(365)
+
+    if (error) {
+      logger.error(`Unable to fetch weight entries for ${userId}:`, error.message)
+      return NextResponse.json(
+        { success: false, error: error.message },
+        { status: 500 }
+      )
+    }
+
+    return NextResponse.json({ success: true, data: data || [] })
+  } catch (error) {
+    logger.error('Weight GET failed:', error.message || error)
+    return NextResponse.json(
+      { success: false, error: 'Failed to fetch weight history.' },
+      { status: 500 }
+    )
+  }
+}
+
+export async function POST(request) {
+  const rateLimitResponse = await checkRateLimit(request, 'POST')
+  if (rateLimitResponse) return rateLimitResponse
+
+  try {
+    const userId = await getAuthUserId()
+    if (!userId) {
+      return NextResponse.json(
+        { success: false, error: 'Unauthorized' },
+        { status: 401 }
+      )
+    }
+
+    const json = await request.json()
+    const parsed = weightEntrySchema.safeParse(json)
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: 'Please check the entered values.',
+          details: parsed.error.flatten(),
+        },
+        { status: 400 }
+      )
+    }
+
+    const { recorded_date, weight_kg, waist_cm = null, height_cm } = parsed.data
+    const bmi = calculateBMI(weight_kg, height_cm)
+
+    const supabaseAdmin = getSupabaseAdmin()
+    const { data, error } = await supabaseAdmin
+      .from('weight_entries')
+      .upsert(
+        {
+          user_id: userId,
+          recorded_date,
+          weight_kg,
+          waist_cm,
+          height_cm,
+          bmi,
+          updated_at: new Date().toISOString(),
+        },
+        { onConflict: 'user_id,recorded_date' }
+      )
+      .select()
+      .single()
+
+    if (error) {
+      logger.error(`Unable to save weight entry for ${userId}:`, error.message)
+      return NextResponse.json(
+        { success: false, error: error.message },
+        { status: 500 }
+      )
+    }
+
+    return NextResponse.json({ success: true, data })
+  } catch (error) {
+    logger.error('Weight POST failed:', error.message || error)
+    return NextResponse.json(
+      { success: false, error: 'Failed to save the weight entry.' },
+      { status: 500 }
+    )
+  }
+}

--- a/components/dashboard/WeightTracker.jsx
+++ b/components/dashboard/WeightTracker.jsx
@@ -1,0 +1,242 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import { Activity, Ruler, Scale, Save } from 'lucide-react'
+import toast from 'react-hot-toast'
+
+const cardStyle = {
+  background: 'rgba(255,255,255,0.08)',
+  border: '1px solid rgba(255,255,255,0.14)',
+  borderRadius: 16,
+  backdropFilter: 'blur(12px)',
+  padding: '1.5rem',
+}
+
+const fieldStyle = {
+  width: '100%',
+  padding: '0.75rem 0.85rem',
+  borderRadius: 10,
+  border: '1px solid rgba(255,255,255,0.18)',
+  background: 'rgba(255,255,255,0.08)',
+  color: '#fff',
+  outline: 'none',
+}
+
+function todayISO() {
+  return new Date().toISOString().split('T')[0]
+}
+
+function bmiLabel(bmi) {
+  if (!bmi) return 'Not calculated'
+  if (bmi < 18.5) return 'Below healthy range'
+  if (bmi < 25) return 'Healthy range'
+  if (bmi < 30) return 'Above healthy range'
+  return 'High range'
+}
+
+export default function WeightTracker({ onSaved }) {
+  const [form, setForm] = useState({
+    recorded_date: todayISO(),
+    weight_kg: '',
+    waist_cm: '',
+    height_cm: '',
+  })
+  const [saving, setSaving] = useState(false)
+
+  useEffect(() => {
+    try {
+      const savedHeight = localStorage.getItem('hercycle-height-cm')
+      if (savedHeight) {
+        setForm(current => ({ ...current, height_cm: savedHeight }))
+      }
+    } catch {
+      // Local storage can be unavailable in privacy-restricted browsers.
+    }
+  }, [])
+
+  const bmi = useMemo(() => {
+    const weight = Number(form.weight_kg)
+    const height = Number(form.height_cm) / 100
+    if (!weight || !height) return null
+    return Number((weight / (height * height)).toFixed(1))
+  }, [form.weight_kg, form.height_cm])
+
+  const setField = (name, value) => {
+    setForm(current => ({ ...current, [name]: value }))
+  }
+
+  const handleSubmit = async event => {
+    event.preventDefault()
+    setSaving(true)
+
+    try {
+      const response = await fetch('/api/weight', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          recorded_date: form.recorded_date,
+          weight_kg: Number(form.weight_kg),
+          waist_cm: form.waist_cm ? Number(form.waist_cm) : null,
+          height_cm: Number(form.height_cm),
+        }),
+      })
+
+      const result = await response.json()
+      if (!response.ok || !result.success) {
+        throw new Error(result.error || 'Unable to save the measurement.')
+      }
+
+      localStorage.setItem('hercycle-height-cm', form.height_cm)
+      toast.success('Measurement saved successfully')
+      setForm(current => ({
+        ...current,
+        weight_kg: '',
+        waist_cm: '',
+      }))
+      onSaved?.(result.data)
+    } catch (error) {
+      toast.error(error.message || 'Unable to save the measurement.')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <section style={cardStyle} aria-labelledby="weight-tracker-title">
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 6 }}>
+        <Scale size={24} color="#e91e8c" />
+        <h2 id="weight-tracker-title" style={{ margin: 0, fontSize: '1.2rem' }}>
+          Weight Tracker
+        </h2>
+      </div>
+
+      <p style={{ color: 'rgba(255,255,255,0.68)', marginTop: 0, marginBottom: 20 }}>
+        Record weight and waist measurements to understand gradual changes over time.
+      </p>
+
+      <form onSubmit={handleSubmit}>
+        <div style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))',
+          gap: 14,
+        }}>
+          <label>
+            <span style={{ display: 'block', marginBottom: 6 }}>Date</span>
+            <input
+              type="date"
+              value={form.recorded_date}
+              max={todayISO()}
+              onChange={e => setField('recorded_date', e.target.value)}
+              required
+              style={fieldStyle}
+            />
+          </label>
+
+          <label>
+            <span style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 6 }}>
+              <Scale size={15} /> Weight (kg)
+            </span>
+            <input
+              type="number"
+              min="20"
+              max="350"
+              step="0.1"
+              value={form.weight_kg}
+              onChange={e => setField('weight_kg', e.target.value)}
+              placeholder="e.g. 62.5"
+              required
+              style={fieldStyle}
+            />
+          </label>
+
+          <label>
+            <span style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 6 }}>
+              <Ruler size={15} /> Waist (cm)
+            </span>
+            <input
+              type="number"
+              min="30"
+              max="250"
+              step="0.1"
+              value={form.waist_cm}
+              onChange={e => setField('waist_cm', e.target.value)}
+              placeholder="Optional"
+              style={fieldStyle}
+            />
+          </label>
+
+          <label>
+            <span style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 6 }}>
+              <Ruler size={15} /> Height (cm)
+            </span>
+            <input
+              type="number"
+              min="100"
+              max="250"
+              step="0.1"
+              value={form.height_cm}
+              onChange={e => setField('height_cm', e.target.value)}
+              placeholder="e.g. 165"
+              required
+              style={fieldStyle}
+            />
+          </label>
+        </div>
+
+        <div style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          gap: 16,
+          flexWrap: 'wrap',
+          marginTop: 18,
+        }}>
+          <div style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 10,
+            color: 'rgba(255,255,255,0.78)',
+          }}>
+            <Activity size={18} color="#e91e8c" />
+            <span>
+              BMI: <strong style={{ color: '#fff' }}>{bmi ?? '—'}</strong>
+              {bmi ? ` · ${bmiLabel(bmi)}` : ''}
+            </span>
+          </div>
+
+          <button
+            type="submit"
+            disabled={saving}
+            style={{
+              border: 0,
+              borderRadius: 10,
+              padding: '0.8rem 1.1rem',
+              background: 'linear-gradient(135deg, #e8527e, #9d3f7a)',
+              color: '#fff',
+              fontWeight: 700,
+              cursor: saving ? 'not-allowed' : 'pointer',
+              opacity: saving ? 0.7 : 1,
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 8,
+            }}
+          >
+            <Save size={17} />
+            {saving ? 'Saving…' : 'Save measurement'}
+          </button>
+        </div>
+      </form>
+
+      <p style={{
+        color: 'rgba(255,255,255,0.52)',
+        fontSize: '0.78rem',
+        lineHeight: 1.5,
+        marginBottom: 0,
+        marginTop: 16,
+      }}>
+        BMI is a general screening measure and is not a diagnosis. Health changes should
+        be discussed with a qualified healthcare professional.
+      </p>
+    </section>
+  )
+}

--- a/components/dashboard/WeightTrendChart.jsx
+++ b/components/dashboard/WeightTrendChart.jsx
@@ -1,0 +1,184 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import { Activity, Scale } from 'lucide-react'
+import {
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts'
+
+const cardStyle = {
+  background: 'rgba(255,255,255,0.08)',
+  border: '1px solid rgba(255,255,255,0.14)',
+  borderRadius: 16,
+  backdropFilter: 'blur(12px)',
+  padding: '1.5rem',
+  marginBottom: '1.5rem',
+}
+
+function formatDate(value) {
+  return new Date(`${value}T00:00:00`).toLocaleDateString('en-IN', {
+    day: 'numeric',
+    month: 'short',
+  })
+}
+
+export default function WeightTrendChart({ refreshKey = 0 }) {
+  const [entries, setEntries] = useState([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    let active = true
+
+    async function loadEntries() {
+      setLoading(true)
+      try {
+        const response = await fetch('/api/weight', { cache: 'no-store' })
+        const result = await response.json()
+        if (active && response.ok && result.success) {
+          setEntries(result.data || [])
+        }
+      } catch (error) {
+        console.error('Failed to load weight history:', error)
+      } finally {
+        if (active) setLoading(false)
+      }
+    }
+
+    loadEntries()
+    return () => {
+      active = false
+    }
+  }, [refreshKey])
+
+  const chartData = useMemo(
+    () => entries.map(entry => ({
+      ...entry,
+      label: formatDate(entry.recorded_date),
+      weight: Number(entry.weight_kg),
+      waist: entry.waist_cm == null ? null : Number(entry.waist_cm),
+      bmi: Number(entry.bmi),
+    })),
+    [entries]
+  )
+
+  const latest = chartData.at(-1)
+  const first = chartData[0]
+  const weightChange = latest && first
+    ? Number((latest.weight - first.weight).toFixed(1))
+    : null
+
+  return (
+    <section style={cardStyle} aria-labelledby="weight-trend-title">
+      <div style={{
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'flex-start',
+        gap: 16,
+        flexWrap: 'wrap',
+        marginBottom: 18,
+      }}>
+        <div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 9 }}>
+            <Scale size={22} color="#e91e8c" />
+            <h3 id="weight-trend-title" style={{ margin: 0, fontSize: '1.05rem' }}>
+              Weight and waist trend
+            </h3>
+          </div>
+          <p style={{ color: 'rgba(255,255,255,0.62)', margin: '6px 0 0' }}>
+            Measurements are shown in chronological order.
+          </p>
+        </div>
+
+        {latest && (
+          <div style={{ textAlign: 'right' }}>
+            <strong style={{ display: 'block', fontSize: '1.3rem' }}>
+              {latest.weight} kg
+            </strong>
+            <span style={{ color: 'rgba(255,255,255,0.62)', fontSize: '0.82rem' }}>
+              BMI {latest.bmi}
+              {weightChange !== null && chartData.length > 1
+                ? ` · ${weightChange > 0 ? '+' : ''}${weightChange} kg overall`
+                : ''}
+            </span>
+          </div>
+        )}
+      </div>
+
+      {loading ? (
+        <p style={{ color: 'rgba(255,255,255,0.65)' }}>Loading measurements…</p>
+      ) : chartData.length === 0 ? (
+        <div style={{
+          minHeight: 180,
+          display: 'grid',
+          placeItems: 'center',
+          textAlign: 'center',
+          color: 'rgba(255,255,255,0.62)',
+        }}>
+          <div>
+            <Activity size={30} style={{ marginBottom: 8 }} />
+            <p style={{ margin: 0 }}>
+              No measurements yet. Add the first entry from the Track page.
+            </p>
+          </div>
+        </div>
+      ) : (
+        <div style={{ width: '100%', height: 300 }}>
+          <ResponsiveContainer>
+            <LineChart data={chartData} margin={{ top: 8, right: 12, left: -8, bottom: 4 }}>
+              <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.1)" />
+              <XAxis
+                dataKey="label"
+                tick={{ fill: 'rgba(255,255,255,0.72)', fontSize: 12 }}
+              />
+              <YAxis
+                yAxisId="weight"
+                tick={{ fill: 'rgba(255,255,255,0.72)', fontSize: 12 }}
+                domain={['dataMin - 3', 'dataMax + 3']}
+              />
+              <YAxis
+                yAxisId="waist"
+                orientation="right"
+                tick={{ fill: 'rgba(255,255,255,0.72)', fontSize: 12 }}
+                domain={['dataMin - 5', 'dataMax + 5']}
+              />
+              <Tooltip
+                contentStyle={{
+                  background: 'rgba(30,12,40,0.96)',
+                  border: '1px solid rgba(232,82,126,0.5)',
+                  borderRadius: 10,
+                }}
+                labelStyle={{ color: '#fff' }}
+              />
+              <Legend />
+              <Line
+                yAxisId="weight"
+                type="monotone"
+                dataKey="weight"
+                name="Weight (kg)"
+                stroke="#e8527e"
+                strokeWidth={3}
+                activeDot={{ r: 6 }}
+              />
+              <Line
+                yAxisId="waist"
+                type="monotone"
+                dataKey="waist"
+                name="Waist (cm)"
+                stroke="#a98bff"
+                strokeWidth={2}
+                connectNulls
+              />
+            </LineChart>
+          </ResponsiveContainer>
+        </div>
+      )}
+    </section>
+  )
+}

--- a/supabase/weight_entries.sql
+++ b/supabase/weight_entries.sql
@@ -1,0 +1,22 @@
+-- Issue #41: Weight Tracker
+CREATE TABLE IF NOT EXISTS weight_entries (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  recorded_date DATE NOT NULL,
+  weight_kg NUMERIC(5,2) NOT NULL CHECK (weight_kg >= 20 AND weight_kg <= 350),
+  waist_cm NUMERIC(5,2) CHECK (waist_cm IS NULL OR (waist_cm >= 30 AND waist_cm <= 250)),
+  height_cm NUMERIC(5,2) NOT NULL CHECK (height_cm >= 100 AND height_cm <= 250),
+  bmi NUMERIC(5,2) NOT NULL CHECK (bmi >= 5 AND bmi <= 100),
+  created_at TIMESTAMPTZ DEFAULT now(),
+  updated_at TIMESTAMPTZ DEFAULT now(),
+  CONSTRAINT weight_entries_user_date_unique UNIQUE (user_id, recorded_date)
+);
+
+CREATE INDEX IF NOT EXISTS weight_entries_user_date_idx
+  ON weight_entries(user_id, recorded_date DESC);
+
+ALTER TABLE weight_entries ENABLE ROW LEVEL SECURITY;
+
+-- The app accesses this table through its authenticated server API using
+-- the Supabase service-role client. Keeping RLS enabled prevents accidental
+-- direct anonymous access.


### PR DESCRIPTION
## Description

This PR adds a Weight Tracker that lets authenticated users record and monitor weight, waist measurements, and BMI over time.

## What was added

* Secure `/api/weight` GET and POST endpoints
* Clerk authentication and user-scoped Supabase queries
* Zod validation for date and measurement values
* Automatic server-side BMI calculation
* Upsert behaviour for one measurement per user per date
* Responsive Weight Tracker form
* Weight and waist trend chart on the Insights page
* Empty, loading, error, and success states
* Supabase migration with validation constraints and an index

## Why this change is useful

Weight management can be relevant for users monitoring PCOS-related health changes. The feature presents trends without treating BMI as a diagnosis and includes a clear health disclaimer.

## Testing performed

* [x] Added a valid weight entry
* [x] Added an entry without an optional waist value
* [x] Updated an entry on the same date
* [x] Confirmed BMI calculation
* [x] Confirmed invalid values are rejected
* [x] Confirmed unauthenticated API access returns 401
* [x] Confirmed data is isolated by Clerk user ID
* [x] Confirmed chart and empty states render correctly
* [x] Tested mobile layout
* [x] Ran `npm run lint`
* [x] Ran `npm run build`

Closes #41

## Screenshots
<img width="1166" height="739" alt="Screenshot 2026-07-11 214351" src="https://github.com/user-attachments/assets/10644b58-e7a2-4401-ad87-03a97a6e688c" />
<img width="1262" height="571" alt="Screenshot 2026-07-11 215112" src="https://github.com/user-attachments/assets/020bc570-4553-4817-9625-8675c755a31d" />
<img width="1446" height="250" alt="Screenshot 2026-07-11 215130" src="https://github.com/user-attachments/assets/8625e270-218c-450e-b0ac-ca18d9902647" />


## Checklist

- [x] This PR is submitted under ECSOC.
- [ ] Added the required **ECSoc26** label to this Pull Request.
- [x] Linked issue using `Fixes #<issue_number>`.
- [x] Tested locally.
- [x] `npm run build` completes successfully.
- [x] GitHub Actions checks pass.
- [x] No breaking changes introduced.
- [x] Documentation updated if required.

> ⚠️ **Important**
>
> PRs submitted for ECSOC **must include the `ECSoc26` label**.
> Pull Requests without this label **will not be processed by ECSOC Sentinel and will not receive a score.**
