### PR TITLE
[ECSoC26] fix(ui): adjust scroll container margins in logs history

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -3094,6 +3094,7 @@ nav ul li a:focus-visible,
   border-top-left-radius: 24px;
   border-top-right-radius: 24px;
   padding: 1.5rem;
+  padding-bottom: 3rem;
   z-index: 1000;
   max-height: 85vh;
   overflow-y: auto;


### PR DESCRIPTION
## Description

This PR fixes the daily logs scroll wrapper overlapping with the bottom edge on smaller laptop screens by increasing the bottom padding on the drawer container.

---

## Related Issue

* Closes #246

---

## Checklist

* [x] I have read CONTRIBUTING.md
* [x] I tested my changes locally
* [x] This PR is scoped to one logical change