### PR TITLE
[ECSoC26] Frontend: Add horizontal scroll wrapper on logged symptoms list for mobile view

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1364,6 +1364,25 @@ nav ul li a.active {
   margin-bottom: 12px;
 }
 
+/* Mobile horizontal scroll wrapper for logged symptoms (Fixes #329) */
+@media (max-width: 640px) {
+  .symp-grid-scroll-wrapper,
+  .symptoms-horizontal-scroll {
+    display: flex !important;
+    overflow-x: auto !important;
+    white-space: nowrap !important;
+    padding-bottom: 8px !important;
+    gap: 8px !important;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+  }
+  .symp-grid-scroll-wrapper .symp-chip,
+  .symptoms-horizontal-scroll .symp-chip {
+    flex: 0 0 auto !important;
+    white-space: nowrap !important;
+  }
+}
+
 .symp-chip {
   background: rgba(255, 255, 255, 0.08);
   border: 1px solid rgba(255, 255, 255, 0.15);

--- a/components/dashboard/DailyLogPanel.jsx
+++ b/components/dashboard/DailyLogPanel.jsx
@@ -56,7 +56,7 @@ export default function DailyLogPanel({
           Common Symptoms
         </div>
 
-        <div className="symp-grid">
+        <div className="symp-grid symp-grid-scroll-wrapper">
           {allDisplaySymptoms.map(symptom => {
             const active = selectedSymptoms.includes(symptom)
             const isCustom = !baseSymptoms.includes(symptom)


### PR DESCRIPTION
## Linked Issue
Fixes #329

## Description
Implemented a responsive flex horizontal scroll wrapper for logged symptom chips on mobile viewports to prevent layout wrapping breakage.

- Adds .symp-grid-scroll-wrapper class to components/dashboard/DailyLogPanel.jsx.
- Defines @media (max-width: 640px) horizontal scroll styling with -webkit-overflow-scrolling: touch in pp/globals.css.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (clean code updates, no behavior modifications)
- [ ] Performance optimization

## Files Modified (2 files)
- components/dashboard/DailyLogPanel.jsx
- pp/globals.css

## Testing
1. Resize screen to mobile width (< 640px) or inspect via mobile device emulator.
2. Observe symptom chips list renders cleanly in a single horizontal scroll row without breaking card layout height.

## Checklist
- [x] This PR is submitted under ECSOC.
- [x] Added the required **ECSoc26** label to this Pull Request.
- [x] Linked issue using Fixes #329.
- [x] Tested locally.
- [x] No breaking changes introduced.