### PR TITLE
backend: Migrate in-memory Map rate-limiting to database-based tracking

### DIFF
--- a/lib/actions/partner.js
+++ b/lib/actions/partner.js
@@ -12,14 +12,55 @@ const MAX_ATTEMPTS_PER_MIN = 5;               // rate limit
 const LOCKOUT_THRESHOLD = 10;                 // consecutive failures before lockout
 const LOCKOUT_DURATION_MS = 15 * 60 * 1000;   // 15-minute lockout
 
-// In-memory attempt tracker (keyed by userId)
-const pairingAttempts = new Map();
+// ─── Supabase-based attempt tracker ────────────────
+// Replaces the in-memory Map which is lost on serverless function recycling.
 
-function getAttemptRecord(userId) {
-  if (!pairingAttempts.has(userId)) {
-    pairingAttempts.set(userId, { count: 0, windowStart: Date.now(), consecutiveFails: 0, lockedUntil: 0 });
-  }
-  return pairingAttempts.get(userId);
+async function getOrCreatePairingRecord(userId) {
+  const supabase = getSupabaseAdmin();
+
+  const { data: existing, error: selectError } = await supabase
+    .from("pairing_attempts")
+    .select("*")
+    .eq("user_id", userId)
+    .maybeSingle();
+
+  if (selectError) throw selectError;
+
+  if (existing) return existing;
+
+  // Initialize a new record for this user
+  const { data: created, error: insertError } = await supabase
+    .from("pairing_attempts")
+    .insert([
+      {
+        user_id: userId,
+        attempt_count: 0,
+        window_start: new Date().toISOString(),
+        consecutive_failures: 0,
+        locked_until: null,
+      },
+    ])
+    .select()
+    .single();
+
+  if (insertError && insertError.code !== "23505") throw insertError;
+  return created || existing;
+}
+
+async function updatePairingRecord(userId, updates) {
+  const supabase = getSupabaseAdmin();
+  const { data, error } = await supabase
+    .from("pairing_attempts")
+    .upsert({
+      user_id: userId,
+      ...updates,
+      updated_at: new Date().toISOString(),
+    })
+    .select()
+    .single();
+
+  if (error) throw error;
+  return data;
 }
 
 // Helper to generate a random 12-character hex code (6 bytes = 281 trillion values)
@@ -93,22 +134,27 @@ export async function acceptPairingCode(code) {
   }
 
   // ── Lockout check ──
-  const record = getAttemptRecord(userId);
+  let record = await getOrCreatePairingRecord(userId);
   const now = Date.now();
 
-  if (record.lockedUntil > now) {
-    const minsLeft = Math.ceil((record.lockedUntil - now) / 60000);
+  if (record.locked_until && new Date(record.locked_until).getTime() > now) {
+    const minsLeft = Math.ceil((new Date(record.locked_until).getTime() - now) / 60000);
     throw new Error(`Too many failed attempts. Try again in ${minsLeft} minute(s).`);
   }
 
   // ── Rate limit check (sliding 1-min window) ──
-  if (now - record.windowStart > 60000) {
-    record.count = 0;
-    record.windowStart = now;
-  }
-  record.count += 1;
-  if (record.count > MAX_ATTEMPTS_PER_MIN) {
-    throw new Error("Too many pairing attempts. Please wait a minute.");
+  const windowStart = new Date(record.window_start).getTime();
+  if (now - windowStart > 60000) {
+    record = await updatePairingRecord(userId, {
+      attempt_count: 1,
+      window_start: new Date(now).toISOString(),
+    });
+  } else {
+    const newCount = (record.attempt_count || 0) + 1;
+    record = await updatePairingRecord(userId, { attempt_count: newCount });
+    if (newCount > MAX_ATTEMPTS_PER_MIN) {
+      throw new Error("Too many pairing attempts. Please wait a minute.");
+    }
   }
 
   const supabase = getSupabaseAdmin();
@@ -143,12 +189,15 @@ export async function acceptPairingCode(code) {
     .maybeSingle();
 
   if (findError || !connection) {
-    record.consecutiveFails += 1;
-    if (record.consecutiveFails >= LOCKOUT_THRESHOLD) {
-      record.lockedUntil = now + LOCKOUT_DURATION_MS;
-      record.consecutiveFails = 0;
+    const newFails = (record.consecutive_failures || 0) + 1;
+    if (newFails >= LOCKOUT_THRESHOLD) {
+      await updatePairingRecord(userId, {
+        consecutive_failures: 0,
+        locked_until: new Date(now + LOCKOUT_DURATION_MS).toISOString(),
+      });
       throw new Error("Too many failed attempts. You have been locked out for 15 minutes.");
     }
+    await updatePairingRecord(userId, { consecutive_failures: newFails });
     throw new Error("Invalid or expired pairing code. Please generate a new code in Settings.");
   }
 
@@ -164,7 +213,7 @@ export async function acceptPairingCode(code) {
     throw new Error("This pairing code has expired. Please generate a new one in Settings.");
   }
 
-  record.consecutiveFails = 0;
+  await updatePairingRecord(userId, { consecutive_failures: 0 });
 
   // Ensure partner user exists in public.users to satisfy FK constraint
   await ensureUserExists(userId);

--- a/supabase/01_add_pairing_attempts.sql
+++ b/supabase/01_add_pairing_attempts.sql
@@ -1,0 +1,13 @@
+-- Migration: Add pairing_attempts table for database-based rate limiting
+-- Replaces the in-memory Map used for pairing attempt tracking
+
+CREATE TABLE IF NOT EXISTS public.pairing_attempts (
+    user_id TEXT PRIMARY KEY,
+    attempt_count INTEGER NOT NULL DEFAULT 0,
+    window_start TIMESTAMPTZ NOT NULL DEFAULT now(),
+    consecutive_failures INTEGER NOT NULL DEFAULT 0,
+    locked_until TIMESTAMPTZ,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.pairing_attempts ENABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
Replace the in-memory `pairingAttempts` Map with a Supabase `pairing_attempts` table to persist rate-limiting and lockout state across serverless function invocations.

### Changes:
- **New migration**: `supabase/01_add_pairing_attempts.sql` — creates the `pairing_attempts` table with RLS enabled
- **Updated `lib/actions/partner.js`**: replaced in-memory Map with Supabase-backed `getOrCreatePairingRecord()` and `updatePairingRecord()` helpers, updated `acceptPairingCode()` to read/write attempt counts, rate-limit windows, and lockout state from the database

Fixes #189