### PR TITLE
[ECSoC26] feat(webhooks): Clerk webhook event deduplication and retry logging

### DIFF
--- a/app/api/webhooks/clerk/route.js
+++ b/app/api/webhooks/clerk/route.js
@@ -3,6 +3,49 @@ import { Webhook } from 'svix'
 import { getSupabaseAdmin } from '@/lib/supabase-admin'
 import { logger } from '@/lib/logger'
 
+/**
+ * Returns true when a webhook delivery for `eventId` was already processed.
+ *
+ * Clerk retries deliveries when a handler returns a non-2xx, and may resend
+ * on a network hiccup — both would otherwise re-run the DB write. The audit
+ * table makes every duplicate a cheap read + early 200.
+ *
+ * @param {ReturnType<getSupabaseAdmin>} supabaseAdmin
+ * @param {string} eventId
+ * @returns {Promise<boolean>}
+ */
+async function isDuplicateEvent(supabaseAdmin, eventId) {
+  const { data: existingEvent } = await supabaseAdmin
+    .from('clerk_webhook_audit')
+    .select('event_id')
+    .eq('event_id', eventId)
+    .maybeSingle()
+
+  return Boolean(existingEvent)
+}
+
+/**
+ * Records a processed webhook delivery so later duplicates are ignored.
+ *
+ * A write failure here must NOT fail the underlying user mutation — the
+ * mutation already succeeded. Log it loudly instead so an operator can spot
+ * the gap, and let the idempotent upsert/delete queries absorb a rare retry.
+ *
+ * @param {ReturnType<getSupabaseAdmin>} supabaseAdmin
+ * @param {string} eventId
+ * @param {string} eventType
+ * @returns {Promise<void>}
+ */
+async function recordAuditEvent(supabaseAdmin, eventId, eventType) {
+  const { error: auditError } = await supabaseAdmin
+    .from('clerk_webhook_audit')
+    .insert({ event_id: eventId, event_type: eventType })
+
+  if (auditError) {
+    logger.error(`Webhook: failed to record audit event ${eventId}:`, auditError.message);
+  }
+}
+
 export async function POST(request) {
   // 1. Retrieve webhook secret
   const WEBHOOK_SECRET = process.env.CLERK_WEBHOOK_SECRET
@@ -39,23 +82,44 @@ export async function POST(request) {
     return new Response('Error: Invalid signature', { status: 400 })
   }
 
-  // 5. Handle user.deleted event (idempotency is guaranteed by cascading delete query filters)
   const eventType = evt.type
   const eventId = svix_id
+  const supabaseAdmin = getSupabaseAdmin()
+
+  // 5. Deduplicate across ALL event types before any database write. A
+  // redundant upsert is wasted work at best and a correctness hazard at worst.
+  try {
+    if (await isDuplicateEvent(supabaseAdmin, eventId)) {
+      logger.warn(`Duplicate Clerk webhook delivery ignored. Event ID: ${eventId}, type: ${eventType}`);
+      return NextResponse.json({
+        success: true,
+        duplicate: true,
+        message: 'Webhook already processed'
+      });
+    }
+  } catch (err) {
+    // Fail-open on the dedup read: a transient audit-table error should not
+    // silently drop a real user creation. The idempotent queries below and the
+    // audit insert keep retries safe.
+    logger.error(`Webhook: duplicate check failed for event ${eventId}:`, err.message || err);
+  }
+
   logger.info(`Received Clerk webhook event: ${eventType}`);
 
   if (eventType === 'user.created') {
     const { id: clerkUserId } = evt.data
     try {
-      const supabaseAdmin = getSupabaseAdmin()
       const { error } = await supabaseAdmin
         .from('users')
         .insert([{ id: clerkUserId }])
-      
+
       if (error) {
         logger.error(`Webhook: failed to insert user ${clerkUserId}:`, error.message);
         throw new Error(error.message);
       }
+
+      await recordAuditEvent(supabaseAdmin, eventId, eventType);
+
       logger.info(`Webhook user.created: Inserted user ${clerkUserId}`);
       return NextResponse.json({ success: true, message: 'User created successfully' })
     } catch (err) {
@@ -73,29 +137,8 @@ export async function POST(request) {
     }
 
     try {
-      const supabaseAdmin = getSupabaseAdmin()
-
-      // Prevent duplicate processing of retried Clerk webhooks
-const { data: existingEvent } = await supabaseAdmin
-  .from('clerk_webhook_audit')
-  .select('event_id')
-  .eq('event_id', eventId)
-  .maybeSingle();
-
-if (existingEvent) {
-  logger.warn(
-    `Duplicate Clerk webhook ignored. Event ID: ${eventId}`
-  );
-
-  return NextResponse.json({
-    success: true,
-    duplicate: true,
-    message: 'Webhook already processed'
-  });
-}
-      
       logger.info(`Webhook user.deleted: Purging database records for user ${clerkUserId}`);
-      
+
       // Delete from users table (cascades to cycles and daily_logs)
       const { error } = await supabaseAdmin
         .from('users')
@@ -107,20 +150,7 @@ if (existingEvent) {
         throw new Error(error.message);
       }
 
-      const { error: auditError } = await supabaseAdmin
-  .from('clerk_webhook_audit')
-  .insert({
-    event_id: eventId,
-    event_type: eventType
-  });
-
-if (auditError) {
-  logger.error(
-    `Webhook: failed to record audit event ${eventId}:`,
-    auditError.message
-  );
-  throw new Error(auditError.message);
-}
+      await recordAuditEvent(supabaseAdmin, eventId, eventType);
 
       logger.info(`Webhook user.deleted: Successfully purged all database records for user ${clerkUserId}`);
       return NextResponse.json({ success: true, message: 'User data purged successfully' })


### PR DESCRIPTION
## Summary
Implements webhook event deduplication for all Clerk events (previously only `user.deleted`) and improves retry logging.

## Changes
- `app/api/webhooks/clerk/route.js`:
  - `isDuplicateEvent` — checks `clerk_webhook_audit` before any DB write; returns 200 OK for already-processed events.
  - `recordAuditEvent` — records successful processing for `user.created` (was missing) and `user.deleted`.
  - Dedup read fails open (logged) so transient audit-table errors never drop a real user creation.
  - Duplicate and audit-failure logs include the event ID for retry troubleshooting.

## Acceptance criteria
- [x] Webhook processing checks event ID before executing database writes
- [x] Returns HTTP 200 OK for already-processed webhook events

Closes #385