### PR TITLE
[ECSoC26] fix(accessibility): add missing aria-label to comment textarea input (#169)

### DIFF
--- a/components/community/CommentSection.jsx
+++ b/components/community/CommentSection.jsx
@@ -37,9 +37,7 @@ export default function CommentSection({ postId, initialComments = [] }) {
         },
         (payload) => {
           // If we receive a new comment via realtime, add it to the top of the list
-          // Ensure we don't duplicate if it's our own comment (though optimistic UI usually needs this check, we aren't doing optimistic insert here)
           setComments((current) => {
-            // Check if it already exists (if we added it on successful POST response)
             if (current.some(c => c.id === payload.new.id)) return current;
             return [payload.new, ...current];
           });
@@ -78,7 +76,6 @@ export default function CommentSection({ postId, initialComments = [] }) {
       }
 
       setNewComment('');
-      // It will also come through realtime, but we can add it immediately for faster feedback
       setComments((current) => {
         if (current.some(c => c.id === data.comment.id)) return current;
         return [data.comment, ...current];
@@ -168,6 +165,7 @@ export default function CommentSection({ postId, initialComments = [] }) {
           value={newComment}
           onChange={(e) => setNewComment(e.target.value)}
           placeholder={t('write_comment') || 'Share your thoughts anonymously...'}
+          aria-label={t('write_comment') || 'Write your comment anonymously'}
           className="w-full bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-4 pr-12 focus:outline-none focus:ring-2 focus:ring-pink-500/50 resize-none"
           rows={3}
           disabled={isSubmitting}


### PR DESCRIPTION
## Linked Issue
Fixes #169

## Description
This PR addresses an accessibility compliance issue where the community section comment `<textarea>` input lacked an accessible label or `aria-label` attribute.

### Key Changes:
- Added `aria-label={t('write_comment') || 'Write your comment anonymously'}` to the comment `<textarea>` element in `components/community/CommentSection.jsx`.
- Screen readers now properly announce the purpose of the textarea input even when placeholder text is present.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (clean code updates, no behavior modifications)
- [ ] Documentation update
- [ ] Performance optimization
- [ ] Security patch

## Testing
- Verified via screen reader / accessibility DOM inspection tools that the textarea element now exposes an accessible name.
- Ran `npm run build` locally to confirm no build issues.

## Screenshots (if UI changes are made)
N/A (Accessibility DOM attribute change only)

## Checklist

- [x] This PR is submitted under ECSOC.
- [x] Added the required **ECSoc26** label to this Pull Request.
- [x] Linked issue using `Fixes #169`.
- [x] Tested locally.
- [x] `npm run build` completes successfully.
- [x] GitHub Actions checks pass.
- [x] No breaking changes introduced.
- [ ] Documentation updated if required.

> ⚠️ **Important**
>
> PRs submitted for ECSOC **must include the `ECSoc26` label**.
> Pull Requests without this label **will not be processed by ECSOC Sentinel and will not receive a score.**