### PR TITLE
[ECSoC26] bugfix: filter invalid and missing start_date cycle history entries (#162)

### DIFF
--- a/lib/api-helpers.js
+++ b/lib/api-helpers.js
@@ -4,7 +4,15 @@
 function dedupeCycles(cycleHistory) {
   if (!cycleHistory || cycleHistory.length === 0) return []
 
-  const sorted = [...cycleHistory].sort((a, b) =>
+  const validHistory = cycleHistory.filter(c => {
+    if (!c || !c.start_date) return false
+    const d = new Date(c.start_date)
+    return d instanceof Date && !isNaN(d.getTime())
+  })
+
+  if (validHistory.length === 0) return []
+
+  const sorted = [...validHistory].sort((a, b) =>
     new Date(a.start_date) - new Date(b.start_date)
   )
 
@@ -32,10 +40,23 @@ export function predictNextPeriod(cycleHistory) {
 
   const deduped = dedupeCycles(cycleHistory)
 
+  if (deduped.length === 0) {
+    const months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec']
+    const estimated = new Date(Date.now() + 28 * 24 * 60 * 60 * 1000)
+    return {
+      nextPeriodDate: `${months[estimated.getMonth()]} ${estimated.getDate()}, ${estimated.getFullYear()}`,
+      confidence: '0%',
+      averageCycleLength: 28
+    }
+  }
+
   // Need at least 2 data points to calculate a meaningful average
   if (deduped.length < 2) {
     const lastPeriod = new Date(deduped[0].start_date)
-    const avgLen = deduped[0].cycle_length || 28
+    let avgLen = parseInt(deduped[0].cycle_length, 10)
+    if (isNaN(avgLen) || avgLen < 21 || avgLen > 45) {
+      avgLen = 28
+    }
     const nextPeriod = new Date(lastPeriod)
     nextPeriod.setDate(nextPeriod.getDate() + avgLen)
     const months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec']

--- a/scripts/test-invalid-dates.js
+++ b/scripts/test-invalid-dates.js
@@ -1,0 +1,70 @@
+import { predictNextPeriod } from '../lib/api-helpers.js';
+
+function assert(condition, message) {
+  if (!condition) {
+    console.error(`❌ Assertion Failed: ${message}`);
+    process.exit(1);
+  }
+}
+
+function runTests() {
+  console.log('Running invalid date validation tests for predictNextPeriod...');
+
+  // Test 1: Empty array input -> Should return default prediction
+  {
+    const res = predictNextPeriod([]);
+    assert(res.averageCycleLength === 28, 'Expected averageCycleLength to be 28');
+    assert(res.confidence === '0%', 'Expected confidence to be 0%');
+    console.log('Test 1 Passed: Empty array input.');
+  }
+
+  // Test 2: Falsy entries / malformed objects -> Should ignore and return default prediction
+  {
+    const res = predictNextPeriod([null, undefined, {}, { start_date: null }]);
+    assert(res.averageCycleLength === 28, 'Expected averageCycleLength to be 28');
+    assert(res.confidence === '0%', 'Expected confidence to be 0%');
+    console.log('Test 2 Passed: Falsy entries and missing fields handled.');
+  }
+
+  // Test 3: Completely invalid start_dates -> Should ignore and return default prediction
+  {
+    const res = predictNextPeriod([
+      { start_date: 'invalid-date' },
+      { start_date: 'hello-world' }
+    ]);
+    assert(res.averageCycleLength === 28, 'Expected averageCycleLength to be 28');
+    assert(res.confidence === '0%', 'Expected confidence to be 0%');
+    console.log('Test 3 Passed: Completely invalid start_dates ignored.');
+  }
+
+  // Test 4: Mix of valid and invalid dates -> Should process only valid dates
+  {
+    // One valid date, two invalid dates -> should fallback to single cycle entry behavior
+    const res = predictNextPeriod([
+      { start_date: 'invalid-date' },
+      { start_date: '2026-07-01', cycle_length: 30 },
+      { start_date: 'garbage-date-again' }
+    ]);
+    assert(res.averageCycleLength === 30, 'Expected averageCycleLength to be 30');
+    assert(res.confidence === '75%', 'Expected confidence to be 75%');
+    assert(res.nextPeriodDate.startsWith('Jul 31'), 'Expected next period: Jul 31');
+    console.log('Test 4 Passed: Mix of valid and invalid dates processed.');
+  }
+
+  // Test 5: Multi-cycle with invalid dates intermixed
+  {
+    // Two valid dates, one invalid date
+    const res = predictNextPeriod([
+      { start_date: '2026-07-01', cycle_length: 30 },
+      { start_date: 'invalid-date' },
+      { start_date: '2026-07-31', cycle_length: 30 }
+    ]);
+    // Gap days: Jul 31 - Jul 1 = 30 days
+    assert(res.averageCycleLength === 30, `Expected averageCycleLength to be 30, got ${res.averageCycleLength}`);
+    console.log('Test 5 Passed: Multi-cycle with invalid dates intermixed.');
+  }
+
+  console.log('=== All Invalid Date Validation Tests Passed Successfully! ===');
+}
+
+runTests();


### PR DESCRIPTION
## Linked Issue
Fixes #162

## Description
This Pull Request fixes a bug in `dedupeCycles` and `predictNextPeriod` where invalid, malformed, or missing `start_date` values in cycle history are processed directly, resulting in `Invalid Date` propagation, `NaN` math, or crashes when trying to access elements from empty deduplicated results.

We implemented:
- Strict validation in `dedupeCycles` to exclude falsy entries, entries missing `start_date`, or containing malformed values that resolve to an invalid `Date`.
- An empty history array check in `predictNextPeriod` immediately after deduplication. If no valid dates remain, it returns a default 28-day estimation safely.
- Robust parsing and validation bounds on single-entry cycle lengths to ensure overall predictability remains in a reasonable clinical range.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (clean code updates, no behavior modifications)
- [ ] Documentation update
- [ ] Performance optimization
- [ ] Security patch

## Testing
We added a test script in `scripts/test-invalid-dates.js` verifying empty, falsy, malformed, mixed, and multi-cycle dates containing invalid elements.

Command run:
```bash
node scripts/test-invalid-dates.js