### PR TITLE
[ECSoC26] fix(ux): unsafe SW controllerchange reload becomes toast banner

### DIFF
--- a/lib/OfflineContext.jsx
+++ b/lib/OfflineContext.jsx
@@ -132,11 +132,24 @@ export function OfflineProvider({ children }) {
           console.error('Service Worker registration failed:', err);
         });
 
-      let refreshing = false;
+      let refreshPrompted = false;
       const handleControllerChange = () => {
-        if (refreshing) return;
-        refreshing = true;
-        window.location.reload();
+        // Never force a reload: the user may be mid-log or mid-typing, and a
+        // spontaneous window.location.reload() would discard unsaved local
+        // state. Surface a non-intrusive banner and let them refresh on their
+        // own terms.
+        if (refreshPrompted) return;
+        refreshPrompted = true;
+        toast('🔄 Update available — click to refresh.', {
+          duration: Infinity,
+          action: {
+            label: 'Refresh',
+            onClick: () => {
+              refreshPrompted = false;
+              window.location.reload();
+            },
+          },
+        });
       };
 
       navigator.serviceWorker.addEventListener('controllerchange', handleControllerChange);


### PR DESCRIPTION
## Summary
Replaces the automatic `window.location.reload()` on Service Worker `controllerchange` with a non-intrusive toast banner.

## Changes
- `lib/OfflineContext.jsx`: the controller handler now shows `🔄 Update available — click to refresh` via react-hot-toast with an explicit Refresh action instead of forcing an unprompted reload. Unsaved in-progress logging/chat state is never discarded.

## Acceptance criteria
- [x] No automatic reload on SW update
- [x] User is offered a click-to-refresh banner

Closes #354