### PR TITLE
[ECSoC26] accessibility: Missing aria-label on Back Button in Self-Care Detail Page #167

### DIFF
--- a/app/[locale]/self-care/[exerciseId]/page.js
+++ b/app/[locale]/self-care/[exerciseId]/page.js
@@ -52,6 +52,7 @@ export default function ExerciseDetailPage() {
         <button 
           onClick={() => router.back()}
           className="absolute top-6 left-4 w-10 h-10 rounded-full bg-white/10 backdrop-blur flex items-center justify-center text-white hover:bg-white/20 transition-colors z-20"
+          aria-label={t('backToSelfCare')}
         >
           <ArrowLeft className="w-5 h-5" />
         </button>


### PR DESCRIPTION
### Describe your changes
Added a localized `aria-label` attribute (`aria-label={t('backToSelfCare')}`) to the navigation Back button on the Self-Care exercise detail page ([page.js](file:///e:/ECSOC-26/hercycle-ai/app/[locale]/self-care/[exerciseId]/page.js)). 

This ensures screen reader users hear descriptive, context-appropriate text ("Back to Self Care" / "स्व-देखभाल पर वापस जाएं") instead of just "button" when tabbing through the page.

### Related Issue
Closes #167
