### PR TITLE
[ECSoC26] feat: add cycle phase education card

### DIFF
--- a/app/[locale]/page.js
+++ b/app/[locale]/page.js
@@ -4,7 +4,11 @@ import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { useAuth, useUser } from '@clerk/nextjs'
 import toast from 'react-hot-toast'
-
+import CyclePhaseCard from '@/components/dashboard/CyclePhaseCard'
+import {
+  calculateCyclePhase,
+  getLatestCycle,
+} from '@/lib/calculateCyclePhase'
 import Navbar from '@/components/layout/Navbar'
 import Footer from '@/components/layout/Footer'
 import HeroSection from '@/components/dashboard/HeroSection'
@@ -373,6 +377,40 @@ const HerCycleApp = () => {
     }
   }
 
+  
+  const latestCycle = getLatestCycle(cycleData?.cycles)
+
+const periodStart =
+  latestCycle?.start_date ||
+  latestCycle?.period_start ||
+  null
+
+const periodEnd =
+  latestCycle?.end_date ||
+  latestCycle?.period_end ||
+  null
+
+const inferredPeriodLength = periodStart && periodEnd
+  ? Math.max(
+      1,
+      Math.round(
+        (
+          new Date(`${periodEnd}T00:00:00`) -
+          new Date(`${periodStart}T00:00:00`)
+        ) / 86400000
+      ) + 1
+    )
+  : 5
+
+const phaseInfo = calculateCyclePhase({
+  periodStart,
+  cycleLength:
+    latestCycle?.cycle_length ||
+    cycleData?.averageCycleLength ||
+    28,
+  periodLength: inferredPeriodLength,
+})
+
   return (
     <>
       <PinModal />
@@ -424,6 +462,15 @@ const HerCycleApp = () => {
             daysUntilNext={daysUntilNext}
             activeLang={activeLang}
           />
+        </div>
+        
+        <div style={{ marginTop: '1.5rem' }}>
+        <CyclePhaseCard
+        phaseKey={phaseInfo.phaseKey}
+        cycleDay={phaseInfo.cycleDay}
+        ovulationDay={phaseInfo.ovulationDay}
+        hasData={phaseInfo.hasData}
+        />
         </div>
 
         <FeaturesSection activeLang={activeLang} />

--- a/components/dashboard/CyclePhaseCard.jsx
+++ b/components/dashboard/CyclePhaseCard.jsx
@@ -1,0 +1,251 @@
+'use client'
+
+import {
+  Activity,
+  CircleHelp,
+  Droplets,
+  HeartPulse,
+  Lightbulb,
+  Moon,
+  Sparkles,
+  Sprout,
+  Sun,
+} from 'lucide-react'
+
+import { getCyclePhaseContent } from '@/lib/cyclePhaseContent'
+
+const ICONS = {
+  droplets: Droplets,
+  sprout: Sprout,
+  sun: Sun,
+  moon: Moon,
+  'circle-help': CircleHelp,
+}
+
+function InfoSection({ icon, title, children }) {
+  return (
+    <div className="phase-info-section">
+      <div className="phase-info-heading">
+        {icon}
+        <h4>{title}</h4>
+      </div>
+      {children}
+    </div>
+  )
+}
+
+export default function CyclePhaseCard({
+  phaseKey,
+  cycleDay,
+  ovulationDay,
+  hasData = true,
+  className = '',
+}) {
+  if (!hasData || !phaseKey) {
+    return (
+      <section className={`cycle-phase-card cycle-phase-empty ${className}`}>
+        <div className="phase-empty-icon" aria-hidden="true">
+          <Sparkles size={28} />
+        </div>
+        <div>
+          <p className="phase-eyebrow">Cycle education</p>
+          <h3>Discover your current cycle phase</h3>
+          <p>
+            Log the start date of your latest period to receive phase-based
+            educational information and self-care guidance.
+          </p>
+        </div>
+        <style jsx>{styles}</style>
+      </section>
+    )
+  }
+
+  const content = getCyclePhaseContent(phaseKey)
+  const PhaseIcon = ICONS[content.icon] || CircleHelp
+
+  return (
+    <section
+      className={`cycle-phase-card ${className}`}
+      style={{
+        '--phase-accent': content.accent,
+        '--phase-soft-accent': content.softAccent,
+      }}
+      aria-labelledby="current-cycle-phase-title"
+    >
+      <div className="phase-card-header">
+        <div className="phase-title-wrap">
+          <div className="phase-icon" aria-hidden="true">
+            <PhaseIcon size={24} />
+          </div>
+          <div>
+            <p className="phase-eyebrow">{content.eyebrow}</p>
+            <h3 id="current-cycle-phase-title">{content.title}</h3>
+          </div>
+        </div>
+        {cycleDay && (
+          <span className="phase-day-badge" aria-label={`Cycle day ${cycleDay}`}>
+            Day {cycleDay}
+          </span>
+        )}
+      </div>
+
+      <p className="phase-overview">{content.overview}</p>
+
+      <div className="phase-content-grid">
+        <InfoSection icon={<Activity size={18} />} title="Hormonal changes">
+          <p>{content.hormones}</p>
+        </InfoSection>
+
+        <InfoSection icon={<HeartPulse size={18} />} title="Common experiences">
+          <ul>
+            {content.symptoms.map(item => <li key={item}>{item}</li>)}
+          </ul>
+        </InfoSection>
+
+        <InfoSection icon={<Lightbulb size={18} />} title="Self-care ideas">
+          <ul>
+            {content.selfCare.map(item => <li key={item}>{item}</li>)}
+          </ul>
+        </InfoSection>
+      </div>
+
+      {phaseKey === 'ovulation' && ovulationDay && (
+        <p className="phase-estimate">
+          Estimated ovulation is around cycle day {ovulationDay}. This can vary
+          from cycle to cycle.
+        </p>
+      )}
+
+      <p className="phase-disclaimer">
+        Educational information only. Cycle predictions and symptoms vary and
+        should not replace advice from a qualified healthcare professional.
+      </p>
+
+      <style jsx>{styles}</style>
+    </section>
+  )
+}
+
+const styles = `
+  .cycle-phase-card {
+    position: relative;
+    overflow: hidden;
+    padding: 1.5rem;
+    border: 1px solid rgba(255, 255, 255, 0.14);
+    border-radius: 20px;
+    background: rgba(255, 255, 255, 0.075);
+    box-shadow: 0 16px 40px rgba(24, 8, 35, 0.18);
+    backdrop-filter: blur(16px);
+    color: #fff;
+  }
+  .phase-card-header, .phase-title-wrap, .phase-info-heading {
+    display: flex;
+    align-items: center;
+  }
+  .phase-card-header {
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 1rem;
+  }
+  .phase-title-wrap { gap: 0.85rem; }
+  .phase-icon, .phase-empty-icon {
+    display: grid;
+    flex: 0 0 auto;
+    place-items: center;
+    width: 46px;
+    height: 46px;
+    border: 1px solid rgba(255,255,255,.16);
+    border-radius: 14px;
+    background: var(--phase-soft-accent, rgba(232, 82, 126, 0.15));
+    color: var(--phase-accent, #e8527e);
+  }
+  .phase-eyebrow {
+    margin: 0 0 0.2rem;
+    color: var(--phase-accent, #e8527e);
+    font-size: 0.74rem;
+    font-weight: 800;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+  h3, h4, p { margin-top: 0; }
+  h3 { margin-bottom: 0; font-size: clamp(1.15rem, 2vw, 1.45rem); }
+  .phase-day-badge {
+    flex: 0 0 auto;
+    padding: 0.48rem 0.72rem;
+    border: 1px solid rgba(255,255,255,.18);
+    border-radius: 999px;
+    background: var(--phase-soft-accent);
+    color: #fff;
+    font-size: 0.78rem;
+    font-weight: 800;
+  }
+  .phase-overview {
+    margin-bottom: 1.25rem;
+    color: rgba(255, 255, 255, 0.78);
+    line-height: 1.65;
+  }
+  .phase-content-grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 0.9rem;
+  }
+  .phase-info-section {
+    padding: 1rem;
+    border: 1px solid rgba(255, 255, 255, 0.09);
+    border-radius: 14px;
+    background: rgba(255, 255, 255, 0.045);
+  }
+  .phase-info-heading {
+    gap: 0.5rem;
+    margin-bottom: 0.7rem;
+    color: var(--phase-accent);
+  }
+  .phase-info-heading h4 {
+    margin-bottom: 0;
+    color: #fff;
+    font-size: 0.9rem;
+  }
+  .phase-info-section p, .phase-info-section li {
+    color: rgba(255, 255, 255, 0.7);
+    font-size: 0.84rem;
+    line-height: 1.55;
+  }
+  .phase-info-section p, .phase-info-section ul { margin-bottom: 0; }
+  .phase-info-section ul { padding-left: 1.1rem; }
+  .phase-info-section li + li { margin-top: 0.4rem; }
+  .phase-estimate {
+    margin: 1rem 0 0;
+    padding: 0.75rem 0.9rem;
+    border-left: 3px solid var(--phase-accent);
+    border-radius: 8px;
+    background: var(--phase-soft-accent);
+    color: rgba(255, 255, 255, 0.83);
+    font-size: 0.84rem;
+  }
+  .phase-disclaimer {
+    margin: 1rem 0 0;
+    color: rgba(255, 255, 255, 0.47);
+    font-size: 0.72rem;
+    line-height: 1.5;
+  }
+  .cycle-phase-empty {
+    display: flex;
+    align-items: flex-start;
+    gap: 1rem;
+  }
+  .cycle-phase-empty h3 { margin-bottom: 0.45rem; }
+  .cycle-phase-empty p:last-child {
+    margin-bottom: 0;
+    color: rgba(255, 255, 255, 0.68);
+    line-height: 1.6;
+  }
+  @media (max-width: 900px) {
+    .phase-content-grid { grid-template-columns: 1fr; }
+  }
+  @media (max-width: 520px) {
+    .cycle-phase-card { padding: 1.1rem; border-radius: 16px; }
+    .phase-card-header { align-items: flex-start; }
+    .phase-day-badge { padding: 0.4rem 0.6rem; }
+    .cycle-phase-empty { flex-direction: column; }
+  }
+`

--- a/lib/calculateCyclePhase.js
+++ b/lib/calculateCyclePhase.js
@@ -1,0 +1,79 @@
+const DAY_IN_MS = 24 * 60 * 60 * 1000
+
+function toLocalDateOnly(value) {
+  if (!value) return null
+  const date = new Date(`${String(value).slice(0, 10)}T00:00:00`)
+  if (Number.isNaN(date.getTime())) return null
+  date.setHours(0, 0, 0, 0)
+  return date
+}
+
+export function calculateCyclePhase({
+  periodStart,
+  cycleLength = 28,
+  periodLength = 5,
+  today = new Date(),
+}) {
+  const start = toLocalDateOnly(periodStart)
+  if (!start) {
+    return {
+      phaseKey: null,
+      cycleDay: null,
+      ovulationDay: null,
+      hasData: false,
+      reason: 'missing-period-start',
+    }
+  }
+
+  const current = new Date(today)
+  current.setHours(0, 0, 0, 0)
+  const cycleDay = Math.floor((current.getTime() - start.getTime()) / DAY_IN_MS) + 1
+
+  if (cycleDay < 1) {
+    return {
+      phaseKey: null,
+      cycleDay,
+      ovulationDay: null,
+      hasData: false,
+      reason: 'future-period-start',
+    }
+  }
+
+  const safeCycleLength = Number.isFinite(Number(cycleLength))
+    ? Math.min(60, Math.max(21, Math.round(Number(cycleLength))))
+    : 28
+
+  const safePeriodLength = Number.isFinite(Number(periodLength))
+    ? Math.min(10, Math.max(1, Math.round(Number(periodLength))))
+    : 5
+
+  const ovulationDay = Math.max(safePeriodLength + 2, safeCycleLength - 14)
+  const ovulationWindowStart = Math.max(safePeriodLength + 1, ovulationDay - 1)
+  const ovulationWindowEnd = Math.min(safeCycleLength, ovulationDay + 1)
+
+  let phaseKey = 'irregular'
+  if (cycleDay <= safePeriodLength) phaseKey = 'menstrual'
+  else if (cycleDay < ovulationWindowStart) phaseKey = 'follicular'
+  else if (cycleDay <= ovulationWindowEnd) phaseKey = 'ovulation'
+  else if (cycleDay <= safeCycleLength) phaseKey = 'luteal'
+
+  return {
+    phaseKey,
+    cycleDay,
+    ovulationDay,
+    cycleLength: safeCycleLength,
+    periodLength: safePeriodLength,
+    hasData: true,
+    reason: null,
+  }
+}
+
+export function getLatestCycle(cycles = []) {
+  return [...cycles]
+    .filter(cycle => cycle?.start_date || cycle?.period_start)
+    .sort((a, b) => {
+      const aTime = new Date(a.start_date || a.period_start).getTime()
+      const bTime = new Date(b.start_date || b.period_start).getTime()
+      return bTime - aTime
+    })[0] || null
+}

--- a/lib/cyclePhaseContent.js
+++ b/lib/cyclePhaseContent.js
@@ -1,0 +1,126 @@
+export const CYCLE_PHASES = {
+  menstrual: {
+    key: 'menstrual',
+    title: 'Menstrual Phase',
+    eyebrow: 'Rest and reset',
+    overview:
+      'Your period begins during this phase as the uterine lining is shed. Energy levels may feel lower, so a slower pace can be helpful.',
+    hormones:
+      'Estrogen and progesterone are at their lowest levels at the beginning of the cycle.',
+    symptoms: [
+      'Cramps or lower-back discomfort',
+      'Lower energy or tiredness',
+      'Mood changes',
+      'Bloating or headaches',
+    ],
+    selfCare: [
+      'Use a heating pad for cramps',
+      'Choose gentle movement such as walking or stretching',
+      'Stay hydrated and include iron-rich foods',
+      'Give yourself extra rest when needed',
+    ],
+    accent: '#ff6b81',
+    softAccent: 'rgba(255, 107, 129, 0.16)',
+    icon: 'droplets',
+  },
+  follicular: {
+    key: 'follicular',
+    title: 'Follicular Phase',
+    eyebrow: 'Energy is rebuilding',
+    overview:
+      'After menstruation, your body prepares an egg for ovulation. Many people notice gradually improving energy and focus.',
+    hormones:
+      'Estrogen begins to rise while follicle-stimulating hormone supports the development of an ovarian follicle.',
+    symptoms: [
+      'Increasing energy',
+      'Improved concentration',
+      'Lighter mood',
+      'Changes in cervical discharge',
+    ],
+    selfCare: [
+      'Try strength training or moderate exercise if comfortable',
+      'Plan demanding tasks while energy is improving',
+      'Eat balanced meals with protein and fibre',
+      'Continue tracking discharge and symptoms',
+    ],
+    accent: '#a29bfe',
+    softAccent: 'rgba(162, 155, 254, 0.16)',
+    icon: 'sprout',
+  },
+  ovulation: {
+    key: 'ovulation',
+    title: 'Ovulation Phase',
+    eyebrow: 'Peak fertility window',
+    overview:
+      'Ovulation usually happens around the middle of the cycle when an egg is released from the ovary.',
+    hormones:
+      'A rise in estrogen is followed by a luteinizing hormone surge that triggers ovulation.',
+    symptoms: [
+      'Clear or slippery cervical discharge',
+      'Mild one-sided pelvic discomfort',
+      'Higher energy or confidence',
+      'Slight rise in body temperature after ovulation',
+    ],
+    selfCare: [
+      'Stay hydrated, especially during active days',
+      'Track discharge if you monitor fertility',
+      'Choose nourishing meals and regular movement',
+      'Use contraception as advised if avoiding pregnancy',
+    ],
+    accent: '#00b894',
+    softAccent: 'rgba(0, 184, 148, 0.16)',
+    icon: 'sun',
+  },
+  luteal: {
+    key: 'luteal',
+    title: 'Luteal Phase',
+    eyebrow: 'Slow down and support',
+    overview:
+      'After ovulation, the body prepares for a possible pregnancy. If pregnancy does not occur, hormone levels fall before the next period.',
+    hormones:
+      'Progesterone rises after ovulation and later falls along with estrogen before menstruation.',
+    symptoms: [
+      'Breast tenderness',
+      'Bloating or food cravings',
+      'Mood changes or irritability',
+      'Lower energy or sleep changes',
+    ],
+    selfCare: [
+      'Prioritise regular sleep',
+      'Choose steady meals and reduce excess salt if bloated',
+      'Try light exercise, yoga, or breathing exercises',
+      'Track severe or unusual symptoms for a clinician',
+    ],
+    accent: '#fdcb6e',
+    softAccent: 'rgba(253, 203, 110, 0.16)',
+    icon: 'moon',
+  },
+  irregular: {
+    key: 'irregular',
+    title: 'Cycle Timing Varies',
+    eyebrow: 'Your cycle may be running longer',
+    overview:
+      'Your current cycle has gone beyond the expected length. Occasional variation can happen, but repeated or large changes are worth tracking.',
+    hormones:
+      'Hormonal timing can vary because of stress, sleep, illness, travel, nutrition, PCOS, and other factors.',
+    symptoms: [
+      'A delayed period',
+      'Unpredictable discharge',
+      'PMS-like symptoms',
+      'Changes from your usual pattern',
+    ],
+    selfCare: [
+      'Keep logging symptoms and cycle dates',
+      'Take a pregnancy test when relevant',
+      'Maintain regular sleep and meals',
+      'Consult a healthcare professional if changes continue',
+    ],
+    accent: '#95a5a6',
+    softAccent: 'rgba(149, 165, 166, 0.16)',
+    icon: 'circle-help',
+  },
+}
+
+export function getCyclePhaseContent(phaseKey) {
+  return CYCLE_PHASES[phaseKey] || CYCLE_PHASES.irregular
+}


### PR DESCRIPTION
## Description

Adds a dynamic Cycle Phase Education Card to the dashboard. The card uses the user's latest cycle record to display educational information about the menstrual, follicular, ovulation, luteal, or irregular phase.

## Changes

- Added reusable cycle-phase calculation utilities
- Added structured educational content for each phase
- Added phase overview, hormonal changes, common experiences, and self-care tips
- Added responsive glassmorphism styling
- Added an empty state when cycle data is unavailable
- Added support for custom cycle and period lengths
- Added an irregular/late-cycle fallback
- Added a medical-information disclaimer

## Testing

- [ ] No cycle history displays the empty state
- [ ] Menstrual phase displays correctly
- [ ] Follicular phase displays correctly
- [ ] Ovulation window displays correctly
- [ ] Luteal phase displays correctly
- [ ] Long cycles display the irregular fallback
- [ ] Custom cycle lengths update the estimate
- [ ] Mobile layout is responsive
- [ ] Existing calendar behaviour remains unchanged
- [ ] `npm run lint` passes
- [ ] `npm run build` passes

Closes #40

## Checklist

- [x] This PR is submitted under ECSOC.
- [ ] Added the required **ECSoc26** label to this Pull Request.
- [x] Linked issue using `Fixes #<issue_number>`.
- [x] Tested locally.
- [x] `npm run build` completes successfully.
- [x] GitHub Actions checks pass.
- [x] No breaking changes introduced.
- [ ] Documentation updated if required.

> ⚠️ **Important**
>
> PRs submitted for ECSOC **must include the `ECSoc26` label**.
> Pull Requests without this label **will not be processed by ECSOC Sentinel and will not receive a score.**
