### PR TITLE
[ECSoC26] backend: fallback static data

### DIFF
--- a/app/api/forum/categories/route.js
+++ b/app/api/forum/categories/route.js
@@ -1,10 +1,43 @@
 import { NextResponse } from 'next/server'
 import { getSupabaseAdmin } from '@/lib/supabase-admin'
+import { logger } from '@/lib/logger'
+
+const DEFAULT_CATEGORIES = [
+  {
+    id: 'cat-pcod-advice',
+    name: 'PCOD Advice',
+    slug: 'pcod-advice',
+    description: 'Share tips and ask questions about managing PCOD.',
+    created_at: '2026-01-01T00:00:00.000Z'
+  },
+  {
+    id: 'cat-cycle-tracking',
+    name: 'Cycle Tracking',
+    slug: 'cycle-tracking',
+    description: 'Discuss period tracking, ovulation, and cycle irregularities.',
+    created_at: '2026-01-01T00:00:00.000Z'
+  },
+  {
+    id: 'cat-mental-health',
+    name: 'Mental Health',
+    slug: 'mental-health',
+    description: 'A safe space to talk about emotional well-being and stress.',
+    created_at: '2026-01-01T00:00:00.000Z'
+  },
+  {
+    id: 'cat-general-discussion',
+    name: 'General Discussion',
+    slug: 'general-discussion',
+    description: "Talk about anything else related to women's health.",
+    created_at: '2026-01-01T00:00:00.000Z'
+  }
+]
 
 /**
  * GET /api/forum/categories
  * Returns all forum categories using the admin client (bypasses RLS).
  * Categories are fully public data — no auth required.
+ * Falls back gracefully to static default categories on database connectivity failure.
  */
 export async function GET() {
   try {
@@ -15,13 +48,17 @@ export async function GET() {
       .order('name')
 
     if (error) {
-      console.error('Error fetching forum categories:', error.message)
-      return NextResponse.json({ success: false, error: error.message }, { status: 500 })
+      logger.warn(`Database error fetching forum categories, serving fallback categories: ${error.message}`)
+      return NextResponse.json({ success: true, data: DEFAULT_CATEGORIES, fallback: true })
     }
 
-    return NextResponse.json({ success: true, data: data || [] })
+    if (!data || data.length === 0) {
+      return NextResponse.json({ success: true, data: DEFAULT_CATEGORIES, fallback: true })
+    }
+
+    return NextResponse.json({ success: true, data })
   } catch (err) {
-    console.error('Forum categories route error:', err)
-    return NextResponse.json({ success: false, error: 'Internal server error' }, { status: 500 })
+    logger.error(`Forum categories route error, serving fallback categories: ${err.message || err}`, err.stack)
+    return NextResponse.json({ success: true, data: DEFAULT_CATEGORIES, fallback: true })
   }
 }


### PR DESCRIPTION
Changes Made
Updated app/api/forum/categories/route.js
:

Fallback Static Dataset: Defined DEFAULT_CATEGORIES representing default forum categories (PCOD Advice, Cycle Tracking, Mental Health, General Discussion).
Graceful Error Recovery: Updated the GET handler to catch database query errors (error) as well as unhandled exceptions (catch (err)).
Zero-Downtime Response: If Supabase or the database connection is unreachable or returns an error, the endpoint logs a structured warning and returns HTTP 200 with { success: true, data: DEFAULT_CATEGORIES, fallback: true }, ensuring the forum categories page renders seamlessly without crashing or displaying a blank screen.


closes #395