### PR TITLE
[ECSoC26] fix: restore Partner Sharing access in account settings

### DIFF
--- a/components/layout/Navbar.jsx
+++ b/components/layout/Navbar.jsx
@@ -5,12 +5,13 @@ import { usePathname, useRouter } from 'next/navigation'
 import { useTranslations, useLocale } from 'next-intl'
 import { useUser, UserButton } from '@clerk/nextjs'
 import { useOffline } from '@/lib/OfflineContext'
-import { User as ProfileIcon, Bell as BellIcon, Shield as ShieldIcon, HelpCircle as HelpIcon, Languages } from 'lucide-react'
+import { User as ProfileIcon, Bell as BellIcon, Shield as ShieldIcon, HelpCircle as HelpIcon, Languages, Users as UsersIcon } from 'lucide-react'
 import PrivacySettingsContent from './PrivacySettingsModal'
 import HealthProfileSettings from './HealthProfileSettings'
 import NotificationSettings from './NotificationSettings'
 import SupportSettings from './SupportSettings'
 import LanguageSettings from '../settings/LanguageSettings'
+import PartnerSharing from '../settings/PartnerSharing'
 
 export default function Navbar() {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
@@ -202,6 +203,9 @@ export default function Navbar() {
         >
           <UserButton.UserProfilePage label="Language" url="language" labelIcon={<Languages className="w-4 h-4" />}>
             <LanguageSettings />
+          </UserButton.UserProfilePage>
+          <UserButton.UserProfilePage label="Partner Sharing" url="partner-sharing" labelIcon={<UsersIcon className="w-4 h-4" />}>
+            <PartnerSharing />
           </UserButton.UserProfilePage>
           <UserButton.UserProfilePage label="Data & Privacy" url="data-privacy" labelIcon={<ShieldIcon className="w-4 h-4" />}>
             <PrivacySettingsContent />


### PR DESCRIPTION
## Linked Issue
Fixes #133 

## Description

This Pull Request restores access to the **Partner Sharing** feature through the account settings interface.

### Changes made
- Added the **Partner Sharing** section to the Clerk Account modal sidebar.
- Integrated the existing Partner Sharing component into the account settings.
- Preserved the existing styling and navigation experience.
- Improved discoverability by making the feature accessible directly from the account settings.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (clean code updates, no behavior modifications)
- [ ] Documentation update
- [ ] Performance optimization
- [ ] Security patch

## Testing

Tested locally by:

- Running the application with `npm run dev`.
- Signing in as a primary user.
- Opening the Account/Profile settings.
- Verifying that the **Partner Sharing** section appears in the sidebar.
- Confirming the Partner Sharing page loads correctly.
- Generating a pairing code successfully.
- Verifying existing account settings continue to function normally.

## Screenshots (if UI changes are made)

- Partner Sharing entry in the Account sidebar.
<img width="1152" height="892" alt="Screenshot 2026-07-19 155251" src="https://github.com/user-attachments/assets/d0f1e93c-a706-43f2-bdf3-99583d0db246" />

- Partner Sharing page with generated pairing code.
<img width="1130" height="885" alt="Screenshot 2026-07-19 155234" src="https://github.com/user-attachments/assets/dfe03389-f3e2-48d7-9489-ddd87ce763c5" />
