### PR TITLE
[ECSoC26] fix: format exported dates as YYYY-MM-DD for CSV compatibility

### DIFF
--- a/app/api/export-data/route.js
+++ b/app/api/export-data/route.js
@@ -77,20 +77,38 @@ export async function GET(request) {
           return [header, ...rows].join('\n')
         }
 
+        // Normalize date-like columns to YYYY-MM-DD so spreadsheets render them cleanly.
+        const formatCsvDateFields = (row) => {
+          const formattedRow = { ...row }
+
+          Object.entries(formattedRow).forEach(([key, value]) => {
+            if (value === null || value === undefined || value === '') return
+            if (typeof value === 'object' && !(value instanceof Date)) return
+
+            const normalizedKey = key.toLowerCase()
+            const isDateColumn =
+              normalizedKey === 'date' ||
+              normalizedKey.endsWith('_date') ||
+              normalizedKey.endsWith('_at') ||
+              normalizedKey.endsWith('at') ||
+              normalizedKey.endsWith('_timestamp') ||
+              normalizedKey.endsWith('timestamp')
+
+            if (isDateColumn) {
+              formattedRow[key] = formatDateForCSV(value)
+            }
+          })
+
+          return formattedRow
+        }
+
         // Append JSON files
         archive.append(JSON.stringify(cycles, null, 2), { name: 'cycles.json' })
         archive.append(JSON.stringify(dailyLogs, null, 2), { name: 'daily_logs.json' })
 
         // Format date fields before CSV generation (keep JSON exports as full ISO values)
-        const cyclesForCsv = cycles.map(c => ({
-          ...c,
-          start_date: formatDateForCSV(c.start_date),
-          end_date: formatDateForCSV(c.end_date),
-        }))
-        const dailyLogsForCsv = dailyLogs.map(l => ({
-          ...l,
-          date: formatDateForCSV(l.date),
-        }))
+        const cyclesForCsv = cycles.map(formatCsvDateFields)
+        const dailyLogsForCsv = dailyLogs.map(formatCsvDateFields)
 
         // Append CSV files
         archive.append(generateCsv(cyclesForCsv), { name: 'cycles.csv' })


### PR DESCRIPTION
## Linked Issue
Fixes #388

## Description
Fix CSV export date formatting in `app/api/export-data/route.js`.

This change normalizes all exported date-like CSV fields to `YYYY-MM-DD` before CSV generation. It prevents raw ISO timestamp strings from causing Excel column layout overflow and parsing issues in Excel, Google Sheets, and Apple Numbers.


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (clean code updates, no behavior modifications)
- [ ] Documentation update
- [ ] Performance optimization
- [ ] Security patch

## Testing
Describe the tests you ran to verify your changes. Include commands and details about your local setup.

node --version && node --input-type=module -e "import { formatDateForCSV } from './lib/utils.js'; console.log(formatDateForCSV('2026-07-21')); console.log(formatDateForCSV('2026-07-21T18:00:00+05:30'));"

- Verified `formatDateForCSV('2026-07-21')` returns `2026-07-21`
- Verified `formatDateForCSV('2026-07-21T18:00:00+05:30')` returns `2026-07-21`
- Confirmed `app/api/export-data/route.js` now normalizes date-like CSV columns via `formatCsvDateFields()`


## Screenshots (if UI changes are made)
Add screenshots or screen recordings demonstrating the visual changes before and after.

## Checklist

- [ x] This PR is submitted under ECSOC.
- [x ] Added the required **ECSoc26** label to this Pull Request.
- [x ] Linked issue using `Fixes #<issue_number>`.
- [x ] Tested locally.
- [x ] `npm run build` completes successfully.
- [x ] GitHub Actions checks pass.
- [ x] No breaking changes introduced.
- [ ] Documentation updated if required.

> ⚠️ **Important**
>
> PRs submitted for ECSOC **must include the `ECSoc26` label**.
> Pull Requests without this label **will not be processed by ECSOC Sentinel and will not receive a score.**
