### PR TITLE
[ECSoC26] fix: restore language switcher in account profile

### DIFF
--- a/components/layout/Navbar.jsx
+++ b/components/layout/Navbar.jsx
@@ -5,11 +5,12 @@ import { usePathname, useRouter } from 'next/navigation'
 import { useTranslations, useLocale } from 'next-intl'
 import { useUser, UserButton } from '@clerk/nextjs'
 import { useOffline } from '@/lib/OfflineContext'
-import { User as ProfileIcon, Bell as BellIcon, Shield as ShieldIcon, HelpCircle as HelpIcon } from 'lucide-react'
+import { User as ProfileIcon, Bell as BellIcon, Shield as ShieldIcon, HelpCircle as HelpIcon, Languages } from 'lucide-react'
 import PrivacySettingsContent from './PrivacySettingsModal'
 import HealthProfileSettings from './HealthProfileSettings'
 import NotificationSettings from './NotificationSettings'
 import SupportSettings from './SupportSettings'
+import LanguageSettings from '../settings/LanguageSettings'
 
 export default function Navbar() {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
@@ -199,6 +200,9 @@ export default function Navbar() {
             }
           }}
         >
+          <UserButton.UserProfilePage label="Language" url="language" labelIcon={<Languages className="w-4 h-4" />}>
+            <LanguageSettings />
+          </UserButton.UserProfilePage>
           <UserButton.UserProfilePage label="Data & Privacy" url="data-privacy" labelIcon={<ShieldIcon className="w-4 h-4" />}>
             <PrivacySettingsContent />
           </UserButton.UserProfilePage>

--- a/components/settings/LanguageSettings.jsx
+++ b/components/settings/LanguageSettings.jsx
@@ -1,0 +1,74 @@
+'use client'
+
+import { useLocale } from 'next-intl'
+import { usePathname } from 'next/navigation'
+import { useTransition } from 'react'
+import { Languages, Check } from 'lucide-react'
+
+export default function LanguageSettings() {
+  const locale = useLocale()
+  const pathname = usePathname()
+  const [isPending, startTransition] = useTransition()
+
+  const switchLanguage = (newLocale) => {
+    if (newLocale === locale) return
+    
+    startTransition(() => {
+      const segments = pathname.split('/')
+      if (segments.length > 1) {
+        segments[1] = newLocale
+      }
+      const newPath = segments.join('/') || '/'
+      window.location.href = newPath
+    })
+  }
+
+  const languages = [
+    { code: 'en', label: 'English', native: 'English' },
+    { code: 'hi', label: 'Hindi', native: 'हिन्दी' },
+  ]
+
+  return (
+    <div className="flex flex-col gap-6 p-1">
+      <div>
+        <h2 className="text-xl font-semibold text-white mb-2">Language Preferences</h2>
+        <p className="text-sm text-white/70 mb-6">
+          Choose the language you want to use in the application.
+        </p>
+      </div>
+
+      <div className="flex flex-col gap-3">
+        {languages.map((lang) => (
+          <button
+            key={lang.code}
+            onClick={() => switchLanguage(lang.code)}
+            disabled={isPending}
+            className={`flex items-center justify-between p-4 rounded-xl border transition-all ${
+              locale === lang.code
+                ? 'border-[#e8527e] bg-[#e8527e]/10'
+                : 'border-white/10 bg-white/5 hover:bg-white/10'
+            } ${isPending ? 'opacity-50 cursor-not-allowed' : ''}`}
+          >
+            <div className="flex items-center gap-3">
+              <div className={`p-2 rounded-lg ${
+                locale === lang.code ? 'bg-[#e8527e]/20 text-[#e8527e]' : 'bg-white/10 text-white/70'
+              }`}>
+                <Languages className="w-5 h-5" />
+              </div>
+              <div className="flex flex-col items-start">
+                <span className={`font-semibold ${locale === lang.code ? 'text-[#e8527e]' : 'text-white'}`}>
+                  {lang.native}
+                </span>
+                <span className="text-xs text-white/50">{lang.label}</span>
+              </div>
+            </div>
+            
+            {locale === lang.code && (
+              <Check className="w-5 h-5 text-[#e8527e]" />
+            )}
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Linked Issue

Fixes #132 

---

## Description

This PR restores the language switching option within the Account/Profile interface.

### Changes Made

- Added a dedicated **Language** section to the Clerk Account/Profile UI.
- Added a reusable `LanguageSettings` component.
- Reused the existing localization mechanism without introducing duplicate translation logic.
- Preserved the existing Clerk UserButton structure and all current functionality.
- Kept the implementation minimal and isolated to the account profile.

---

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation update
- [ ] Performance optimization
- [ ] Security patch

---

## Testing

- Verified Language section appears in the Account/Profile interface.
- Verified switching between English and Hindi works.
- Verified existing profile pages remain accessible.
- Tested locally.

---

## Screenshots
<img width="1432" height="925" alt="Screenshot 2026-07-19 110924" src="https://github.com/user-attachments/assets/478ee136-992b-4713-9be8-ac1765c4ad1f" />
<img width="1416" height="913" alt="Screenshot 2026-07-19 110946" src="https://github.com/user-attachments/assets/f238a545-7d12-436e-8cef-22b0b4aedc21" />


