### PR TITLE
[ECSoC26] Frontend: Prevent Self-Care Step Illustration Opacity Glitch on Navigation

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -3277,3 +3277,13 @@ nav ul li a:focus-visible,
     grid-template-columns: repeat(15, minmax(0, 1fr));
   }
 }
+
+/* ──── SELF-CARE OPACITY & TRANSITION GLITCH FIX (Fixes #330) ──── */
+.self-care-step-img,
+.self-care-card img,
+.group-hover\:scale-110 {
+  will-change: opacity, transform;
+  backface-visibility: hidden;
+  -webkit-backface-visibility: hidden;
+  transform-style: preserve-3d;
+}

--- a/components/self-care/ExerciseCard.jsx
+++ b/components/self-care/ExerciseCard.jsx
@@ -25,7 +25,8 @@ export default function ExerciseCard({ exercise, isFavorite, onToggleFavorite })
       <img
         src={exercise.image}
         alt={exercise.title}
-        className="absolute inset-0 w-full h-full object-cover transition-transform duration-700 group-hover:scale-110"
+        className="absolute inset-0 w-full h-full object-cover transition-transform duration-700 group-hover:scale-110 [will-change:opacity,transform] [backface-visibility:hidden]"
+        style={{ willChange: 'opacity, transform', backfaceVisibility: 'hidden' }}
       />
       <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/20 to-transparent opacity-80"></div>
 


### PR DESCRIPTION
## Linked Issue
Fixes #330

## Description
Prevented opacity flickering and glitching transitions on Self-Care step illustrations and exercise cards during step navigation.

- Applied will-change: opacity, transform, ackface-visibility: hidden, and 3D transform acceleration on self-care step illustrations and cards in components/self-care/ExerciseCard.jsx and pp/globals.css.
- Stabilizes GPU compositing layers to ensure smooth, glitch-free image rendering.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (clean code updates, no behavior modifications)
- [ ] Performance optimization

## Files Modified (2 files)
- components/self-care/ExerciseCard.jsx
- pp/globals.css

## Testing
1. Navigate to /self-care page.
2. Step through exercises/illustrations; observe zero opacity flickering or GPU composite layer glitches.

## Checklist
- [x] This PR is submitted under ECSOC.
- [x] Added the required **ECSoc26** label to this Pull Request.
- [x] Linked issue using Fixes #330.
- [x] Tested locally.
- [x] No breaking changes introduced.