### PR TITLE
[ECSoC26] feat(prediction): cycle prediction variance threshold filtering

### DIFF
--- a/lib/api-helpers.js
+++ b/lib/api-helpers.js
@@ -144,7 +144,11 @@ function filterOutliers(values, minKeep = 2) {
  *   missedCycles?: number,
  *   isStale?: boolean,
  *   hasEnoughRecentData?: boolean,
- *   lastLoggedDate?: string
+ *   lastLoggedDate?: string,
+ *   isIrregular?: boolean,
+ *   regularityLabel?: string,
+ *   varianceStdDev?: number,
+ *   predictionWindow?: { from: string, to: string } | null
  * }} The first three fields are unchanged, so the three existing call sites
  *   (/api/predict-cycle, the offline client, and the PDF report) keep working.
  */
@@ -165,7 +169,8 @@ export function predictNextPeriod(cycleHistory, today = new Date()) {
     if (isNaN(avgLen) || avgLen < 21 || avgLen > 45) {
       avgLen = 28
     }
-    const { nextPeriod, missedCycles } = projectForward(lastPeriod, avgLen, today)
+    const singleLastPeriod = new Date(deduped[0].start_date)
+    const { nextPeriod, missedCycles } = projectForward(singleLastPeriod, avgLen, today)
     const months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec']
     return {
       nextPeriodDate: `${months[nextPeriod.getMonth()]} ${nextPeriod.getDate()}, ${nextPeriod.getFullYear()}`,
@@ -207,6 +212,18 @@ export function predictNextPeriod(cycleHistory, today = new Date()) {
 
   avgLength = Math.max(21, Math.min(45, avgLength || 28))
 
+  // Variance threshold filtering: measure the spread of the (outlier-free)
+  // cycle gaps. A standard deviation above 5 days means the history is too
+  // irregular to support a confident single-date projection, so the prediction
+  // is tagged 'Irregular Cycle' and reported as a window instead.
+  let stdDev = 0
+  if (filteredGaps.length >= 2) {
+    const gapMean = filteredGaps.reduce((a, b) => a + b, 0) / filteredGaps.length
+    const gapVariance = filteredGaps.reduce((sum, gap) => sum + Math.pow(gap - gapMean, 2), 0) / filteredGaps.length
+    stdDev = Math.sqrt(gapVariance)
+  }
+  const isIrregular = filteredGaps.length >= 2 && stdDev > 5
+
   const lastLoggedStart = deduped[deduped.length - 1].start_date
   const lastPeriod = new Date(lastLoggedStart)
 
@@ -216,7 +233,19 @@ export function predictNextPeriod(cycleHistory, today = new Date()) {
   const { nextPeriod, missedCycles } = projectForward(lastPeriod, avgLength, today)
 
   const months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec']
-  const formattedDate = `${months[nextPeriod.getMonth()]} ${nextPeriod.getDate()}, ${nextPeriod.getFullYear()}`
+  const formatPredictionDate = (date) => `${months[date.getMonth()]} ${date.getDate()}, ${date.getFullYear()}`
+  const formattedDate = formatPredictionDate(nextPeriod)
+
+  // Irregular cycles get a ±1 standard deviation window around the projected
+  // date so the UI can show a realistic range instead of a false-precise day.
+  let predictionWindow = null
+  if (isIrregular) {
+    const fromDate = new Date(nextPeriod)
+    fromDate.setDate(fromDate.getDate() - Math.round(stdDev))
+    const toDate = new Date(nextPeriod)
+    toDate.setDate(toDate.getDate() + Math.round(stdDev))
+    predictionWindow = { from: formatPredictionDate(fromDate), to: formatPredictionDate(toDate) }
+  }
 
   // Confidence is based on the filtered gaps (outliers excluded → more stable)
   let variance = 0
@@ -237,7 +266,11 @@ export function predictNextPeriod(cycleHistory, today = new Date()) {
     missedCycles,
     isStale:           missedCycles > 0,
     hasEnoughRecentData: missedCycles < MAX_MEANINGFUL_MISSED_CYCLES,
-    lastLoggedDate:    lastLoggedStart
+    lastLoggedDate:    lastLoggedStart,
+    isIrregular,
+    regularityLabel:   isIrregular ? 'Irregular Cycle' : 'Regular Cycle',
+    varianceStdDev:    Math.round(stdDev * 10) / 10,
+    predictionWindow
   }
 }
 


### PR DESCRIPTION
## Summary
Enhances `predictNextPeriod` to detect irregular cycles via cycle variance and report a prediction window instead of a false-precise single date.

## Changes
- `lib/api-helpers.js`:
  - Computes stdDev of the outlier-filtered cycle gaps.
  - Tags predictions with `isIrregular` + `regularityLabel: 'Irregular Cycle'` when stdDev > 5 days.
  - Adds `predictionWindow: { from, to }` (\u00b11 stdDev) for irregular cycles.
  - Exposes `varianceStdDev` so confidence reflects historical regularity.
  - Fixes a pre-existing `ReferenceError` (TDZ) in the single-entry path.

## Acceptance criteria
- [x] High-variance predictions output a window range instead of a single date
- [x] Confidence reflects historical cycle regularity (unchanged existing fields)

Closes #382