### PR TITLE
[ECSoC26] fix(lib): allow crudLimiter to accept and enforce custom rate limits

### DIFF
--- a/lib/rateLimiter.js
+++ b/lib/rateLimiter.js
@@ -78,12 +78,24 @@ const rateLimitStore = new Map();
 
 function createLimiter({ interval, maxRequests }) {
   return {
-    async check(request) {
-      const forwarded = request.headers.get('x-forwarded-for');
-      const ip = forwarded ? forwarded.split(',')[0].trim() : 'unknown';
+    async check(customLimitOrRequest, identifier) {
+      let limit = maxRequests;
+      let targetId = 'unknown';
+
+      if (typeof customLimitOrRequest === 'number') {
+        // Modern usage: check(limit, identifier)
+        limit = customLimitOrRequest;
+        targetId = identifier || 'unknown';
+      } else if (customLimitOrRequest && typeof customLimitOrRequest.headers === 'object') {
+        // Legacy usage: check(request)
+        const forwarded = customLimitOrRequest.headers.get('x-forwarded-for');
+        targetId = forwarded ? forwarded.split(',')[0].trim() : 'unknown';
+      } else if (typeof customLimitOrRequest === 'string') {
+        targetId = customLimitOrRequest;
+      }
 
       const now = Date.now();
-      const record = rateLimitStore.get(ip) || { count: 0, resetAt: now + interval };
+      const record = rateLimitStore.get(targetId) || { count: 0, resetAt: now + interval };
 
       if (now > record.resetAt) {
         record.count = 0;
@@ -91,9 +103,9 @@ function createLimiter({ interval, maxRequests }) {
       }
 
       record.count += 1;
-      rateLimitStore.set(ip, record);
+      rateLimitStore.set(targetId, record);
 
-      if (record.count > maxRequests) {
+      if (record.count > limit) {
         throw new Error('Rate limit exceeded');
       }
     }


### PR DESCRIPTION
## Linked Issue
Fixes #71

## Description
Updated `crudLimiter.check()` in `lib/rateLimiter.js` to properly accept and enforce custom rate limits. Previously, the method signature only accepted one parameter, causing custom limits (like the 20 req/min intended in the `log-day` route) to be silently dropped in favor of the hardcoded default of 30. Individual routes can now strictly define their own thresholds.

## Type of Change
- [x] Bug fix
- [x] Security/Reliability improvement

*Contributor for ECSoC & ELUSOC 2026* 🚀