### PR TITLE
[ECSoC26] fix(accessibility): add missing aria-label to close button in PartnerSharingModal (#175)

### DIFF
--- a/components/layout/PartnerSharingModal.jsx
+++ b/components/layout/PartnerSharingModal.jsx
@@ -21,7 +21,10 @@ export default function PartnerSharingModal({ isOpen, setIsOpen }) {
                 Manage your partner pairing and privacy settings.
               </Dialog.Description>
               <Dialog.Close asChild>
-                <button className="text-white/70 hover:text-white transition-colors bg-white/10 hover:bg-white/20 p-2 rounded-full focus:outline-none focus:ring-2 focus:ring-white/50">
+                <button
+                  className="text-white/70 hover:text-white transition-colors bg-white/10 hover:bg-white/20 p-2 rounded-full focus:outline-none focus:ring-2 focus:ring-white/50"
+                  aria-label="Close"
+                >
                   <X className="w-5 h-5" />
                 </button>
               </Dialog.Close>


### PR DESCRIPTION
## Linked Issue
Fixes #175

## Description
This PR resolves an accessibility issue where the close button inside `PartnerSharingModal` contained an icon (`lucide-react` `<X>`) without a textual label or `aria-label` attribute.

### Key Changes:
- Added `aria-label="Close"` to the `<button>` element inside `<Dialog.Close asChild>` in `components/layout/PartnerSharingModal.jsx`.
- Screen readers will now announce "Close" when focusing on the modal dismiss button.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (clean code updates, no behavior modifications)
- [ ] Documentation update
- [ ] Performance optimization
- [ ] Security patch

## Testing
- Inspected the close button element using accessibility DevTools to verify that its accessible name is correctly exposed as `"Close"`.
- Verified build completed without warnings via `npm run build`.

## Screenshots (if UI changes are made)
N/A (Accessibility attribute addition only)

## Checklist

- [x] This PR is submitted under ECSOC.
- [x] Added the required **ECSoc26** label to this Pull Request.
- [x] Linked issue using `Fixes #175`.
- [x] Tested locally.
- [x] `npm run build` completes successfully.
- [x] GitHub Actions checks pass.
- [x] No breaking changes introduced.
- [ ] Documentation updated if required.

> ⚠️ **Important**
>
> PRs submitted for ECSOC **must include the `ECSoc26` label**.
> Pull Requests without this label **will not be processed by ECSOC Sentinel and will not receive a score.**