### PR TITLE
[ECSoC26] bugfix: validate and normalize single cycle entry cycle_length in predictNextPeriod (#163)

### DIFF
--- a/lib/api-helpers.js
+++ b/lib/api-helpers.js
@@ -35,7 +35,10 @@ export function predictNextPeriod(cycleHistory) {
   // Need at least 2 data points to calculate a meaningful average
   if (deduped.length < 2) {
     const lastPeriod = new Date(deduped[0].start_date)
-    const avgLen = deduped[0].cycle_length || 28
+    let avgLen = parseInt(deduped[0].cycle_length, 10)
+    if (isNaN(avgLen) || avgLen < 21 || avgLen > 45) {
+      avgLen = 28
+    }
     const nextPeriod = new Date(lastPeriod)
     nextPeriod.setDate(nextPeriod.getDate() + avgLen)
     const months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec']

--- a/scripts/test-prediction-bug.js
+++ b/scripts/test-prediction-bug.js
@@ -1,0 +1,70 @@
+import { predictNextPeriod } from '../lib/api-helpers.js';
+
+function assert(condition, message) {
+  if (!condition) {
+    console.error(`❌ Assertion Failed: ${message}`);
+    process.exit(1);
+  }
+}
+
+function runTests() {
+  console.log('Running predictNextPeriod single entry validation tests...');
+
+  const startDate = '2026-07-01';
+
+  // Test 1: Normal cycle_length (e.g. 30) -> Should keep 30
+  {
+    const history = [{ start_date: startDate, cycle_length: 30 }];
+    const res = predictNextPeriod(history);
+    assert(res.averageCycleLength === 30, `Expected 30, got ${res.averageCycleLength}`);
+    // Expected next period date: Jul 31 (Jul 1 + 30 days)
+    assert(res.nextPeriodDate.startsWith('Jul 31'), `Expected Jul 31, got ${res.nextPeriodDate}`);
+    console.log('Test 1 Passed: Normal length accepted.');
+  }
+
+  // Test 2: Cycle length too high (e.g. 100) -> Should fallback to 28
+  {
+    const history = [{ start_date: startDate, cycle_length: 100 }];
+    const res = predictNextPeriod(history);
+    assert(res.averageCycleLength === 28, `Expected fallback 28, got ${res.averageCycleLength}`);
+    // Expected next period date: Jul 29 (Jul 1 + 28 days)
+    assert(res.nextPeriodDate.startsWith('Jul 29'), `Expected Jul 29, got ${res.nextPeriodDate}`);
+    console.log('Test 2 Passed: Excessively high length normalized.');
+  }
+
+  // Test 3: Cycle length too low (e.g. 10) -> Should fallback to 28
+  {
+    const history = [{ start_date: startDate, cycle_length: 10 }];
+    const res = predictNextPeriod(history);
+    assert(res.averageCycleLength === 28, `Expected fallback 28, got ${res.averageCycleLength}`);
+    console.log('Test 3 Passed: Excessively low length normalized.');
+  }
+
+  // Test 4: Negative cycle length (e.g. -5) -> Should fallback to 28
+  {
+    const history = [{ start_date: startDate, cycle_length: -5 }];
+    const res = predictNextPeriod(history);
+    assert(res.averageCycleLength === 28, `Expected fallback 28, got ${res.averageCycleLength}`);
+    console.log('Test 4 Passed: Negative length normalized.');
+  }
+
+  // Test 5: Numeric string (e.g. "32") -> Should parse and use 32
+  {
+    const history = [{ start_date: startDate, cycle_length: '32' }];
+    const res = predictNextPeriod(history);
+    assert(res.averageCycleLength === 32, `Expected 32, got ${res.averageCycleLength}`);
+    console.log('Test 5 Passed: Numeric string parsed successfully.');
+  }
+
+  // Test 6: Non-numeric/garbage string -> Should fallback to 28
+  {
+    const history = [{ start_date: startDate, cycle_length: 'garbage' }];
+    const res = predictNextPeriod(history);
+    assert(res.averageCycleLength === 28, `Expected fallback 28, got ${res.averageCycleLength}`);
+    console.log('Test 6 Passed: Garbage string normalized.');
+  }
+
+  console.log('=== All predictNextPeriod Validation Tests Passed! ===');
+}
+
+runTests();


### PR DESCRIPTION
## Linked Issue
Fixes #163

## Description
This Pull Request fixes a bug in `predictNextPeriod` where a single cycle history entry uses `deduped[0].cycle_length || 28` directly without bounding or validation. This could accept unrealistic cycle lengths (e.g. 100 days, negative numbers, or non-numeric strings) leading to incorrect next-period date predictions.

We implemented:
- Strict bounds validation (`[21, 45]`) on single-cycle history entry cycle lengths using `parseInt` parsing.
- A fallback default of 28 if the parsed cycle length is out-of-range, NaN, or non-numeric, matching the multi-cycle path normalization behavior.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (clean code updates, no behavior modifications)
- [ ] Documentation update
- [ ] Performance optimization
- [ ] Security patch

## Testing
We added a test script in `scripts/test-prediction-bug.js` covering normal, excessively high, excessively low, negative, numeric string, and non-numeric garbage inputs.

Command run:
```bash
node scripts/test-prediction-bug.js
