### PR TITLE
[ECSoC26] fix: add pointer cursor to onboarding modal overlay

### DIFF
--- a/components/dashboard/OnboardingModal.jsx
+++ b/components/dashboard/OnboardingModal.jsx
@@ -51,7 +51,7 @@ export default function OnboardingModal({ onComplete, onSkip }) {
         const errMsg = error?.message || error?.details || error?.hint || JSON.stringify(error) || 'Unknown error'
         console.error('Insert error details:', {
           message: error?.message,
-          details: error?.details, 
+          details: error?.details,
           hint: error?.hint,
           code: error?.code,
           full: error
@@ -80,8 +80,18 @@ export default function OnboardingModal({ onComplete, onSkip }) {
   const today = new Date().toISOString().split('T')[0]
 
   return (
-    <div className="onboard-overlay" role="dialog" aria-modal="true">
-      <div className="onboard-card">
+    <div
+      className="onboard-overlay"
+      role="dialog"
+      aria-modal="true"
+      style={{ cursor: 'pointer' }}
+      onClick={(e) => {
+        if (e.target === e.currentTarget) {
+          handleSkip()
+        }
+      }}
+    >
+      <div className="onboard-card" onClick={(e) => e.stopPropagation()} style={{ cursor: 'default' }}>
         {/* Decorative top */}
         <div className="onboard-header-art">
           <span className="onboard-emoji">🌸</span>


### PR DESCRIPTION
## Linked Issue
Fixes #247

## Description
Added a pointer cursor hint to the OnboardingModal's background overlay, and implemented click-outside-to-dismiss so the cursor hint actually reflects real behavior.

- Added `cursor: pointer` to the `.onboard-overlay` container so hovering the dark backdrop visually signals it's clickable.
- Added an `onClick` handler on the overlay that calls the existing `handleSkip()` (only when the click target is the overlay itself, via `e.target === e.currentTarget`), so clicking outside the card now dismisses the modal the same way "Skip for now" does.
- Added `e.stopPropagation()` on `.onboard-card`'s click handler so clicks inside the card never bubble up and accidentally trigger dismiss.
- Added `cursor: default` on `.onboard-card` to override CSS cursor inheritance from the overlay — without this, the pointer cursor incorrectly bled onto the card's plain areas (title, subtitle, decorative elements). Buttons, sliders, and the date input are unaffected since they already set their own cursor via their element type/styles.
- No changes to onboarding form logic, step flow, or save/skip behavior.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
- Ran `npm run dev` locally, cleared `localStorage['onboarding_complete']` and tested with a fresh user (zero cycles) to trigger the modal.
- Hovered the dark blurred backdrop outside the card → confirmed pointer cursor shows.
- Hovered the card's plain areas (title, subtitle, decorative flower/rings, padding) → confirmed normal arrow cursor, not pointer.
- Hovered buttons, sliders, and the date input → confirmed their own correct cursor styles are unaffected.
- Clicked the dark overlay outside the card → confirmed the modal dismisses (same as clicking "Skip for now", sets `onboarding_complete = 'skipped'`).
- Clicked inside the card (title, inputs, buttons, padding) → confirmed the modal does **not** dismiss and click events don't bubble up.
- Ran through the full onboarding flow (Step 1 date entry → Continue → Step 2 sliders → Start) and confirmed cycle data still saves correctly and the modal closes via `onComplete()` as before.
- Confirmed "Skip for now" button still works independently of the new overlay click handler.
- `npm run build` completed successfully.

## Checklist
- [x] This PR is submitted under ECSOC.
- [ ] Added the required **ECSoc26** label to this Pull Request.
- [x] Linked issue using `Fixes #247`.
- [x] Tested locally.
- [x] `npm run build` completes successfully.
- [ ] GitHub Actions checks pass.
- [x] No breaking changes introduced.
- [x] Documentation updated if required.