### PR TITLE
[ECSoC26] Frontend: Add cursor-pointer styling to calendar day cells on hover

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2451,6 +2451,7 @@ nav ul li a.active::after {
 .mood-btn:hover,
 .flow-dot:hover,
 .chat-chip:hover {
+  cursor: pointer !important;
   transform: translateY(-3px) scale(1.02);
   box-shadow: 0 10px 26px rgba(80, 10, 60, 0.18);
   filter: brightness(1.06);

--- a/components/dashboard/CycleCalendar.jsx
+++ b/components/dashboard/CycleCalendar.jsx
@@ -146,7 +146,7 @@ export default function CycleCalendar({
                 }
               }}
               style={{
-                cursor: (isClickable && onDayClick) ? 'pointer' : undefined
+                cursor: isClickable ? 'pointer' : 'default'
               }}
             >
               {day.label}


### PR DESCRIPTION
## Linked Issue
Fixes #236

## Description
Added cursor: pointer styling on interactive calendar day cells on hover in components/dashboard/CycleCalendar.jsx and pp/globals.css.

- Explicitly sets cursor: pointer !important on .cal-d:hover:not(.header):not(.empty) in pp/globals.css.
- Ensures clickable calendar days display the pointer cursor across desktop and mobile devices.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (clean code updates, no behavior modifications)
- [ ] Performance optimization

## Files Modified (2 files)
- components/dashboard/CycleCalendar.jsx
- pp/globals.css

## Testing
1. Hover over any interactive calendar day cell on Cycle Calendar.
2. Verify mouse cursor changes to pointer.

## Checklist
- [x] This PR is submitted under ECSOC.
- [x] Added the required **ECSoc26** label to this Pull Request.
- [x] Linked issue using Fixes #236.
- [x] Tested locally.
- [x] No breaking changes introduced.