### PR TITLE
[ECSoC26] [Architecture]: Unify settings hub and overhaul clerk modal aesthetics

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2958,3 +2958,12 @@ nav ul li a:focus-visible,
 
   font-weight: 600;
 }
+/* Force Hide Clerk Watermark */
+.cl-watermark, .cl-internal-b3alnr { display: none !important; opacity: 0 !important; visibility: hidden !important; }
+
+
+/* Ultra Aggressive Clerk Watermark Removal */
+.cl-rootBox a[href*='clerk.com'], .cl-rootBox a[href*='clerk.dev'] { display: none !important; }
+.cl-rootBox div:has(> a[href*='clerk.com']) { display: none !important; }
+.cl-rootBox div[style*='bottom: 0'] { display: none !important; }
+

--- a/components/layout/HealthProfileSettings.jsx
+++ b/components/layout/HealthProfileSettings.jsx
@@ -1,0 +1,13 @@
+export default function HealthProfileSettings() {
+  return (
+    <div className="p-4 sm:p-8 flex flex-col items-center justify-center h-full text-center space-y-6 animate-in fade-in duration-300 mt-8">
+      <div className="p-4 bg-pink-500/10 rounded-full mb-2 border border-pink-500/20">
+        <span className="text-3xl">👤</span>
+      </div>
+      <h1 className="text-2xl sm:text-3xl font-bold text-white tracking-tight">Health Profile</h1>
+      <p className="text-white/60 text-sm sm:text-base leading-relaxed max-w-md">
+        Your comprehensive health profile and cycle information will be available here. We are currently building this feature!
+      </p>
+    </div>
+  )
+}

--- a/components/layout/Navbar.jsx
+++ b/components/layout/Navbar.jsx
@@ -3,24 +3,20 @@ import { useState } from 'react'
 import Link from 'next/link'
 import { usePathname, useRouter } from 'next/navigation'
 import { useTranslations, useLocale } from 'next-intl'
-import { useClerk, useUser } from '@clerk/nextjs'
+import { useUser, UserButton } from '@clerk/nextjs'
 import { useOffline } from '@/lib/OfflineContext'
-import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
-import { Settings, LogOut, Languages, Users, Link2Off } from 'lucide-react'
-import PrivacySettingsModal from './PrivacySettingsModal'
-import PartnerSharingModal from './PartnerSharingModal'
-import { disconnectAsPartner } from '@/lib/actions/partner'
-import toast from 'react-hot-toast'
+import { User as ProfileIcon, Bell as BellIcon, Shield as ShieldIcon, HelpCircle as HelpIcon } from 'lucide-react'
+import PrivacySettingsContent from './PrivacySettingsModal'
+import HealthProfileSettings from './HealthProfileSettings'
+import NotificationSettings from './NotificationSettings'
+import SupportSettings from './SupportSettings'
 
 export default function Navbar() {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
-  const [isPrivacyModalOpen, setIsPrivacyModalOpen] = useState(false)
-  const [isPartnerModalOpen, setIsPartnerModalOpen] = useState(false)
   const t = useTranslations('Navbar')
   const locale = useLocale()
   const router = useRouter()
   const pathname = usePathname()
-  const { signOut } = useClerk()
   const { user } = useUser()
   const { isOffline, pendingSyncCount, isSyncing } = useOffline()
 
@@ -43,32 +39,10 @@ export default function Navbar() {
     }
   }
 
-  const handleLogout = async () => {
-    await signOut()
-    router.push(`/${locale}/auth/login`)
-  }
-
-  const handleDisconnectAsPartner = async () => {
-    if (!confirm('Are you sure you want to disconnect? You will need a new code to reconnect.')) return
-    try {
-      await disconnectAsPartner()
-      await user?.reload()
-      toast.success('Disconnected successfully')
-      window.location.href = `/${locale}/onboarding`
-    } catch (error) {
-      toast.error('Failed to disconnect')
-    }
-  }
-
   const isActive = (href) => {
     if (href === `/${locale}`) return pathname === `/${locale}` || pathname === '/'
     if (href === `/${locale}/partner`) return pathname === `/${locale}/partner`
     return pathname.startsWith(href)
-  }
-
-  const switchLanguage = (newLocale) => {
-    const currentPathWithoutLocale = pathname.replace(`/${locale}`, '') || '/'
-    router.push(`/${newLocale}${currentPathWithoutLocale === '/' ? '' : currentPathWithoutLocale}`)
   }
 
   return (
@@ -160,108 +134,81 @@ export default function Navbar() {
           </button>
         )}
 
-        <DropdownMenu.Root>
-          <DropdownMenu.Trigger asChild>
-            <button
-              className="p-1.5 sm:p-2 rounded-full hover:bg-white/10 transition-colors border border-transparent hover:border-white/20 outline-none focus-visible:ring-2 focus-visible:ring-white/50"
-              aria-label="Settings"
-            >
-              <Settings className="w-5 h-5 sm:w-6 sm:h-6 text-white/90" />
-            </button>
-          </DropdownMenu.Trigger>
-
-          <DropdownMenu.Portal>
-            <DropdownMenu.Content
-              align="end"
-              sideOffset={8}
-              className="z-[100] min-w-[200px] p-2 rounded-xl border border-white/20 shadow-xl animate-in fade-in zoom-in-95 duration-200"
-              style={{
-                background: 'rgba(255, 255, 255, 0.15)',
+        <UserButton
+          userProfileProps={{
+            appearance: {
+              variables: {
+                colorBackground: 'transparent',
+                colorText: 'white',
+                colorTextSecondary: 'rgba(255, 255, 255, 0.7)',
+                colorPrimary: '#e8527e',
+              },
+              elements: {
+                modalContent: {
+                  backdropFilter: 'blur(24px)',
+                  WebkitBackdropFilter: 'blur(24px)',
+                  backgroundColor: 'rgba(255, 255, 255, 0.15)',
+                  border: '1px solid rgba(255, 255, 255, 0.2)',
+                  boxShadow: '0 8px 32px 0 rgba(228, 115, 168, 0.3)',
+                  color: 'white'
+                },
+                navbar: {
+                  borderRight: '1px solid rgba(255, 255, 255, 0.1)',
+                },
+                navbarButton: "hover:bg-white/10 data-[active=true]:bg-white/20",
+                scrollBox: "bg-transparent",
+                dividerLine: "bg-white/10",
+                badge: "bg-white/10 border-white/20 text-white",
+                button: "hover:bg-white/10 border-white/20 text-white",
+                button__danger: "text-red-400 border border-red-500/30 bg-red-500/10 hover:bg-red-500/20 px-5 py-2.5 rounded-xl transition-all shadow-lg font-medium",
+                profileSectionPrimaryButton__danger: "text-red-400 border border-red-500/30 bg-red-500/10 hover:bg-red-500/20 px-5 py-2.5 rounded-xl transition-all shadow-lg font-medium",
+                profileSectionTitleText: "text-white/70",
+                formFieldInput: "bg-white/5 border-white/10 text-white",
+                formFieldLabel: "text-white/70",
+                watermark: { display: 'none' },
+                footer: { display: 'none' },
+              }
+            }
+          }}
+          appearance={{
+            variables: {
+              colorBackground: 'rgba(255, 255, 255, 0.15)',
+              colorText: 'white',
+              colorTextSecondary: 'rgba(255, 255, 255, 0.8)',
+            },
+            elements: {
+              avatarBox: "w-10 h-10 sm:w-12 sm:h-12 shadow-md border-2 border-white/20 transition-transform hover:scale-105",
+              userButtonPopoverCard: {
                 backdropFilter: 'blur(16px)',
                 WebkitBackdropFilter: 'blur(16px)',
-                boxShadow: '0 8px 32px 0 rgba(228, 115, 168, 0.2)'
-              }}
-            >
-              <div className="px-2 py-1.5 text-[10px] font-semibold text-white/70 uppercase tracking-wider mb-1">
-                Settings
-              </div>
-              
-              <div className="flex items-center justify-between px-2 py-2 mb-1 rounded-lg hover:bg-white/5 transition-colors">
-                <div className="flex items-center gap-2 text-sm text-white/90">
-                  <Languages className="w-4 h-4 text-white/70" />
-                  <span>Language</span>
-                </div>
-                <div className="flex bg-white/10 rounded-lg p-0.5 border border-white/10">
-                  <button
-                    className={`px-2 py-1 rounded-md text-xs font-bold transition-all duration-200 ${locale === 'en' ? 'bg-white/25 text-white shadow-sm' : 'text-white/60 hover:text-white hover:bg-white/5'}`}
-                    onClick={() => switchLanguage('en')}
-                  >
-                    EN
-                  </button>
-                  <button
-                    className={`px-2 py-1 rounded-md text-xs font-bold transition-all duration-200 ${locale === 'hi' ? 'bg-white/25 text-white shadow-sm' : 'text-white/60 hover:text-white hover:bg-white/5'}`}
-                    onClick={() => switchLanguage('hi')}
-                  >
-                    हि
-                  </button>
-                </div>
-              </div>
-
-              <DropdownMenu.Separator className="h-[1px] bg-white/20 my-1 mx-1" />
-
-              {!isPartner && (
-                <DropdownMenu.Item asChild onSelect={() => setIsPartnerModalOpen(true)}>
-                  <button
-                    className="w-full flex items-center gap-2 px-2 py-2 text-sm text-white hover:text-white hover:bg-white/15 rounded-lg transition-colors outline-none cursor-pointer mt-1 group"
-                  >
-                    <Users className="w-4 h-4 text-white/70 group-hover:text-white transition-colors" />
-                    <span>Partner Sharing</span>
-                  </button>
-                </DropdownMenu.Item>
-              )}
-
-              {!isPartner && (
-                <DropdownMenu.Item asChild onSelect={() => setIsPrivacyModalOpen(true)}>
-                  <button
-                    className="w-full flex items-center gap-2 px-2 py-2 text-sm text-white hover:text-white hover:bg-white/15 rounded-lg transition-colors outline-none cursor-pointer mt-1 group"
-                  >
-                    <Settings className="w-4 h-4 text-white/70 group-hover:text-white transition-colors" />
-                    <span>Privacy & Data</span>
-                  </button>
-                </DropdownMenu.Item>
-              )}
-
-              <DropdownMenu.Item asChild>
-                <button
-                  onClick={handleLogout}
-                  className="w-full flex items-center gap-2 px-2 py-2 text-sm text-white hover:text-white hover:bg-white/15 rounded-lg transition-colors outline-none cursor-pointer mt-1 group"
-                >
-                  <LogOut className="w-4 h-4 text-white/70 group-hover:text-white transition-colors" />
-                  <span>{t('signOut')}</span>
-                </button>
-              </DropdownMenu.Item>
-
-              {isPartner && (
-                <>
-                  <DropdownMenu.Separator className="h-[1px] bg-white/20 my-1 mx-1" />
-                  <DropdownMenu.Item asChild>
-                    <button
-                      onClick={handleDisconnectAsPartner}
-                      className="w-full flex items-center gap-2 px-2 py-2 text-sm text-red-400 hover:text-red-300 hover:bg-red-500/10 rounded-lg transition-colors outline-none cursor-pointer mt-1 group"
-                    >
-                      <Link2Off className="w-4 h-4 text-red-400 group-hover:text-red-300 transition-colors" />
-                      <span>Disconnect</span>
-                    </button>
-                  </DropdownMenu.Item>
-                </>
-              )}
-            </DropdownMenu.Content>
-          </DropdownMenu.Portal>
-        </DropdownMenu.Root>
+                boxShadow: '0 8px 32px 0 rgba(228, 115, 168, 0.2)',
+                border: '1px solid rgba(255, 255, 255, 0.2)',
+                borderRadius: '16px',
+              },
+              userPreviewMainIdentifier: "font-bold",
+              userButtonPopoverActionButton: "hover:bg-white/10 transition-colors rounded-xl",
+              userButtonPopoverActionButtonText: "font-medium",
+              userButtonPopoverFooter: "hidden",
+              userPreview: "hover:bg-white/5 transition-colors rounded-xl",
+              watermark: { display: 'none' },
+              footer: { display: 'none' },
+            }
+          }}
+        >
+          <UserButton.UserProfilePage label="Data & Privacy" url="data-privacy" labelIcon={<ShieldIcon className="w-4 h-4" />}>
+            <PrivacySettingsContent />
+          </UserButton.UserProfilePage>
+          <UserButton.UserProfilePage label="Health Profile" url="health-profile" labelIcon={<ProfileIcon className="w-4 h-4" />}>
+            <HealthProfileSettings />
+          </UserButton.UserProfilePage>
+          <UserButton.UserProfilePage label="Notifications" url="notifications" labelIcon={<BellIcon className="w-4 h-4" />}>
+            <NotificationSettings />
+          </UserButton.UserProfilePage>
+          <UserButton.UserProfilePage label="Help & Support" url="support" labelIcon={<HelpIcon className="w-4 h-4" />}>
+            <SupportSettings />
+          </UserButton.UserProfilePage>
+        </UserButton>
       </div>
-
-      <PrivacySettingsModal isOpen={isPrivacyModalOpen} setIsOpen={setIsPrivacyModalOpen} />
-      <PartnerSharingModal isOpen={isPartnerModalOpen} setIsOpen={setIsPartnerModalOpen} />
     </nav>
   )
 }

--- a/components/layout/NotificationSettings.jsx
+++ b/components/layout/NotificationSettings.jsx
@@ -1,0 +1,13 @@
+export default function NotificationSettings() {
+  return (
+    <div className="p-4 sm:p-8 flex flex-col items-center justify-center h-full text-center space-y-6 animate-in fade-in duration-300 mt-8">
+      <div className="p-4 bg-purple-500/10 rounded-full mb-2 border border-purple-500/20">
+        <span className="text-3xl">🔔</span>
+      </div>
+      <h1 className="text-2xl sm:text-3xl font-bold text-white tracking-tight">Notifications</h1>
+      <p className="text-white/60 text-sm sm:text-base leading-relaxed max-w-md">
+        Manage your alerts, period reminders, and app notifications. This feature is coming soon!
+      </p>
+    </div>
+  )
+}

--- a/components/layout/PrivacySettingsModal.jsx
+++ b/components/layout/PrivacySettingsModal.jsx
@@ -6,11 +6,9 @@ import * as Dialog from '@radix-ui/react-dialog'
 import toast from 'react-hot-toast'
 import { Download, AlertTriangle, Trash2, X } from 'lucide-react'
 
-export default function PrivacySettingsModal({ isOpen, setIsOpen }) {
+export default function PrivacySettingsContent() {
   const { getToken } = useAuth()
-  const [isDeleting, setIsDeleting] = useState(false)
   const [isExporting, setIsExporting] = useState(false)
-  const [deleteConfirmation, setDeleteConfirmation] = useState('')
 
   const handleExportData = async () => {
     setIsExporting(true)
@@ -43,112 +41,38 @@ export default function PrivacySettingsModal({ isOpen, setIsOpen }) {
     }
   }
 
-  const handleDeleteAccount = async () => {
-    if (deleteConfirmation !== 'DELETE') return;
 
-    setIsDeleting(true)
-    const toastId = toast.loading('Deleting account...')
-    try {
-      const token = await getToken()
-      // Call our backend API to perform the deletion
-      const res = await fetch('/api/delete-account', {
-        method: 'POST',
-        headers: {
-          Authorization: `Bearer ${token}`
-        }
-      })
-
-      if (!res.ok) {
-        throw new Error('Failed to delete account via API')
-      }
-
-      toast.success('Account deleted successfully.', { id: toastId })
-      setIsOpen(false)
-      // Immediately redirect — don't wait for signOut since the account is already gone
-      window.location.href = '/en/auth/login'
-    } catch (error) {
-      console.error(error)
-      toast.error('Failed to delete account. Please try again.', { id: toastId })
-      setIsDeleting(false)
-    }
-  }
 
   return (
-    <Dialog.Root open={isOpen} onOpenChange={setIsOpen}>
-      <Dialog.Portal>
-        <Dialog.Overlay className="fixed inset-0 bg-black/40 backdrop-blur-sm z-[100] animate-in fade-in" />
-        <Dialog.Content className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-[90vw] max-w-lg z-[101] max-h-[85vh] overflow-y-auto animate-in zoom-in-95 duration-200 rounded-3xl">
-          
-          <div className="glass p-6 sm:p-8 rounded-3xl space-y-6 shadow-2xl relative overflow-hidden" style={{ background: 'rgba(50, 10, 40, 0.45)' }}>
-            {/* Subtle glow behind the card */}
-            <div className="absolute top-[-50%] right-[-50%] w-[100%] h-[100%] bg-white/5 blur-3xl rounded-full pointer-events-none"></div>
+    <div className="p-4 sm:p-8 flex flex-col items-center justify-center h-full text-center space-y-10 animate-in fade-in duration-300 mt-8">
+      
+      {/* Centered Icon & Text */}
+      <div className="space-y-5 max-w-md flex flex-col items-center">
+        <div className="p-5 bg-white/5 rounded-2xl mb-2 border border-white/10 shadow-xl">
+          <Download className="w-10 h-10 text-white/80" />
+        </div>
+        
+        <div className="space-y-2">
+          <h1 className="text-2xl sm:text-3xl font-bold text-white tracking-tight">Export Your Data</h1>
+          <p className="text-white/60 text-sm sm:text-base leading-relaxed">
+            Download a complete archive of your logged cycles, symptoms, and health metrics in an easy-to-read JSON format.
+          </p>
+        </div>
+      </div>
 
-            <div className="flex justify-between items-center relative z-10">
-              <Dialog.Title className="text-2xl font-bold text-white">Privacy & Data</Dialog.Title>
-              <Dialog.Description className="sr-only">
-                Manage your privacy and data settings, including exporting your data or permanently deleting your account.
-              </Dialog.Description>
-              <Dialog.Close asChild>
-                <button className="text-white/70 hover:text-white transition-colors bg-white/10 hover:bg-white/20 p-2 rounded-full focus:outline-none focus:ring-2 focus:ring-white/50">
-                  <X className="w-5 h-5" />
-                </button>
-              </Dialog.Close>
-            </div>
+      {/* Centered Action */}
+      <div className="pt-2 w-full sm:w-auto">
+        <div 
+          onClick={!isExporting ? handleExportData : undefined}
+          role="button"
+          tabIndex={0}
+          className={`relative flex items-center justify-center w-full sm:w-auto min-w-[220px] gap-3 bg-[#e8527e] hover:bg-[#d43d68] text-white px-8 py-3.5 rounded-xl transition-all shadow-lg font-medium select-none ${isExporting ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer hover:-translate-y-0.5 active:scale-[0.98]'}`}
+        >
+          <Download className={`w-5 h-5 transition-transform duration-300 ${isExporting ? 'animate-bounce' : ''}`} />
+          <span>{isExporting ? 'Preparing Archive...' : 'Download Data Archive'}</span>
+        </div>
+      </div>
 
-            {/* Data Export Section */}
-            <section className="space-y-3 relative z-10">
-              <h2 className="text-lg font-semibold text-white">Export Your Data</h2>
-              <p className="text-white/70 text-sm">
-                Download a copy of all your health data in JSON and CSV formats.
-              </p>
-              <button 
-                onClick={handleExportData}
-                disabled={isExporting}
-                className="flex items-center justify-center w-full gap-2 bg-white/10 hover:bg-white/20 text-white px-5 py-2.5 rounded-xl transition-colors font-medium disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-white/50"
-              >
-                <Download className="w-4 h-4" />
-                {isExporting ? 'Exporting...' : 'Export My Data'}
-              </button>
-            </section>
-
-            <hr className="border-white/10 relative z-10" />
-
-            {/* Account Deletion Section */}
-            <section className="space-y-3 relative z-10">
-              <h2 className="text-lg font-semibold text-red-400">Danger Zone</h2>
-              <div className="bg-red-500/10 border border-red-500/20 p-4 rounded-2xl flex flex-col gap-3">
-                <div className="flex items-start gap-2">
-                  <AlertTriangle className="w-5 h-5 text-red-400 shrink-0" />
-                  <p className="text-red-300/80 text-xs leading-relaxed">
-                    Permanently delete your account and all associated data. This action is irreversible.
-                  </p>
-                </div>
-                <div className="mt-2 w-full">
-                  <label className="block text-red-300/90 text-xs mb-1.5 font-semibold">
-                    Type <span className="text-white font-bold bg-white/10 px-1 py-0.5 rounded">DELETE</span> to confirm
-                  </label>
-                  <input 
-                    type="text"
-                    value={deleteConfirmation}
-                    onChange={(e) => setDeleteConfirmation(e.target.value)}
-                    className="w-full bg-black/20 border border-red-500/30 rounded-lg px-3 py-2 text-white text-sm focus:outline-none focus:border-red-400 focus:ring-1 focus:ring-red-400 placeholder:text-white/20 transition-all"
-                    placeholder="DELETE"
-                  />
-                </div>
-                <button 
-                  onClick={handleDeleteAccount}
-                  disabled={isDeleting || deleteConfirmation !== 'DELETE'}
-                  className="flex items-center justify-center w-full gap-2 bg-red-500/20 hover:bg-red-500/30 text-red-300 px-5 py-2.5 rounded-xl transition-colors font-medium border border-red-500/30 mt-1 disabled:opacity-40 disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-red-500/50"
-                >
-                  <Trash2 className="w-4 h-4" />
-                  {isDeleting ? 'Deleting...' : 'Delete Account'}
-                </button>
-              </div>
-            </section>
-
-          </div>
-        </Dialog.Content>
-      </Dialog.Portal>
-    </Dialog.Root>
+    </div>
   )
 }

--- a/components/layout/SupportSettings.jsx
+++ b/components/layout/SupportSettings.jsx
@@ -1,0 +1,13 @@
+export default function SupportSettings() {
+  return (
+    <div className="p-4 sm:p-8 flex flex-col items-center justify-center h-full text-center space-y-6 animate-in fade-in duration-300 mt-8">
+      <div className="p-4 bg-blue-500/10 rounded-full mb-2 border border-blue-500/20">
+        <span className="text-3xl">🛟</span>
+      </div>
+      <h1 className="text-2xl sm:text-3xl font-bold text-white tracking-tight">Help & Support</h1>
+      <p className="text-white/60 text-sm sm:text-base leading-relaxed max-w-md">
+        Need assistance or have feedback? Our support resources will be available here soon.
+      </p>
+    </div>
+  )
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,7 +70,8 @@
                 "tailwindcss-animate": "^1.0.7",
                 "uuid": "^14.0.1",
                 "vaul": "^1.1.2",
-                "zod": "^3.25.67"
+                "zod": "^3.25.67",
+                "zustand": "^5.0.14"
             },
             "devDependencies": {
                 "autoprefixer": "^10.4.19",
@@ -6970,6 +6971,35 @@
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
+            }
+        },
+        "node_modules/zustand": {
+            "version": "5.0.14",
+            "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.14.tgz",
+            "integrity": "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.20.0"
+            },
+            "peerDependencies": {
+                "@types/react": ">=18.0.0",
+                "immer": ">=9.0.6",
+                "react": ">=18.0.0",
+                "use-sync-external-store": ">=1.2.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "immer": {
+                    "optional": true
+                },
+                "react": {
+                    "optional": true
+                },
+                "use-sync-external-store": {
+                    "optional": true
+                }
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -72,7 +72,8 @@
         "tailwindcss-animate": "^1.0.7",
         "uuid": "^14.0.1",
         "vaul": "^1.1.2",
-        "zod": "^3.25.67"
+        "zod": "^3.25.67",
+        "zustand": "^5.0.14"
     },
     "devDependencies": {
         "autoprefixer": "^10.4.19",


### PR DESCRIPTION
- closes #114

### Description
This PR consolidates fragmented user settings into a unified "Settings Hub" natively integrated within the Clerk UserProfile modal, while enhancing the global UI to match our glassmorphism design system. 

### Architectural Changes
- **Unified Settings:** Migrated Data & Privacy, Health Profile, Notifications, and Help & Support into native sidebar tabs within the Clerk modal (`<UserButton.UserProfilePage>`).
- **State Cleanup:** Removed custom dropdown actions and deleted `lib/store/modalStore.js`. All modal routing is now handled natively by Clerk, reducing codebase complexity.

### UI & Styling Improvements
- **Glassmorphism Theme:** Customized Clerk's `appearance` prop to enforce our brand aesthetic, adding frosted glass backgrounds, custom borders, and brand accents across all internal UI elements.
- **Danger Zone Styling:** Restyled Clerk's native "Delete Account" button to use a custom red glass effect for visual distinction.
- **Style Collision Fix:** Refactored the "Export My Data" button to use a `div` element, successfully bypassing Clerk's aggressive global CSS injection and restoring our custom Tailwind styling.
- **White-Labeling:** Applied aggressive CSS overrides in `globals.css` to completely hide the "Secured by Clerk" and "Development Mode" watermarks across all modals and dropdowns.

### Screenshot 

<img width="2880" height="1800" alt="Screenshot 2026-07-13 133728" src="https://github.com/user-attachments/assets/5cbfbaa5-f802-4f2f-8808-158eec34f610" />
