### PR TITLE
[ECSoC26] fix(security): stop the rate limiter failing open on random anon buckets and DB errors (Fixes #472)

### DIFF
--- a/lib/rate-limiter.js
+++ b/lib/rate-limiter.js
@@ -1,52 +1,198 @@
 /**
- * HerCycle AI — Lightweight In-Memory Rate Limiter
- * 
- * ⚠️ WARNING:
- * This limiter is NOT suitable for distributed/serverless production deployments (like Vercel serverless).
- * The memory state is isolated to each serverless container and is lost when the container recycles.
- * Replace with Redis/Upstash if scaling to multiple instances or serverless.
+ * rate-limiter.js — the in-process fixed-window counter and the request
+ * identity helpers shared by lib/rateLimiter.js.
+ *
+ * ## Why this module exists
+ *
+ * `lib/rateLimiter.js` enforces limits in Postgres via the `enforce_rate_limit`
+ * RPC, which is the only correct place for them once the app runs on more than
+ * one instance. But a limiter that depends on the database has to answer one
+ * question the database cannot: *what happens when the database is down?*
+ *
+ * The answer must not be "allow everything", because a database under load is
+ * exactly the moment rate limiting matters most, and the AI endpoints spend
+ * money per call. So this module provides a degraded-mode counter that lives in
+ * the process. It is deliberately conservative:
+ *
+ *   - per-container state, so a serverless fleet of N containers enforces at
+ *     most N x the configured limit rather than no limit at all
+ *   - lost on recycle, which is acceptable for a fallback that only runs during
+ *     an outage
+ *
+ * ⚠️ It is NOT a replacement for the database limiter in normal operation.
+ *
+ * Nothing here imports from `next/*` or from Clerk, so the module is usable
+ * from Route Handlers, Middleware and plain Node scripts alike.
  */
 
-const rateLimits = new Map();
+import { createHash } from 'node:crypto'
 
-// Periodic cleanup of stale rate limit windows to prevent memory leaks (every 5 minutes)
-if (typeof global !== 'undefined') {
-  if (!global.rateLimitCleanupInterval) {
-    global.rateLimitCleanupInterval = setInterval(() => {
-      const now = Date.now();
-      for (const [key, window] of rateLimits.entries()) {
-        // Remove windows older than 1 minute
-        if (now - window.timestamp > 60000) {
-          rateLimits.delete(key);
-        }
+/** Default window length, matching the `interval` the exported limiters use. */
+export const DEFAULT_INTERVAL_MS = 60 * 1000
+
+/** Windows older than this are dropped by the sweeper. */
+const STALE_AFTER_MS = 5 * 60 * 1000
+
+/** How often the sweeper runs. */
+const CLEANUP_INTERVAL_MS = 5 * 60 * 1000
+
+/** cacheKey -> { windowStart: number, requests: number } */
+const rateLimits = new Map()
+
+// Periodic cleanup of expired windows so a long-lived container does not
+// accumulate one Map entry per identifier seen since boot.
+//
+// `unref()` matters: without it this timer keeps the Node event loop alive, so
+// any script that imports this module hangs instead of exiting.
+if (typeof globalThis !== 'undefined' && !globalThis.__hercycleRateLimitSweeper) {
+  const sweeper = setInterval(() => {
+    const now = Date.now()
+    for (const [key, window] of rateLimits.entries()) {
+      if (now - window.windowStart > STALE_AFTER_MS) {
+        rateLimits.delete(key)
       }
-    }, 300000); // 5 minutes
+    }
+  }, CLEANUP_INTERVAL_MS)
+
+  if (typeof sweeper.unref === 'function') sweeper.unref()
+  globalThis.__hercycleRateLimitSweeper = sweeper
+}
+
+/**
+ * Records one request against `key` and reports whether it is within `limit`.
+ *
+ * Fixed window: the first request starts a window of `intervalMs`, and the
+ * counter resets on the first request after the window closes.
+ *
+ * @param {string} key identifier for the caller, already namespaced by route
+ * @param {{ limit: number, intervalMs?: number, now?: number }} options
+ * @returns {{ allowed: boolean, count: number, remaining: number, resetAt: number }}
+ */
+export function consume(key, { limit, intervalMs = DEFAULT_INTERVAL_MS, now = Date.now() } = {}) {
+  // A missing, zero or negative limit is a misconfiguration. Rejecting is the
+  // safe reading of it: this is a security control, and a control that treats
+  // "I don't know the limit" as "no limit" is the bug this module was written
+  // to remove.
+  const safeLimit = Number.isFinite(limit) && limit > 0 ? Math.floor(limit) : 0
+  const safeInterval = Number.isFinite(intervalMs) && intervalMs > 0 ? intervalMs : DEFAULT_INTERVAL_MS
+
+  let window = rateLimits.get(key)
+
+  if (!window || now - window.windowStart >= safeInterval) {
+    window = { windowStart: now, requests: 0 }
+  }
+
+  window.requests += 1
+  rateLimits.set(key, window)
+
+  return {
+    allowed: window.requests <= safeLimit,
+    count: window.requests,
+    remaining: Math.max(0, safeLimit - window.requests),
+    resetAt: window.windowStart + safeInterval,
   }
 }
 
 /**
- * Checks if a request exceeds the configured limit.
- * @param {string} key Unique identifier for the client (e.g., Clerk user ID)
- * @param {string} route The identifier for the rate limit configuration (e.g., 'chat', 'prediction')
- * @param {number} limit Maximum requests allowed in the 1-minute window
- * @returns {boolean} True if allowed, false if rate limited
+ * Backwards-compatible wrapper over {@link consume}.
+ *
+ * @param {string} key
+ * @param {string} route
+ * @param {number} limit
+ * @returns {boolean} true when the request is within the limit
  */
 export function isAllowed(key, route, limit) {
-  const now = Date.now();
-  const cacheKey = `${key}:${route}`;
-  
-  let userWindow = rateLimits.get(cacheKey);
-  
-  if (!userWindow || now - userWindow.timestamp > 60000) {
-    // New window or window expired
-    userWindow = {
-      timestamp: now,
-      requests: 0
-    };
+  return consume(`${key}:${route}`, { limit }).allowed
+}
+
+/**
+ * Drops all in-memory windows. Exported for tests; not used at runtime.
+ */
+export function resetInMemoryRateLimits() {
+  rateLimits.clear()
+}
+
+/**
+ * Robust client IP extraction across proxy stacks.
+ *
+ * Order of preference matches how reverse proxies forward the real client:
+ *  1. `x-forwarded-for` — standard chain; the left-most entry is the client.
+ *  2. `x-real-ip`      — nginx/Vercel commonly set this directly.
+ *  3. `cf-connecting-ip` — Cloudflare's direct client header.
+ *
+ * Returns `null` when no usable address is present so callers can decide how
+ * to handle the unidentifiable case (see buildAnonymousIdentifier).
+ *
+ * @param {Request} request
+ * @returns {string|null}
+ */
+export function extractClientIp(request) {
+  if (!request?.headers) return null
+
+  const forwarded = request.headers.get('x-forwarded-for')
+  if (forwarded) {
+    const first = forwarded.split(',')[0].trim()
+    if (first && first !== 'unknown') return first
   }
-  
-  userWindow.requests += 1;
-  rateLimits.set(cacheKey, userWindow);
-  
-  return userWindow.requests <= limit;
+
+  const realIp = request.headers.get('x-real-ip')
+  if (realIp && realIp.trim() && realIp.trim() !== 'unknown') return realIp.trim()
+
+  const cfIp = request.headers.get('cf-connecting-ip')
+  if (cfIp && cfIp.trim()) return cfIp.trim()
+
+  return null
+}
+
+/**
+ * Headers used to build a coarse identity for a caller we cannot attribute to a
+ * user or an IP. They are chosen because they are stable for a given client
+ * across requests — which is the only property that matters here.
+ */
+const FINGERPRINT_HEADERS = [
+  'user-agent',
+  'accept-language',
+  'sec-ch-ua',
+  'sec-ch-ua-platform',
+]
+
+/**
+ * The bucket every caller falls into when nothing at all can be derived from
+ * the request. Shared on purpose: one strict bucket is the safe failure mode,
+ * because the alternative — a bucket per request — is no limit at all.
+ */
+export const UNATTRIBUTED_IDENTIFIER = 'anon:unattributed'
+
+/**
+ * Builds a **stable** identifier for a request with no resolvable user and no
+ * resolvable IP.
+ *
+ * This replaces `anon:${Math.random()...}`, which produced a fresh identifier on
+ * every call — so the limiter looked up a bucket it had never seen, found a
+ * count of 1, and allowed the request. No value of `limit` could ever be
+ * exceeded on that path, which made the limiter a no-op for every caller that
+ * did not present a forwarding header (self-hosted and Docker deployments,
+ * local and preview environments, and any client that simply omits them).
+ *
+ * The fingerprint is coarse and easy to vary deliberately. That is fine: it is
+ * a fallback for a request that already told us nothing, and varying it is no
+ * cheaper than rotating an IP. What matters is that a client that does *not*
+ * try to evade is counted consistently instead of being waved through.
+ *
+ * @param {Request} request
+ * @returns {string}
+ */
+export function buildAnonymousIdentifier(request) {
+  if (!request?.headers) return UNATTRIBUTED_IDENTIFIER
+
+  const parts = []
+  for (const header of FINGERPRINT_HEADERS) {
+    const value = request.headers.get(header)
+    if (value && value.trim()) parts.push(`${header}=${value.trim()}`)
+  }
+
+  if (parts.length === 0) return UNATTRIBUTED_IDENTIFIER
+
+  const digest = createHash('sha256').update(parts.join('|')).digest('hex')
+  return `anon:${digest.slice(0, 24)}`
 }

--- a/lib/rateLimiter.js
+++ b/lib/rateLimiter.js
@@ -1,5 +1,10 @@
 import { getAuthUserId } from './clerk-server';
 import { getSupabaseAdmin } from '@/lib/supabase-admin';
+import {
+  buildAnonymousIdentifier,
+  consume,
+  extractClientIp,
+} from '@/lib/rate-limiter';
 import { AsyncLocalStorage } from 'node:async_hooks';
 import { NextResponse } from 'next/server';
 
@@ -20,16 +25,27 @@ if (NextResponse.json) {
   };
 }
 
-function createLimiter({ interval, maxRequests }) {
+/**
+ * Creates a limiter backed by the `enforce_rate_limit` Postgres RPC.
+ *
+ * When that backend is unavailable the limiter degrades to the in-process
+ * counter in `lib/rate-limiter.js` rather than allowing the request. See
+ * {@link enforceLimit} for why.
+ *
+ * @param {{ interval: number, maxRequests: number, name?: string, getClient?: () => object }} config
+ * @param {() => object} [config.getClient] injection seam for tests; defaults to
+ *   the shared Supabase admin client
+ */
+export function createLimiter({ interval, maxRequests, name = 'default', getClient = getSupabaseAdmin }) {
   return {
     async check(customLimitOrRequest, identifier) {
       let limit = maxRequests;
-      let targetId = 'unknown';
+      let targetId = null;
 
       if (typeof customLimitOrRequest === 'number') {
         // Modern usage: check(limit, identifier)
         limit = customLimitOrRequest;
-        targetId = identifier || 'unknown';
+        targetId = identifier || null;
       } else if (customLimitOrRequest && typeof customLimitOrRequest.headers === 'object') {
         // Legacy/standard usage: check(request)
         targetId = await getRateLimitIdentifier(customLimitOrRequest);
@@ -37,90 +53,122 @@ function createLimiter({ interval, maxRequests }) {
         targetId = customLimitOrRequest;
       }
 
-      let count = 1;
-      let resetAt = null;
-      let allowed = true;
-      let dbError = false;
+      // A caller that could not be identified at all still has to land in a
+      // real bucket. `unknown` is a stable string, so it behaves as one shared
+      // strict bucket rather than as an exemption.
+      if (!targetId) targetId = 'unknown';
 
-      try {
-        const supabase = getSupabaseAdmin();
-        const { data, error } = await supabase.rpc('enforce_rate_limit', {
-          p_identifier: targetId,
-          p_limit: limit,
-          p_interval: interval
-        });
+      const decision = await enforceLimit({ getClient, targetId, limit, interval, name });
 
-        if (error) {
-          console.error('Rate Limiter DB Error:', error.message || error);
-          dbError = true;
-        } else if (data) {
-          allowed = data.allowed;
-          count = data.count || 1;
-          resetAt = data.reset_at;
-        }
-      } catch (err) {
-        console.error('Rate Limiter unexpected error:', err.message || err);
-        dbError = true;
-      }
-
-      // Compute headers
-      const remaining = dbError ? limit : Math.max(0, limit - count);
-      const reset = resetAt 
-        ? Math.ceil(new Date(resetAt).getTime() / 1000)
-        : Math.ceil((Date.now() + interval) / 1000);
+      const reset = Math.ceil(decision.resetAt / 1000);
+      const retryAfterSeconds = Math.max(1, Math.ceil((decision.resetAt - Date.now()) / 1000));
 
       const rateLimitHeaders = {
         'X-RateLimit-Limit': String(limit),
-        'X-RateLimit-Remaining': String(remaining),
+        'X-RateLimit-Remaining': String(decision.remaining),
         'X-RateLimit-Reset': String(reset)
       };
+
+      // Only advertise Retry-After when the caller actually has to wait, so a
+      // successful response is not decorated with a misleading hint.
+      if (!decision.allowed) {
+        rateLimitHeaders['Retry-After'] = String(retryAfterSeconds);
+      }
 
       // Transition context
       rateLimitStorage.enterWith(rateLimitHeaders);
 
-      if (!allowed) {
+      if (!decision.allowed) {
         throw new Error('Rate limit exceeded');
       }
     }
   };
 }
 
-export const aiLimiter = createLimiter({ interval: 60 * 1000, maxRequests: 5 });
-export const crudLimiter = createLimiter({ interval: 60 * 1000, maxRequests: 30 });
-export const devLimiter = createLimiter({ interval: 60 * 1000, maxRequests: 10 });
-
 /**
- * Robust client IP extraction across proxy stacks.
+ * Resolves one allow/deny decision.
  *
- * Order of preference matches how reverse proxies forward the real client:
- *  1. `x-forwarded-for` — standard chain; the left-most entry is the client.
- *  2. `x-real-ip`      — nginx/Vercel commonly set this directly.
- *  3. `cf-connecting-ip` — Cloudflare's direct client header.
+ * The database is authoritative when it answers. When it does not — an RPC
+ * error, a thrown client error, or a success with no payload (which is what a
+ * missing `enforce_rate_limit` function looks like on a fresh install) — the
+ * decision falls through to the in-process counter.
  *
- * Returns `null` when no usable address is present so callers can decide how
- * to handle the unidentifiable case (see getRateLimitIdentifier).
+ * The previous implementation initialised `allowed = true` and only ever
+ * assigned it from a successful RPC, so every one of those failure paths
+ * allowed the request. That turned a database incident into a total loss of
+ * rate limiting across the app, including on the AI endpoints that spend money
+ * per call.
  *
- * @param {Request} request
- * @returns {string|null}
+ * @param {{ getClient: () => object, targetId: string, limit: number, interval: number, name: string }} params
+ * @returns {Promise<{ allowed: boolean, remaining: number, resetAt: number, degraded: boolean }>}
  */
-export function extractClientIp(request) {
-  if (!request?.headers) return null;
+async function enforceLimit({ getClient, targetId, limit, interval, name }) {
+  try {
+    const supabase = getClient();
+    const { data, error } = await supabase.rpc('enforce_rate_limit', {
+      p_identifier: targetId,
+      p_limit: limit,
+      p_interval: interval
+    });
 
-  const forwarded = request.headers.get('x-forwarded-for');
-  if (forwarded) {
-    const first = forwarded.split(',')[0].trim();
-    if (first && first !== 'unknown') return first;
+    if (error) {
+      console.error('Rate Limiter DB Error:', error.message || error);
+    } else if (data && typeof data.allowed === 'boolean') {
+      const count = data.count || 1;
+      const resetAt = data.reset_at
+        ? new Date(data.reset_at).getTime()
+        : Date.now() + interval;
+
+      return {
+        allowed: data.allowed,
+        remaining: Math.max(0, limit - count),
+        resetAt: Number.isFinite(resetAt) ? resetAt : Date.now() + interval,
+        degraded: false
+      };
+    } else {
+      console.error('Rate Limiter DB Error: enforce_rate_limit returned no decision');
+    }
+  } catch (err) {
+    console.error('Rate Limiter unexpected error:', err.message || err);
   }
 
-  const realIp = request.headers.get('x-real-ip');
-  if (realIp && realIp.trim() && realIp.trim() !== 'unknown') return realIp.trim();
+  // Degraded mode. Per-container state means a fleet of N containers enforces
+  // at most N x `limit`, which is a far smaller hole than the unlimited one it
+  // replaces.
+  console.warn(`[Rate Limit] Falling back to the in-memory limiter for "${name}".`);
+  const local = consume(`${name}:${targetId}`, { limit, intervalMs: interval });
 
-  const cfIp = request.headers.get('cf-connecting-ip');
-  if (cfIp && cfIp.trim()) return cfIp.trim();
-
-  return null;
+  return {
+    allowed: local.allowed,
+    remaining: local.remaining,
+    resetAt: local.resetAt,
+    degraded: true
+  };
 }
 
+export const aiLimiter = createLimiter({ interval: 60 * 1000, maxRequests: 5, name: 'ai' });
+export const crudLimiter = createLimiter({ interval: 60 * 1000, maxRequests: 30, name: 'crud' });
+export const devLimiter = createLimiter({ interval: 60 * 1000, maxRequests: 10, name: 'dev' });
+
+// Re-exported so existing importers of `@/lib/rateLimiter` keep working; the
+// implementation now lives in the framework-free `@/lib/rate-limiter`.
+export { extractClientIp, buildAnonymousIdentifier };
+
+/**
+ * Resolves the bucket a request should be counted against, most specific first:
+ *
+ *  1. the authenticated Clerk user,
+ *  2. the client IP as reported by the proxy stack,
+ *  3. a stable fingerprint derived from the request's own headers.
+ *
+ * Step 3 used to be `anon:${Math.random()...}`, which handed every
+ * unattributable request a private bucket and therefore exempted it from the
+ * limit entirely. See `buildAnonymousIdentifier` for why a coarse shared bucket
+ * is the right failure mode here.
+ *
+ * @param {Request} request
+ * @returns {Promise<string>}
+ */
 export async function getRateLimitIdentifier(request) {
   try {
     const userId = await getAuthUserId();
@@ -130,8 +178,8 @@ export async function getRateLimitIdentifier(request) {
   }
 
   const ip = extractClientIp(request);
-  if (!ip) return `anon:${Math.random().toString(36).slice(2, 12)}`;
+  if (ip) return `ip:${ip}`;
 
-  return `ip:${ip}`;
+  return buildAnonymousIdentifier(request);
 }
 

--- a/lib/supabase-admin.js
+++ b/lib/supabase-admin.js
@@ -66,6 +66,26 @@ export function getSupabaseAdmin() {
         }
         return makeMockQuery([], null);
       },
+      // The mock client has to answer `rpc` too. Without it every
+      // `supabase.rpc(...)` call in mock mode threw a TypeError that the
+      // callers swallowed, which meant mock runs exercised the rate limiter's
+      // degraded path rather than its real one.
+      rpc: (name) => {
+        if (name === 'handle_vote') {
+          return Promise.resolve({ data: { action: 'added', current_vote: 1 }, error: null });
+        }
+        if (name === 'enforce_rate_limit') {
+          return Promise.resolve({
+            data: {
+              allowed: true,
+              count: 1,
+              reset_at: new Date(Date.now() + 60000).toISOString()
+            },
+            error: null
+          });
+        }
+        return Promise.resolve({ data: null, error: null });
+      },
     };
   }
 

--- a/scripts/test-rate-limiter.js
+++ b/scripts/test-rate-limiter.js
@@ -1,0 +1,198 @@
+/**
+ * Regression suite for lib/rate-limiter.js — the request-identity helpers and
+ * the in-process counter that lib/rateLimiter.js degrades to.
+ *
+ * Guards the fix for the two fail-open paths in the limiter:
+ *
+ *   1. `getRateLimitIdentifier` returned `anon:${Math.random()...}` when no
+ *      client IP could be resolved, so every unattributable request got a
+ *      private bucket and no limit could ever be exceeded.
+ *   2. `createLimiter().check()` initialised `allowed = true` and only ever
+ *      assigned it from a successful RPC, so an RPC error, a thrown client
+ *      error, or a missing `enforce_rate_limit` function allowed the request.
+ *
+ *   node scripts/test-rate-limiter.js
+ */
+
+import {
+  DEFAULT_INTERVAL_MS,
+  UNATTRIBUTED_IDENTIFIER,
+  buildAnonymousIdentifier,
+  consume,
+  extractClientIp,
+  isAllowed,
+  resetInMemoryRateLimits,
+} from '../lib/rate-limiter.js'
+
+let passed = 0
+let failed = 0
+
+function check(actual, expected, label) {
+  if (Object.is(actual, expected)) {
+    passed += 1
+    return
+  }
+  failed += 1
+  console.error(`  ❌ ${label}`)
+  console.error(`       expected: ${JSON.stringify(expected)}`)
+  console.error(`       actual:   ${JSON.stringify(actual)}`)
+}
+
+function checkTrue(actual, label) {
+  check(actual, true, label)
+}
+
+function section(title) {
+  console.log(`\n— ${title}`)
+}
+
+/** Minimal stand-in for a Request, with only the surface the limiter touches. */
+function fakeRequest(headers = {}) {
+  const normalised = new Map(
+    Object.entries(headers).map(([key, value]) => [key.toLowerCase(), value])
+  )
+  return {
+    headers: {
+      get: (key) => (normalised.has(key.toLowerCase()) ? normalised.get(key.toLowerCase()) : null),
+    },
+  }
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+section('client IP extraction')
+
+check(
+  extractClientIp(fakeRequest({ 'x-forwarded-for': '203.0.113.7, 70.41.3.18' })),
+  '203.0.113.7',
+  'the left-most x-forwarded-for entry is the client'
+)
+check(
+  extractClientIp(fakeRequest({ 'x-forwarded-for': ' 203.0.113.7 ' })),
+  '203.0.113.7',
+  'x-forwarded-for is trimmed'
+)
+check(
+  extractClientIp(fakeRequest({ 'x-forwarded-for': 'unknown', 'x-real-ip': '198.51.100.4' })),
+  '198.51.100.4',
+  'a literal "unknown" falls through to x-real-ip'
+)
+check(
+  extractClientIp(fakeRequest({ 'cf-connecting-ip': '192.0.2.9' })),
+  '192.0.2.9',
+  'Cloudflare header is honoured'
+)
+check(extractClientIp(fakeRequest({})), null, 'no forwarding headers yields null')
+check(extractClientIp(null), null, 'a missing request yields null')
+
+// ───────────────────────────────────────────────────────────────────────────
+section('anonymous identifiers are stable, not random')
+
+const browserHeaders = {
+  'user-agent': 'Mozilla/5.0 (Linux; Android 14) Chrome/126',
+  'accept-language': 'en-IN,en;q=0.9',
+}
+
+const first = buildAnonymousIdentifier(fakeRequest(browserHeaders))
+const second = buildAnonymousIdentifier(fakeRequest(browserHeaders))
+
+check(first, second, 'the same request shape yields the same identifier')
+checkTrue(first.startsWith('anon:'), 'the identifier is namespaced')
+checkTrue(first.length > 'anon:'.length, 'the identifier carries a digest')
+
+const otherClient = buildAnonymousIdentifier(
+  fakeRequest({ ...browserHeaders, 'user-agent': 'Mozilla/5.0 (Macintosh) Safari/17' })
+)
+checkTrue(first !== otherClient, 'a different client yields a different identifier')
+
+check(
+  buildAnonymousIdentifier(fakeRequest({})),
+  UNATTRIBUTED_IDENTIFIER,
+  'a request with nothing to fingerprint falls into the shared strict bucket'
+)
+check(
+  buildAnonymousIdentifier(null),
+  UNATTRIBUTED_IDENTIFIER,
+  'a missing request falls into the shared strict bucket'
+)
+
+// The regression this whole module exists for: a header-less client used to be
+// waved through indefinitely because each request minted a fresh bucket.
+resetInMemoryRateLimits()
+const headerless = fakeRequest({})
+let allowedCount = 0
+for (let i = 0; i < 20; i += 1) {
+  if (consume(buildAnonymousIdentifier(headerless), { limit: 5 }).allowed) allowedCount += 1
+}
+check(allowedCount, 5, 'a header-less caller is limited to 5 of 20 requests, not all 20')
+
+// ───────────────────────────────────────────────────────────────────────────
+section('fixed-window counting')
+
+resetInMemoryRateLimits()
+
+const now = 1_800_000_000_000
+
+check(consume('user:a', { limit: 3, now }).allowed, true, 'request 1 of 3 allowed')
+check(consume('user:a', { limit: 3, now: now + 10 }).allowed, true, 'request 2 of 3 allowed')
+check(consume('user:a', { limit: 3, now: now + 20 }).allowed, true, 'request 3 of 3 allowed')
+check(consume('user:a', { limit: 3, now: now + 30 }).allowed, false, 'request 4 is rejected')
+
+const overLimit = consume('user:a', { limit: 3, now: now + 40 })
+check(overLimit.remaining, 0, 'remaining is clamped at zero')
+check(overLimit.resetAt, now + DEFAULT_INTERVAL_MS, 'resetAt is the end of the window that is open')
+
+check(
+  consume('user:a', { limit: 3, now: now + DEFAULT_INTERVAL_MS }).allowed,
+  true,
+  'the counter resets once the window has elapsed'
+)
+check(
+  consume('user:a', { limit: 3, now: now + DEFAULT_INTERVAL_MS - 1 }).allowed,
+  true,
+  'a request one millisecond before the window closes lands in the new window'
+)
+
+resetInMemoryRateLimits()
+check(consume('user:b', { limit: 1, now }).allowed, true, 'a different key has its own window')
+check(consume('user:b', { limit: 1, now }).allowed, false, 'and its own limit')
+check(consume('user:c', { limit: 1, now }).allowed, true, 'keys do not interfere')
+
+resetInMemoryRateLimits()
+const remaining = consume('user:d', { limit: 5, now })
+check(remaining.count, 1, 'count starts at one')
+check(remaining.remaining, 4, 'remaining reflects the limit minus the count')
+
+// ───────────────────────────────────────────────────────────────────────────
+section('degenerate configuration fails closed')
+
+resetInMemoryRateLimits()
+check(consume('user:e', { limit: 0, now }).allowed, false, 'a limit of zero rejects')
+check(consume('user:f', { limit: -1, now }).allowed, false, 'a negative limit rejects')
+check(consume('user:g', {}).allowed, false, 'a missing limit rejects rather than allowing everything')
+
+resetInMemoryRateLimits()
+check(
+  consume('user:h', { limit: 2, intervalMs: 0, now }).allowed,
+  true,
+  'a zero interval falls back to the default window instead of resetting every call'
+)
+check(consume('user:h', { limit: 2, intervalMs: 0, now }).allowed, true, 'second request still allowed')
+check(consume('user:h', { limit: 2, intervalMs: 0, now }).allowed, false, 'third request is rejected')
+
+// ───────────────────────────────────────────────────────────────────────────
+section('isAllowed wrapper')
+
+resetInMemoryRateLimits()
+check(isAllowed('user_1', 'chat', 2), true, 'first call allowed')
+check(isAllowed('user_1', 'chat', 2), true, 'second call allowed')
+check(isAllowed('user_1', 'chat', 2), false, 'third call rejected')
+check(isAllowed('user_1', 'cycles', 2), true, 'a different route has a separate budget')
+check(isAllowed('user_2', 'chat', 2), true, 'a different user has a separate budget')
+
+// ───────────────────────────────────────────────────────────────────────────
+if (failed > 0) {
+  console.error(`\n❌ ${failed} assertion(s) failed, ${passed} passed.`)
+  process.exit(1)
+}
+
+console.log(`\n✅ All ${passed} rate limiter assertions passed.`)


### PR DESCRIPTION
## Linked Issue
Fixes #472

## Description

The limiter behind every API route (`aiLimiter`, `crudLimiter`, `devLimiter`) enforced nothing in two situations. Both are fixed here, plus the plumbing needed to test them.

### 1. Unattributable requests were handed a private bucket

```js
const ip = extractClientIp(request);
if (!ip) return `anon:${Math.random().toString(36).slice(2, 12)}`;
```

A fresh random identifier on **every call**, so the limiter looked up a bucket it had never seen, found a count of 1, and allowed the request. No value of `limit` could ever be exceeded on that path. `extractClientIp()` returns `null` whenever `x-forwarded-for`, `x-real-ip` and `cf-connecting-ip` are all absent — which is the case for self-hosted and Docker deployments (we ship a `Dockerfile`), local and preview environments, and any client that simply omits the headers when talking to the origin. It also wrote one junk row per request through the `enforce_rate_limit` RPC.

Now: `buildAnonymousIdentifier()` derives a **stable** SHA-256 digest from the request's own headers (`user-agent`, `accept-language`, `sec-ch-ua`, `sec-ch-ua-platform`), falling back to one shared strict bucket when there is nothing to derive from.

That fingerprint is coarse and easy to vary on purpose — and that is fine. It is a fallback for a request that already told us nothing, and varying it is no cheaper than rotating an IP. What matters is that a client which is *not* trying to evade is now counted consistently instead of being waved through.

### 2. A database error disabled every limit in the app

```js
let allowed = true;
// ... only ever assigned inside `else if (data)`
```

An RPC error, a thrown client error, or a success with no payload (which is what a missing `enforce_rate_limit` function looks like on a fresh install — it is not in `MASTER_PRODUCTION_MIGRATION.sql`) all left `allowed` at its initial `true`. `dbError` was tracked but only ever widened the `X-RateLimit-Remaining` header; it never reached the allow/deny decision.

So the moment the database was under load — exactly when rate limiting matters — every limit switched off, including on `/api/chat`, `/api/pcod-risk` and `/api/partner-coach`, which spend money per call.

Now the decision falls through to an in-process fixed-window counter. Per-container state means a fleet of N containers enforces at most `N × limit`. That is still a hole, but a bounded one, and it is the honest trade for a fallback that only runs during an outage. The degraded path logs a warning so it is visible in production rather than silent.

### Also in this change

- **`lib/rate-limiter.js` rewritten.** It was a 52-line stub that nothing imported. It is now the fallback counter plus the identity helpers, with no imports from `next/*` or Clerk — so it is testable from a plain Node script and usable from Middleware. Its cleanup timer is now `unref()`'d; without that it keeps the Node event loop alive and any script importing the module hangs instead of exiting.
- **An invalid limit fails closed.** Zero, negative or missing now rejects rather than being clamped up to 1. A control that reads "I don't know the limit" as "no limit" is the bug this PR is about.
- **`Retry-After` on 429s**, alongside the existing `X-RateLimit-*` headers, and only when the caller actually has to wait.
- **`createLimiter` takes an optional `getClient`**, so the backend can be injected instead of reached for through a module singleton.
- **The `MOCK_DB` branch of `getSupabaseAdmin` now answers `rpc()`.** It only had `from`, so every `supabase.rpc(...)` call in mock mode threw a `TypeError` that the callers swallowed — meaning mock runs were exercising the limiter's *degraded* path, not its real one. `lib/supabase-mock.js` already had this; the admin client's inline mock had drifted from it.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (clean code updates, no behavior modifications)
- [ ] Documentation update
- [ ] Performance optimization
- [x] Security patch

## Files Modified

| File | Change |
|---|---|
| `lib/rate-limiter.js` | rewritten — `consume`, `isAllowed`, `resetInMemoryRateLimits`, `extractClientIp`, `buildAnonymousIdentifier` |
| `lib/rateLimiter.js` | stable anonymous identifier; `enforceLimit()` extracted and made fail-closed; `Retry-After`; `getClient` seam; re-exports `extractClientIp` so existing importers are unaffected |
| `lib/supabase-admin.js` | mock client answers `rpc()` |
| `scripts/test-rate-limiter.js` | **new** — 37 assertions |

`getRateLimitIdentifier` and `extractClientIp` keep their existing import paths and signatures, so the four routes that import them (`chat`, `pcod-risk`, `predict-cycle`, `seed`) need no changes.

## Testing

```bash
node scripts/test-rate-limiter.js
# ✅ All 37 rate limiter assertions passed.

npm run build          # compiles clean
npm run test:e2e       # 7 / 7 suites passed
```

The suite covers:

- IP extraction across the three proxy header conventions, including the literal `unknown` sentinel and the trimming of a multi-hop `x-forwarded-for` chain
- identifier **stability** — the same request shape produces the same identifier twice, different clients produce different ones, and a request with nothing to fingerprint lands in the shared bucket
- **the headline regression**: 20 requests from a header-less caller against a limit of 5 now yield 5 allowed, not 20
- fixed-window arithmetic: boundary at exactly `intervalMs`, one millisecond before, per-key isolation, `remaining` clamped at zero
- fail-closed on a zero, negative or missing limit
- the `isAllowed(key, route, limit)` wrapper keeping separate budgets per route and per user

The e2e suites make six HTTP requests in total, well under `crudLimiter`'s 30/min, so the newly-active degraded limiter does not affect them — I verified that rather than assuming it.

Manual check for the identifier bug, against a dev server with no proxy in front of it:

```bash
for i in $(seq 1 10); do
  curl -s -o /dev/null -w "%{http_code} " localhost:3000/api/pcod-risk
done
```

Before: ten identical status codes. After: the 6th request onward returns `429` with a `Retry-After` header, because `aiLimiter` is 5/min.

## Screenshots (if UI changes are made)
N/A — backend-only change, no UI modifications.

## Notes for reviewers

This is distinct from #462, which adds a limiter call to the account-deletion route. That adds a call site; this fixes the limiter those call sites depend on.

The in-memory fallback is explicitly **not** a replacement for the Postgres limiter in normal operation — the module header says so. If the project would rather have the degraded path reject outright instead of falling back to a local counter, that is a one-line change in `enforceLimit()` and I am happy to make it.

## Checklist
- [x] This PR is submitted under ECSOC.
- [x] Added the required **ECSoc26** label to this Pull Request.
- [x] Linked issue using `Fixes #472`.
- [x] Tested locally.
- [x] `npm run build` completes successfully.
- [x] No breaking changes introduced.
- [x] Documentation updated if required (module-level docs in `lib/rate-limiter.js`).
