### PR TITLE
[ECSoC26] fix(accessibility): add keyboard event listener to custom action button (#176)

### DIFF
--- a/components/layout/PrivacySettingsModal.jsx
+++ b/components/layout/PrivacySettingsModal.jsx
@@ -83,7 +83,12 @@ export default function PrivacySettingsContent() {
     }
   }
 
-
+  const handleKeyDown = (e) => {
+    if ((e.key === 'Enter' || e.key === ' ') && !isExporting) {
+      e.preventDefault()
+      handleExportData()
+    }
+  }
 
   return (
     <div className="p-4 sm:p-8 flex flex-col h-full animate-in fade-in duration-300 mt-2 max-w-2xl mx-auto w-full space-y-6">
@@ -127,6 +132,7 @@ export default function PrivacySettingsContent() {
         </div>
         <button
           onClick={!isExporting ? handleExportData : undefined}
+          onKeyDown={handleKeyDown}
           disabled={isExporting}
           className={`shrink-0 flex items-center justify-center gap-2 bg-white/10 hover:bg-white/20 text-white px-5 py-2.5 rounded-xl transition-all font-medium border border-white/10 ${isExporting ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer active:scale-95'}`}
         >


### PR DESCRIPTION
## Linked Issue
Fixes #176

## Description
This PR resolves an accessibility issue in `PrivacySettingsModal.jsx` by ensuring that interactive data export triggers handle keyboard events (`Enter` and `Space` keys) in addition to click events.

### Key Changes:
- Added `handleKeyDown` event handler to intercept `Enter` and `Space` key presses.
- Attached `onKeyDown={handleKeyDown}` to the data export interactive element.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (clean code updates, no behavior modifications)
- [ ] Documentation update
- [ ] Performance optimization
- [ ] Security patch

## Testing
- Tested triggering the data export via keyboard (`Tab` focus + `Enter` / `Space`).
- Confirmed `npm run build` succeeds locally.

## Screenshots (if UI changes are made)
N/A (Accessibility event handling change only)

## Checklist

- [x] This PR is submitted under ECSOC.
- [x] Added the required **ECSoc26** label to this Pull Request.
- [x] Linked issue using `Fixes #176`.
- [x] Tested locally.
- [x] `npm run build` completes successfully.
- [x] GitHub Actions checks pass.
- [x] No breaking changes introduced.
- [ ] Documentation updated if required.

> ⚠️ **Important**
>
> PRs submitted for ECSOC **must include the `ECSoc26` label**.
> Pull Requests without this label **will not be processed by ECSOC Sentinel and will not receive a score.**