### PR TITLE
[ECSoC26] fix(css): mobile alignment audit for small screens

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -3158,6 +3158,77 @@ nav ul li a:focus-visible,
     grid-template-columns: repeat(2, 1fr) !important;
     gap: 10px !important;
   }
+
+  /* #363: page-level alignment audit */
+  .page {
+    padding-left: 16px;
+    padding-right: 16px;
+  }
+
+  nav {
+    padding: 12px 16px;
+    margin-bottom: 20px;
+  }
+
+  .sec-head {
+    font-size: 1.6rem;
+    margin-bottom: 18px;
+  }
+
+  .hero-left h1 {
+    font-size: 2.4rem;
+  }
+
+  .hero-btns {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .hero-btns > * {
+    width: 100%;
+    text-align: center;
+  }
+
+  .feat-card {
+    padding: 20px 18px;
+  }
+}
+
+/* ──── COMPACT HANDSETS (≤479px) ──── */
+@media (max-width: 479px) {
+  .page {
+    padding: 18px 12px 40px;
+  }
+
+  nav {
+    padding: 10px 12px;
+  }
+
+  .hero-left h1 {
+    font-size: 2rem;
+  }
+
+  .hero-left p {
+    font-size: 0.9rem;
+    margin-bottom: 20px;
+  }
+
+  .sec-head {
+    font-size: 1.45rem;
+  }
+
+  .feat-card h4 {
+    font-size: 1rem;
+  }
+
+  .feat-card p {
+    font-size: 0.82rem;
+  }
+
+  .status-badge {
+    max-width: 100%;
+    flex-wrap: wrap;
+  }
 }
 
 /* ──── CHALLENGES ──── */


### PR DESCRIPTION
## Summary
Addresses the mobile alignment issues in #363 with a CSS-only audit.

## Changes
- `@media (max-width: 768px)`: reduced `.page`/`nav` horizontal padding, stacked `.hero-btns` full-width, scaled `.sec-head` and `.hero-left h1`, tightened `.feat-card` padding.
- New `@media (max-width: 479px)` block: compact padding, further font scaling, and `.status-badge` wrap protection so nothing overflows on small handsets.

No markup changes; purely CSS so all pages benefit.

Closes #363