### PR TITLE
[ECSoC26] fix(ui): normalize line height of symptom pills in DailyLogPanel.jsx

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1374,7 +1374,11 @@ nav ul li a.active {
   color: var(--text-soft);
   cursor: pointer;
   transition: all 0.22s;
-  text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  line-height: 1.4;
 }
 
 .symp-chip:hover,


### PR DESCRIPTION
## Description

This PR normalizes the vertical alignment of symptom pills in the Daily Log panel. By standardizing the \line-height\ and utilizing flexbox centering (\lign-items: center\, \justify-content: center\), the icon and text now align perfectly on all viewports, resolving the slightly off appearance on mobile.

---

## Related Issue

* Closes #242

---

## Checklist

* [x] I have read CONTRIBUTING.md
* [x] I tested my changes locally
* [x] This PR is scoped to one logical change