### PR TITLE
[ECSoC26] fix(api): make vote and count updates atomic

### DIFF
--- a/app/api/forum/vote/route.js
+++ b/app/api/forum/vote/route.js
@@ -31,73 +31,26 @@ export async function POST(req) {
 
     const supabase = getSupabaseAdmin();
     
-    // 1. Check if user already voted
-    const { data: existingVote, error: fetchError } = await supabase
-      .from('forum_votes')
-      .select('id, vote_value')
-      .eq('user_id', hashedUserId)
-      .eq('item_type', itemType)
-      .eq('item_id', itemId)
-      .single();
+    // 1. Execute atomic vote operation via Postgres RPC
+    const { data: result, error: rpcError } = await supabase.rpc('handle_vote', {
+      p_user_id: hashedUserId,
+      p_item_type: itemType,
+      p_item_id: itemId,
+      p_vote_value: voteValue
+    });
 
-    if (fetchError && fetchError.code !== 'PGRST116') {
-      console.error('Fetch Vote Error:', fetchError);
-      return NextResponse.json({ error: 'Database error' }, { status: 500 });
+    if (rpcError) {
+      console.error('Vote RPC Error:', rpcError);
+      return NextResponse.json({ error: 'Failed to record vote' }, { status: 500 });
     }
 
-    const tableName = itemType === 'post' ? 'forum_posts' : 'forum_comments';
-
-    if (existingVote) {
-      // User has already voted
-      if (existingVote.vote_value === voteValue) {
-         // Same vote, maybe toggle it off (remove vote)
-         await supabase.from('forum_votes').delete().eq('id', existingVote.id);
-         
-         // Decrement/Increment back
-         const { error: updateError } = await supabase.rpc('decrement_vote', {
-            table_name: tableName,
-            row_id: itemId,
-            amount: voteValue
-         });
-         
-         if (updateError) {
-             // Fallback if RPC doesn't exist, though typically we'd create an RPC or do a two-step.
-             // For simplicity if RPC isn't provided, we can fetch and update.
-             const { data: item } = await supabase.from(tableName).select('upvotes').eq('id', itemId).single();
-             if (item) {
-                 await supabase.from(tableName).update({ upvotes: item.upvotes - voteValue }).eq('id', itemId);
-             }
-         }
-         return NextResponse.json({ message: 'Vote removed', currentVote: 0 }, { status: 200 });
-      } else {
-         // Changing vote
-         await supabase.from('forum_votes').update({ vote_value: voteValue }).eq('id', existingVote.id);
-         
-         // If changed from 1 to -1, net change is -2. If -1 to 1, net change is 2.
-         const netChange = voteValue * 2;
-         const { data: item } = await supabase.from(tableName).select('upvotes').eq('id', itemId).single();
-         if (item) {
-             await supabase.from(tableName).update({ upvotes: item.upvotes + netChange }).eq('id', itemId);
-         }
-         return NextResponse.json({ message: 'Vote changed', currentVote: voteValue }, { status: 200 });
-      }
-    } else {
-      // New vote
-      const { error: insertError } = await supabase
-        .from('forum_votes')
-        .insert([{ user_id: hashedUserId, item_type: itemType, item_id: itemId, vote_value: voteValue }]);
-        
-      if (insertError) {
-          console.error('Insert Vote Error:', insertError);
-          return NextResponse.json({ error: 'Failed to record vote' }, { status: 500 });
-      }
-
-      const { data: item } = await supabase.from(tableName).select('upvotes').eq('id', itemId).single();
-      if (item) {
-          await supabase.from(tableName).update({ upvotes: item.upvotes + voteValue }).eq('id', itemId);
-      }
-      return NextResponse.json({ message: 'Vote added', currentVote: voteValue }, { status: 201 });
-    }
+    // Determine correct HTTP status based on the action taken
+    const status = result.action === 'added' ? 201 : 200;
+    
+    return NextResponse.json({ 
+      message: `Vote ${result.action}`, 
+      currentVote: result.current_vote 
+    }, { status });
   } catch (error) {
     console.error('Vote Error:', error);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });


### PR DESCRIPTION
## Linked Issue
Fixes #72

## Description
Data Integrity Patch: Fixed a race condition in `app/api/forum/vote/route.js`. Previously, inserting a vote record and updating the denormalized `upvotes` count occurred in two separate database calls. If the second call failed, the database state became permanently corrupted. These operations are now wrapped atomically so they succeed or fail together.

## Type of Change
- [x] Bug fix
- [x] Data integrity improvement

*Contributor for ECSoC & ELUSOC 2026* 🚀