### PR TITLE
[ECSoC26] fix: use Devanagari font throughout Hindi PDF reports

### DIFF
--- a/lib/generateReport.js
+++ b/lib/generateReport.js
@@ -1,12 +1,12 @@
 import jsPDF from 'jspdf';
 import autoTable from 'jspdf-autotable';
 
-export default async function generateReport({ 
+export default async function generateReport({
   userName = 'khushji',
   email = 'khushi79916234@gmail.com',
-  generatedDate = new Date().toISOString().replace('T', ' ').slice(0, 16) + ' UTC', 
-  cycles = [], 
-  pcod = {}, 
+  generatedDate = new Date().toISOString().replace('T', ' ').slice(0, 16) + ' UTC',
+  cycles = [],
+  pcod = {},
   recentSymptoms = [],
   locale = 'en'
 }) {
@@ -14,21 +14,34 @@ export default async function generateReport({
   const marginLeft = 20;
   let currentY = 30;
 
+  let fontFamily = 'helvetica';
+  const normalFont = 'normal';
+  const boldFont = 'bold';
+  const italicFont = locale === 'hi' ? 'normal' : 'italic';
+
   if (locale === 'hi') {
     try {
       const response = await fetch('/fonts/NotoSansDevanagari-Regular.ttf');
+
       if (response.ok) {
         const buffer = await response.arrayBuffer();
+
         const base64Font = btoa(
-          new Uint8Array(buffer).reduce((data, byte) => data + String.fromCharCode(byte), '')
+          new Uint8Array(buffer).reduce(
+            (data, byte) => data + String.fromCharCode(byte),
+            ''
+          )
         );
+
         doc.addFileToVFS('NotoSansDevanagari.ttf', base64Font);
         doc.addFont('NotoSansDevanagari.ttf', 'NotoSansDevanagari', 'normal');
-        doc.addFont('NotoSansDevanagari.ttf', 'NotoSansDevanagari', 'bold'); // Fallback bold
-        doc.setFont('NotoSansDevanagari');
+        doc.addFont('NotoSansDevanagari.ttf', 'NotoSansDevanagari', 'bold');
+
+        fontFamily = 'NotoSansDevanagari';
+        doc.setFont(fontFamily, normalFont);
       }
-    } catch(e) {
-      console.warn("Could not load Hindi font for PDF", e);
+    } catch (e) {
+      console.warn('Could not load Hindi font for PDF', e);
     }
   }
 
@@ -39,32 +52,32 @@ export default async function generateReport({
 
   // ── HEADER ──
   doc.setFontSize(20);
-  doc.setFont('helvetica', 'bold');
+  doc.setFont(fontFamily, boldFont);
   doc.setTextColor(brandPink[0], brandPink[1], brandPink[2]);
   doc.text('HerCycle AI — Doctor Report', doc.internal.pageSize.getWidth() / 2, currentY, { align: 'center' });
   currentY += 12;
 
   // ── PATIENT INFO ──
   doc.setFontSize(10);
-  doc.setFont('helvetica', 'normal');
+  doc.setFont(fontFamily, normalFont);
   doc.setTextColor(0, 0, 0);
-  doc.setFont('helvetica', 'bold');
+  doc.setFont(fontFamily, boldFont);
   doc.text('Patient: ', marginLeft, currentY);
-  doc.setFont('helvetica', 'normal');
+  doc.setFont(fontFamily, normalFont);
   doc.text(userName, marginLeft + 14, currentY);
 
-  doc.setFont('helvetica', 'bold');
+  doc.setFont(fontFamily, boldFont);
   doc.text('Email: ', marginLeft + 45, currentY);
-  doc.setFont('helvetica', 'normal');
+  doc.setFont(fontFamily, normalFont);
   doc.text(email, marginLeft + 56, currentY);
-  
+
   currentY += 8;
   doc.text(`Generated: ${generatedDate}`, marginLeft, currentY);
   currentY += 15;
 
   // ── SECTION 1: CYCLE SUMMARY ──
   doc.setFontSize(14);
-  doc.setFont('helvetica', 'bold');
+  doc.setFont(fontFamily, boldFont);
   doc.setTextColor(brandPink[0], brandPink[1], brandPink[2]);
   doc.text('Cycle Summary', marginLeft, currentY);
   currentY += 6;
@@ -87,22 +100,25 @@ export default async function generateReport({
     ],
     theme: 'plain',
     styles: {
+      font: fontFamily,
+      fontStyle: normalFont,
       lineWidth: 0.1,
       lineColor: borderColor,
       fontSize: 10,
       cellPadding: 3,
-      textColor: [0, 0, 0] // Black text
+      textColor: [0, 0, 0]
     },
     columnStyles: {
-      0: { 
-        fillColor: lightPink, 
+      0: {
+        fillColor: lightPink,
         textColor: brandPink,
-        fontStyle: 'normal',
-        cellWidth: 80 
+        font: fontFamily,
+        fontStyle: normalFont,
+        cellWidth: 80
       },
-      1: { 
-        fillColor: [255, 255, 255], 
-        cellWidth: 80 
+      1: {
+        fillColor: [255, 255, 255],
+        cellWidth: 80
       }
     },
     margin: { left: marginLeft + 10 }
@@ -112,14 +128,14 @@ export default async function generateReport({
 
   // ── SECTION 2: RECENT CYCLE HISTORY ──
   doc.setFontSize(12);
-  doc.setFont('helvetica', 'bold');
+  doc.setFont(fontFamily, boldFont);
   doc.setTextColor(brandPink[0], brandPink[1], brandPink[2]);
   doc.text('Recent Cycle History', marginLeft, currentY);
   currentY += 6;
 
   if (cycles.length === 0) {
     doc.setFontSize(10);
-    doc.setFont('helvetica', 'normal');
+    doc.setFont(fontFamily, normalFont);
     doc.setTextColor(0, 0, 0);
     doc.text('No cycles logged yet.', marginLeft, currentY);
     currentY += 12;
@@ -134,8 +150,19 @@ export default async function generateReport({
       head: [['Start Date', 'End Date', 'Cycle Length']],
       body: cycleData,
       theme: 'plain',
-      styles: { lineWidth: 0.1, lineColor: borderColor, fontSize: 10 },
-      headStyles: { fillColor: lightPink, textColor: brandPink },
+      styles: {
+        font: fontFamily,
+        fontStyle: normalFont,
+        lineWidth: 0.1,
+        lineColor: borderColor,
+        fontSize: 10
+      },
+      headStyles: {
+        font: fontFamily,
+        fontStyle: boldFont,
+        fillColor: lightPink,
+        textColor: brandPink
+      },
       margin: { left: marginLeft }
     });
     currentY = doc.lastAutoTable.finalY + 12;
@@ -143,21 +170,21 @@ export default async function generateReport({
 
   // ── SECTION 3: RECENT SYMPTOMS ──
   doc.setFontSize(12);
-  doc.setFont('helvetica', 'bold');
+  doc.setFont(fontFamily, boldFont);
   doc.setTextColor(brandPink[0], brandPink[1], brandPink[2]);
   doc.text('Recent Symptoms (last 15 entries)', marginLeft, currentY);
   currentY += 6;
 
   if (recentSymptoms.length === 0) {
     doc.setFontSize(10);
-    doc.setFont('helvetica', 'normal');
+    doc.setFont(fontFamily, normalFont);
     doc.setTextColor(0, 0, 0);
     doc.text('No symptom logs yet.', marginLeft, currentY);
     currentY += 15;
   } else {
     // If symptoms exist, format them
     doc.setFontSize(10);
-    doc.setFont('helvetica', 'normal');
+    doc.setFont(fontFamily, normalFont);
     doc.setTextColor(0, 0, 0);
     doc.text(recentSymptoms.join(', '), marginLeft, currentY, { maxWidth: doc.internal.pageSize.getWidth() - 40 });
     currentY += 15;
@@ -166,7 +193,7 @@ export default async function generateReport({
   // ── FOOTER DISCLAIMER ──
   doc.setFontSize(9);
   doc.setTextColor(0, 0, 0);
-  doc.setFont('helvetica', 'italic');
+  doc.setFont(fontFamily, italicFont);
   const disclaimer = 'This report is generated by HerCycle AI for informational purposes only and is not a medical diagnosis.';
   doc.text(disclaimer, marginLeft, currentY);
 


### PR DESCRIPTION
## Linked Issue

Fixes #139 

## Description

This PR fixes font rendering in Hindi PDF reports by ensuring all text uses the registered `NotoSansDevanagari` font instead of reverting to Helvetica.

### Changes made

- Added safe fallback to Helvetica if the Hindi font cannot be loaded.
- Replaced hardcoded `helvetica` font usage with dynamic font selection based on locale.
- Updated all text-rendering calls (headers, patient information, section titles, symptoms, and footer).
- Configured both `jspdf-autotable` tables to use the correct font for table headers and cells.

## Type of Change

- [x] Bug fix

## Testing

- Tested PDF generation in English locale.
- Tested PDF generation in Hindi locale.
- Verified that all PDF sections use the appropriate font.
- Confirmed graceful fallback when the Hindi font is unavailable.

## Checklist

- [x] Fixes #139
- [x] Tested locally
- [x] No breaking changes introduced