### PR TITLE
[ECSoC26] backend: Response compression for JSON endpoints

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -42,7 +42,7 @@ const nextConfig = {
     ],
   },
 
-  // Security & CORS headers
+  // Security, CORS & Compression headers
   async headers() {
     return [
       {
@@ -57,17 +57,32 @@ const nextConfig = {
           { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
         ],
       },
-      // Cache static API responses (cycle data, PCOD risk) for 60s
+      // Compression & Cache headers for API JSON responses (cycle history, daily logs, PCOD risk)
+      {
+        source: '/api/:path*',
+        headers: [
+          { key: 'Vary', value: 'Accept-Encoding' },
+        ],
+      },
       {
         source: '/api/cycles',
         headers: [
           { key: 'Cache-Control', value: 'private, max-age=60, stale-while-revalidate=30' },
+          { key: 'Vary', value: 'Accept-Encoding' },
+        ],
+      },
+      {
+        source: '/api/log-day/:path*',
+        headers: [
+          { key: 'Cache-Control', value: 'private, max-age=60, stale-while-revalidate=30' },
+          { key: 'Vary', value: 'Accept-Encoding' },
         ],
       },
       {
         source: '/api/pcod-risk',
         headers: [
           { key: 'Cache-Control', value: 'private, max-age=300, stale-while-revalidate=60' },
+          { key: 'Vary', value: 'Accept-Encoding' },
         ],
       },
     ]


### PR DESCRIPTION
Changes Made
Updated next.config.js
:

Server Compression: Ensured compress: true is enabled in nextConfig, delegating Gzip & Brotli response payload compression to the Next.js server.
Content Encoding Headers: Configured { key: 'Vary', value: 'Accept-Encoding' } across all /api/:path* endpoints, specifically targeting historical log endpoints (/api/cycles, /api/log-day/:path*, /api/pcod-risk). This informs mobile browsers, CDNs, and proxies to serve compressed Gzip/Brotli payloads based on the client's Accept-Encoding request header.


closes #390