### PR TITLE
[ECSoC26] feat(offline): API timeout AbortController handlers with friendly fallback notification

### DIFF
--- a/lib/OfflineContext.jsx
+++ b/lib/OfflineContext.jsx
@@ -13,7 +13,7 @@ import {
   orderForDrain,
   planNextAttempt,
 } from './sync-queue'
-import fetchWithTimeout from './fetch-with-timeout'
+import fetchWithTimeout, { TimeoutError } from './fetch-with-timeout'
 import toast from 'react-hot-toast'
 
 const OfflineContext = createContext({
@@ -26,6 +26,23 @@ const OfflineContext = createContext({
   discardFailedSync: async () => { },
   offlineClient: {}
 })
+
+/**
+ * Logs a network fallback and, when the cause was an aborted request
+ * (AbortController 8s timeout), tells the user what happened instead of
+ * leaving them staring at a frozen loading state.
+ *
+ * @param {Error} err
+ * @param {string} label
+ */
+function logNetworkFallback(err, label) {
+  if (err instanceof TimeoutError) {
+    console.warn(`${label}: request timed out, falling back to offline data`, err);
+    toast.error('⚠️ The server took too long to respond. Showing your saved data.');
+    return;
+  }
+  console.warn(`${label}: fetch failed, falling back to offline data`, err);
+}
 
 /**
  * Resolves every record's `encrypted_data` into plain fields.
@@ -366,7 +383,7 @@ export function OfflineProvider({ children }) {
             };
           }
         } catch (e) {
-          console.warn('Fetch cycles failed, falling back to IndexedDB', e);
+          logNetworkFallback(e, 'Fetch cycles');
         }
       }
 
@@ -408,7 +425,7 @@ export function OfflineProvider({ children }) {
             return { success: true, data: null };
           }
         } catch (e) {
-          console.warn('Fetch today log failed, falling back to IndexedDB', e);
+          logNetworkFallback(e, 'Fetch today log');
         }
       }
 
@@ -434,7 +451,7 @@ export function OfflineProvider({ children }) {
             return data;
           }
         } catch (e) {
-          console.warn('Fetch all logs failed, falling back to IndexedDB', e);
+          logNetworkFallback(e, 'Fetch all logs');
         }
       }
 


### PR DESCRIPTION
## Summary
Ensures stalled backend requests abort after 8s (AbortController) and the user gets a friendly offline fallback notification instead of a frozen loading state.

## Changes
- `lib/OfflineContext.jsx`:
  - All fetches already use `fetchWithTimeout` (AbortController, 8 000 ms timeout).
  - New `logNetworkFallback` recognises `TimeoutError` and shows `⚠️ The server took too long to respond. Showing your saved data.` while falling back to IndexedDB.
  - Applied to fetchCycles, fetchTodayLog, fetchAllLogs fallback paths.

## Acceptance criteria
- [x] Network fetch requests abort automatically after 8 seconds
- [x] User receives a friendly offline fallback notification instead of a frozen loading state

Closes #381