### PR TITLE
[ECSoC26] fix(backend): bound, retry and validate every ML microservice call

### DIFF
--- a/lib/api-helpers.js
+++ b/lib/api-helpers.js
@@ -1,4 +1,6 @@
 import { addDays, compareDates, diffInDays, formatDisplayDate, getTodayISO, parseDateValue } from './date-utils.js'
+import { ML_FAILURE_REASONS, callMlService } from './ml-client.js'
+import { parseMlPrediction, parseMlRisk } from './ml-schemas.js'
 
 // A history this far behind cannot support a meaningful projection: past this
 // point the app is guessing, and prolonged amenorrhea is itself a PCOD signal
@@ -464,46 +466,76 @@ function calculatePCODRiskFallback(cycleHistory, symptoms) {
   }
 }
 
-export async function predictNextPeriod(cycleHistory, today = new Date()) {
-  const mlServiceUrl = process.env.ML_SERVICE_URL || process.env.NEXT_PUBLIC_ML_SERVICE_URL;
-  if (mlServiceUrl) {
-    try {
-      const response = await fetch(`${mlServiceUrl}/predict-cycle`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ cycle_history: cycleHistory || [], today: today.toISOString() })
-      });
-      if (response.ok) {
-        const data = await response.json();
-        if (data && data.prediction) {
-          return data.prediction;
-        }
-      }
-    } catch (e) {
-      console.warn('ML Microservice prediction failed, falling back to rule-based engine:', e.message || e);
-    }
+/**
+ * The two ML-backed entry points below share one contract:
+ *
+ *   > The rule-based engine is the answer. The ML service is allowed to
+ *   > *improve* on it, and is allowed to fail without anyone noticing.
+ *
+ * Everything that used to be inline here — the timeout, the retry budget, the
+ * circuit breaker, the response validation — now lives in `lib/ml-client.js`
+ * and `lib/ml-schemas.js`, so both call sites get identical behaviour and the
+ * policy is unit-testable without a network. See `scripts/test-ml-client.js`.
+ *
+ * `callMlService` never throws and never returns an unvalidated payload, so
+ * there is no try/catch here: a failure is just a falsy `ok`.
+ */
+
+/**
+ * Reasons that are worth a log line. `disabled` and `circuit_open` are the
+ * expected steady states of a deployment without an ML service (or with one
+ * that is known to be down) and logging them would emit a line per request.
+ */
+const NOISY_ML_REASONS = new Set([ML_FAILURE_REASONS.DISABLED, ML_FAILURE_REASONS.CIRCUIT_OPEN])
+
+/**
+ * Predicts the next period, preferring the ML service when it is healthy.
+ *
+ * @param {Array} cycleHistory rows from the `cycles` table
+ * @param {Date} [today] injectable clock
+ * @param {object} [options] test seam forwarded to `callMlService`
+ * @returns {Promise<object>} the same shape as {@link predictNextPeriodFallback}
+ */
+export async function predictNextPeriod(cycleHistory, today = new Date(), options = {}) {
+  const result = await callMlService(
+    '/predict-cycle',
+    { cycle_history: cycleHistory || [], today: today.toISOString() },
+    { ...options, parse: parseMlPrediction }
+  )
+
+  if (result.ok) return result.value
+
+  if (!NOISY_ML_REASONS.has(result.reason)) {
+    console.warn(
+      `ML prediction unavailable (${result.reason}); using the rule-based engine.`
+    )
   }
-  return predictNextPeriodFallback(cycleHistory, today);
+
+  return predictNextPeriodFallback(cycleHistory, today)
 }
 
-export async function calculatePCODRisk(cycleHistory, symptoms) {
-  const mlServiceUrl = process.env.ML_SERVICE_URL || process.env.NEXT_PUBLIC_ML_SERVICE_URL;
-  if (mlServiceUrl) {
-    try {
-      const response = await fetch(`${mlServiceUrl}/pcod-risk`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ cycle_history: cycleHistory || [], symptoms: symptoms || [] })
-      });
-      if (response.ok) {
-        const data = await response.json();
-        if (data && data.risk) {
-          return data.risk;
-        }
-      }
-    } catch (e) {
-      console.warn('ML Microservice PCOD risk calculation failed, falling back to rule-based engine:', e.message || e);
-    }
+/**
+ * Scores PCOD risk, preferring the ML service when it is healthy.
+ *
+ * @param {Array} cycleHistory rows from the `cycles` table
+ * @param {Array} symptoms logged symptoms, in any of the shapes the fallback accepts
+ * @param {object} [options] test seam forwarded to `callMlService`
+ * @returns {Promise<object>} the same shape as {@link calculatePCODRiskFallback}
+ */
+export async function calculatePCODRisk(cycleHistory, symptoms, options = {}) {
+  const result = await callMlService(
+    '/pcod-risk',
+    { cycle_history: cycleHistory || [], symptoms: symptoms || [] },
+    { ...options, parse: parseMlRisk }
+  )
+
+  if (result.ok) return result.value
+
+  if (!NOISY_ML_REASONS.has(result.reason)) {
+    console.warn(
+      `ML PCOD risk unavailable (${result.reason}); using the rule-based engine.`
+    )
   }
-  return calculatePCODRiskFallback(cycleHistory, symptoms);
+
+  return calculatePCODRiskFallback(cycleHistory, symptoms)
 }

--- a/lib/ml-client.js
+++ b/lib/ml-client.js
@@ -1,0 +1,526 @@
+/**
+ * ml-client.js — the transport policy for the optional ML microservice.
+ *
+ * ## The bug this exists to prevent
+ *
+ * `lib/api-helpers.js` reached the ML service with a bare `fetch()`:
+ *
+ *     const response = await fetch(`${mlServiceUrl}/predict-cycle`, {
+ *       method: 'POST',
+ *       headers: { 'Content-Type': 'application/json' },
+ *       body: JSON.stringify({ ... })
+ *     })
+ *     if (response.ok) {
+ *       const data = await response.json()
+ *       if (data && data.prediction) return data.prediction   // <- verbatim
+ *     }
+ *
+ * Three separate failures live in those six lines:
+ *
+ * 1. **No timeout.** No `AbortController`, no `signal`. A container that accepts
+ *    the connection and then never writes a byte — an OOM, a deadlock, a paused
+ *    task — leaves that `await` pending forever. `/api/predict-cycle` and
+ *    `/api/pcod-risk` then hang until the platform kills the function, even
+ *    though a correct rule-based answer was available on the next line.
+ *
+ * 2. **No retry, and no breaker.** One transient 502 discarded the ML result
+ *    entirely; conversely a *permanently* dead service was re-dialled on every
+ *    single request, so every prediction paid the full connect-and-fail cost.
+ *    Both extremes are wrong: transient faults deserve a retry, sustained ones
+ *    deserve to be skipped.
+ *
+ * 3. **No validation.** `if (data && data.prediction)` accepts a string, an
+ *    empty object, `{ confidence: null }` — anything truthy. That value was
+ *    returned straight out of the route and rendered, producing `undefined%`
+ *    confidence and `Invalid Date` where a correct fallback was one line away.
+ *
+ * ## The policy
+ *
+ * | condition                                  | classification | effect                    |
+ * |--------------------------------------------|----------------|---------------------------|
+ * | 2xx with a schema-valid body               | `success`      | use the ML result         |
+ * | 2xx with a body the schema rejects         | `invalid`      | fall back, do NOT retry   |
+ * | 400, 401, 403, 404, 409, 422               | `permanent`    | fall back, do NOT retry   |
+ * | 408, 425, 429, 5xx, network error, timeout | `transient`    | retry with backoff        |
+ *
+ * A `permanent` or `invalid` answer means the request will not succeed as
+ * written, so retrying only adds latency to a fallback that is already correct.
+ * Only `transient` faults are retried, and only a bounded number of times.
+ *
+ * Consecutive transient failures trip a circuit breaker. While it is open every
+ * call short-circuits to the fallback engine immediately, which turns a dead ML
+ * service from "every request is slow" into "every request is fast and
+ * rule-based". After a cooldown the breaker half-opens and lets exactly one
+ * probe through; that probe's outcome closes it or re-opens it.
+ *
+ * ## Design note
+ *
+ * The ML service is an **optimisation, never a correctness dependency**. Every
+ * failure path in this module ends in `{ ok: false }`, and every caller is
+ * expected to answer from the deterministic rule-based engine when it sees one.
+ * Nothing here throws.
+ *
+ * The policy pieces (`classifyMlResponse`, `computeMlBackoffMs`,
+ * `createCircuitBreaker`, `resolveMlConfig`) are pure and separately exported so
+ * they can be tested exhaustively without a network — see
+ * `scripts/test-ml-client.js`.
+ */
+
+/** Wall-clock budget for a single ML attempt, before retries. */
+export const DEFAULT_ML_TIMEOUT_MS = 4000
+
+/**
+ * Retries *after* the first attempt. One retry (two attempts total) is the
+ * right default: it covers the single dropped connection that dominates real
+ * transient failures, without doubling the latency budget of a service that is
+ * genuinely down — the breaker handles that case instead.
+ */
+export const DEFAULT_ML_RETRIES = 1
+
+/** First retry delay. Deliberately short: a user is waiting on this request. */
+export const DEFAULT_ML_BACKOFF_MS = 150
+
+/** Ceiling for the retry backoff. */
+export const MAX_ML_BACKOFF_MS = 2000
+
+/** Consecutive failed calls that trip the breaker open. */
+export const DEFAULT_BREAKER_THRESHOLD = 3
+
+/** How long the breaker stays open before allowing a probe. */
+export const DEFAULT_BREAKER_COOLDOWN_MS = 30 * 1000
+
+/** Breaker states. */
+export const BREAKER_CLOSED = 'closed'
+export const BREAKER_OPEN = 'open'
+export const BREAKER_HALF_OPEN = 'half-open'
+
+/**
+ * Statuses that mean "this request will never succeed as written".
+ *
+ * 401/403 are here rather than in the transient set on purpose: a misconfigured
+ * ML credential is a deploy-time problem, and retrying it just multiplies the
+ * latency of a fallback that was always going to be used.
+ */
+const PERMANENT_STATUSES = new Set([400, 401, 403, 404, 405, 409, 415, 422])
+
+/** Statuses that are explicitly worth another attempt. */
+const TRANSIENT_STATUSES = new Set([408, 425, 429])
+
+/**
+ * Reasons a call did not produce a usable ML result. Surfaced on the result
+ * object so callers can log *why* they fell back rather than just that they did.
+ */
+export const ML_FAILURE_REASONS = {
+  /** No `ML_SERVICE_URL` configured — the service is simply not in use. */
+  DISABLED: 'disabled',
+  /** The breaker is open; no request was attempted. */
+  CIRCUIT_OPEN: 'circuit_open',
+  /** The attempt budget was exhausted by transient faults. */
+  TRANSIENT: 'transient',
+  /** The service answered with a status that will not change on retry. */
+  PERMANENT: 'permanent',
+  /** The service answered 2xx with a body the schema rejected. */
+  INVALID_RESPONSE: 'invalid_response',
+  /** The attempt exceeded the timeout budget. */
+  TIMEOUT: 'timeout',
+}
+
+/**
+ * Reads the ML configuration out of an environment bag.
+ *
+ * Every numeric knob is clamped rather than trusted, because a typo'd env var
+ * (`ML_SERVICE_TIMEOUT_MS=0`, or a value with a stray unit suffix) should
+ * degrade to the default rather than disable the timeout or spin the retry loop.
+ *
+ * @param {Record<string, string|undefined>} [env]
+ * @returns {{
+ *   baseUrl: string|null,
+ *   timeoutMs: number,
+ *   retries: number,
+ *   breakerThreshold: number,
+ *   breakerCooldownMs: number
+ * }}
+ */
+export function resolveMlConfig(env = process.env) {
+  const rawUrl = env.ML_SERVICE_URL || env.NEXT_PUBLIC_ML_SERVICE_URL || ''
+  const trimmed = String(rawUrl).trim()
+
+  return {
+    // A trailing slash plus the leading slash on a path yields `//predict-cycle`,
+    // which some routers 404 on. Normalise once, here.
+    baseUrl: trimmed ? trimmed.replace(/\/+$/, '') : null,
+    timeoutMs: clampInt(env.ML_SERVICE_TIMEOUT_MS, DEFAULT_ML_TIMEOUT_MS, 250, 30000),
+    retries: clampInt(env.ML_SERVICE_RETRIES, DEFAULT_ML_RETRIES, 0, 5),
+    breakerThreshold: clampInt(env.ML_SERVICE_BREAKER_THRESHOLD, DEFAULT_BREAKER_THRESHOLD, 1, 50),
+    breakerCooldownMs: clampInt(
+      env.ML_SERVICE_BREAKER_COOLDOWN_MS, DEFAULT_BREAKER_COOLDOWN_MS, 1000, 10 * 60 * 1000
+    ),
+  }
+}
+
+/**
+ * Parses an integer from an env value, falling back to `fallback` for anything
+ * that is not a finite in-range number.
+ *
+ * @param {unknown} raw
+ * @param {number} fallback
+ * @param {number} min
+ * @param {number} max
+ * @returns {number}
+ */
+function clampInt(raw, fallback, min, max) {
+  if (raw === undefined || raw === null || raw === '') return fallback
+  const parsed = Number(raw)
+  if (!Number.isFinite(parsed)) return fallback
+  return Math.min(max, Math.max(min, Math.round(parsed)))
+}
+
+/**
+ * Classifies one ML attempt.
+ *
+ * @param {{ status?: number, ok?: boolean }|null} response the fetch Response,
+ *   or `null` when the request threw (network failure, DNS, abort)
+ * @returns {'success'|'permanent'|'transient'}
+ */
+export function classifyMlResponse(response) {
+  // A thrown request — offline, DNS failure, connection reset, or our own
+  // abort — is always worth one more try.
+  if (!response) return 'transient'
+
+  const status = Number(response.status)
+  if (!Number.isFinite(status)) return 'transient'
+
+  if (status >= 200 && status < 300) return 'success'
+  if (PERMANENT_STATUSES.has(status)) return 'permanent'
+  if (TRANSIENT_STATUSES.has(status)) return 'transient'
+  if (status >= 500) return 'transient'
+
+  // Any other 4xx is a request the payload cannot recover from.
+  if (status >= 400) return 'permanent'
+
+  // 1xx/3xx reaching here means a redirect the fetch layer did not follow.
+  return 'transient'
+}
+
+/**
+ * Exponential backoff with full jitter, floored at half the ceiling.
+ *
+ * Jitter matters even on a two-attempt budget: a fleet of serverless instances
+ * that all failed against the same ML restart would otherwise retry in lockstep
+ * and knock it over a second time.
+ *
+ * @param {number} attempt how many attempts have already failed (>= 1)
+ * @param {() => number} [random] injectable for deterministic tests
+ * @param {number} [baseMs]
+ * @returns {number} milliseconds to wait before the next attempt
+ */
+export function computeMlBackoffMs(attempt, random = Math.random, baseMs = DEFAULT_ML_BACKOFF_MS) {
+  const safeAttempt = Number.isFinite(attempt) && attempt > 0 ? Math.floor(attempt) : 1
+  // Cap the exponent before the shift so a corrupted counter cannot overflow.
+  const exponent = Math.min(safeAttempt - 1, 16)
+  const ceiling = Math.min(baseMs * 2 ** exponent, MAX_ML_BACKOFF_MS)
+  const floor = ceiling / 2
+  return Math.round(floor + random() * floor)
+}
+
+/**
+ * A three-state circuit breaker.
+ *
+ * Closed  — requests flow; `threshold` consecutive failures opens it.
+ * Open    — requests short-circuit; after `cooldownMs` it becomes half-open.
+ * Half-open — exactly one probe is allowed through. Success closes the breaker
+ *             and resets the counter; failure re-opens it and restarts the
+ *             cooldown.
+ *
+ * The half-open state is what stops a recovering service from being hit by the
+ * full request volume the instant the cooldown expires.
+ *
+ * State is per-process, which is the correct scope here: each serverless
+ * instance learns about the ML service's health from its own traffic, and there
+ * is no shared store to keep consistent.
+ *
+ * @param {{ threshold?: number, cooldownMs?: number }} [options]
+ */
+export function createCircuitBreaker(options = {}) {
+  const threshold = Number.isFinite(options.threshold) && options.threshold > 0
+    ? Math.floor(options.threshold)
+    : DEFAULT_BREAKER_THRESHOLD
+  const cooldownMs = Number.isFinite(options.cooldownMs) && options.cooldownMs > 0
+    ? Math.floor(options.cooldownMs)
+    : DEFAULT_BREAKER_COOLDOWN_MS
+
+  let consecutiveFailures = 0
+  let openedAt = 0
+  let probeInFlight = false
+
+  /**
+   * The breaker's state as of `now`. Reading is what promotes open ->
+   * half-open, so there is no timer to leak in a serverless process.
+   *
+   * @param {number} now epoch millis
+   * @returns {'closed'|'open'|'half-open'}
+   */
+  function state(now) {
+    if (consecutiveFailures < threshold) return BREAKER_CLOSED
+    if (now - openedAt >= cooldownMs) return BREAKER_HALF_OPEN
+    return BREAKER_OPEN
+  }
+
+  return {
+    state,
+
+    /**
+     * Whether a request may be attempted right now.
+     *
+     * In half-open only the first caller gets through; concurrent callers are
+     * refused so a recovering service sees one probe, not a thundering herd.
+     *
+     * @param {number} now epoch millis
+     * @returns {boolean}
+     */
+    allowRequest(now) {
+      const current = state(now)
+      if (current === BREAKER_CLOSED) return true
+      if (current === BREAKER_OPEN) return false
+
+      if (probeInFlight) return false
+      probeInFlight = true
+      return true
+    },
+
+    /** Records a successful call: closes the breaker and clears the counter. */
+    onSuccess() {
+      consecutiveFailures = 0
+      openedAt = 0
+      probeInFlight = false
+    },
+
+    /**
+     * Records a failed call. Opens the breaker on the `threshold`-th
+     * consecutive failure, and restarts the cooldown when a half-open probe
+     * fails.
+     *
+     * @param {number} now epoch millis
+     */
+    onFailure(now) {
+      const wasHalfOpen = state(now) === BREAKER_HALF_OPEN
+      probeInFlight = false
+      consecutiveFailures += 1
+
+      if (wasHalfOpen || consecutiveFailures === threshold) {
+        openedAt = now
+      }
+    },
+
+    /** Test/ops hook: forget everything the breaker has learned. */
+    reset() {
+      consecutiveFailures = 0
+      openedAt = 0
+      probeInFlight = false
+    },
+
+    /** Introspection, for logging and tests. */
+    snapshot(now) {
+      return { state: state(now), consecutiveFailures, openedAt, threshold, cooldownMs }
+    },
+  }
+}
+
+/** The process-wide breaker guarding the ML service. */
+export const mlBreaker = createCircuitBreaker()
+
+/**
+ * Performs one ML request with an enforced timeout.
+ *
+ * Returns `null` instead of throwing on any transport failure, so the caller's
+ * classification table has a single "no response" case to reason about rather
+ * than a mix of thrown errors and status codes.
+ *
+ * @param {string} url
+ * @param {unknown} payload
+ * @param {{ timeoutMs: number, fetchImpl: typeof fetch }} deps
+ * @returns {Promise<{ response: Response|null, timedOut: boolean }>}
+ */
+async function attemptOnce(url, payload, { timeoutMs, fetchImpl }) {
+  const controller = new AbortController()
+  let timedOut = false
+
+  const timer = setTimeout(() => {
+    timedOut = true
+    controller.abort()
+  }, timeoutMs)
+
+  try {
+    const response = await fetchImpl(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+      signal: controller.signal,
+    })
+    return { response, timedOut: false }
+  } catch {
+    // AbortError (ours or the caller's), DNS failure, ECONNREFUSED, a TLS
+    // error — all of them mean "no usable response", which is the only
+    // distinction the policy needs.
+    return { response: null, timedOut }
+  } finally {
+    // Always clear: a leaked timer keeps a serverless instance alive past the
+    // response, which is billed time for nothing.
+    clearTimeout(timer)
+  }
+}
+
+/**
+ * Reads a response body as JSON without letting a malformed body throw.
+ *
+ * A 200 carrying HTML — an ingress error page, a login redirect that was
+ * followed — is a real production shape, and it must be classified as an
+ * invalid response rather than crashing the route.
+ *
+ * @param {Response} response
+ * @returns {Promise<unknown|null>}
+ */
+async function readJson(response) {
+  try {
+    return await response.json()
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Calls an ML endpoint and returns a validated result, or an explained failure.
+ *
+ * Never throws and never returns an unvalidated payload.
+ *
+ * @param {string} path endpoint path, e.g. `/predict-cycle`
+ * @param {unknown} payload request body
+ * @param {object} [options]
+ * @param {(raw: unknown) => {ok: true, value: any}|{ok: false, reason: string}} options.parse
+ *   schema check applied to the parsed body; anything it rejects is treated as
+ *   `invalid` and falls back
+ * @param {Record<string, string|undefined>} [options.env]
+ * @param {typeof fetch} [options.fetchImpl]
+ * @param {() => number} [options.now]
+ * @param {() => number} [options.random]
+ * @param {(ms: number) => Promise<void>} [options.sleep]
+ * @param {ReturnType<typeof createCircuitBreaker>} [options.breaker]
+ * @param {{ warn: Function, debug?: Function }} [options.log]
+ * @returns {Promise<{ ok: true, value: any, attempts: number }
+ *                 | { ok: false, reason: string, attempts: number, status?: number }>}
+ */
+export async function callMlService(path, payload, options = {}) {
+  const {
+    parse,
+    env = process.env,
+    fetchImpl = globalThis.fetch,
+    now = Date.now,
+    random = Math.random,
+    sleep = defaultSleep,
+    breaker = mlBreaker,
+    log = console,
+  } = options
+
+  const config = resolveMlConfig(env)
+
+  if (!config.baseUrl) {
+    return { ok: false, reason: ML_FAILURE_REASONS.DISABLED, attempts: 0 }
+  }
+
+  if (typeof fetchImpl !== 'function') {
+    // Node < 18 without a polyfill. Treat as "service not usable" rather than
+    // throwing a ReferenceError out of a route handler.
+    return { ok: false, reason: ML_FAILURE_REASONS.DISABLED, attempts: 0 }
+  }
+
+  if (!breaker.allowRequest(now())) {
+    return { ok: false, reason: ML_FAILURE_REASONS.CIRCUIT_OPEN, attempts: 0 }
+  }
+
+  const url = `${config.baseUrl}${path}`
+  const maxAttempts = config.retries + 1
+  let attempts = 0
+  let lastStatus
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    attempts = attempt
+
+    const { response, timedOut } = await attemptOnce(url, payload, {
+      timeoutMs: config.timeoutMs,
+      fetchImpl,
+    })
+
+    const classification = classifyMlResponse(response)
+    lastStatus = response ? Number(response.status) : undefined
+
+    if (classification === 'permanent') {
+      breaker.onFailure(now())
+      log.warn?.(
+        `[ml-client] ${path} rejected with ${lastStatus}; using the rule-based engine.`
+      )
+      return { ok: false, reason: ML_FAILURE_REASONS.PERMANENT, attempts, status: lastStatus }
+    }
+
+    if (classification === 'success') {
+      const body = await readJson(response)
+      const parsed = typeof parse === 'function' ? parse(body) : { ok: true, value: body }
+
+      if (parsed.ok) {
+        breaker.onSuccess()
+        return { ok: true, value: parsed.value, attempts }
+      }
+
+      // A 2xx the schema rejects is the service's answer, not a fault of the
+      // connection — retrying returns the same body. Count it against the
+      // breaker (a service emitting garbage is unhealthy) but stop here.
+      breaker.onFailure(now())
+      log.warn?.(
+        `[ml-client] ${path} returned an unusable payload (${parsed.reason}); ` +
+        'using the rule-based engine.'
+      )
+      return {
+        ok: false,
+        reason: ML_FAILURE_REASONS.INVALID_RESPONSE,
+        attempts,
+        status: lastStatus,
+      }
+    }
+
+    // Transient. Retry if there is budget left.
+    if (attempt < maxAttempts) {
+      await sleep(computeMlBackoffMs(attempt, random))
+      continue
+    }
+
+    breaker.onFailure(now())
+    const reason = timedOut ? ML_FAILURE_REASONS.TIMEOUT : ML_FAILURE_REASONS.TRANSIENT
+    log.warn?.(
+      `[ml-client] ${path} failed after ${attempts} attempt(s) (${reason}); ` +
+      'using the rule-based engine.'
+    )
+    return { ok: false, reason, attempts, status: lastStatus }
+  }
+
+  /* c8 ignore next 2 — the loop always returns; this satisfies the linter. */
+  return { ok: false, reason: ML_FAILURE_REASONS.TRANSIENT, attempts }
+}
+
+/**
+ * Default backoff sleep.
+ *
+ * @param {number} ms
+ * @returns {Promise<void>}
+ */
+function defaultSleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+/**
+ * True when the ML service is configured at all.
+ *
+ * @param {Record<string, string|undefined>} [env]
+ * @returns {boolean}
+ */
+export function isMlServiceConfigured(env = process.env) {
+  return resolveMlConfig(env).baseUrl !== null
+}

--- a/lib/ml-schemas.js
+++ b/lib/ml-schemas.js
@@ -1,0 +1,271 @@
+/**
+ * ml-schemas.js — the shape contract for anything the ML microservice returns.
+ *
+ * ## Why this module exists
+ *
+ * The only check the ML path ever performed was truthiness:
+ *
+ *     if (data && data.prediction) return data.prediction
+ *
+ * `data.prediction` could be the string `"ok"`, an empty object, or
+ * `{ confidence: null, averageCycleLength: "twenty-eight" }` and all three
+ * passed. Whatever it was got returned straight out of `/api/predict-cycle` and
+ * handed to `PredictionCard`, which renders `confidence` and `nextPeriodDate`
+ * directly — so a malformed payload surfaced as `undefined%` next to
+ * `Invalid Date`, while a correct rule-based answer sat unused one line below.
+ *
+ * The same held for `/pcod-risk`, where the unvalidated payload became the risk
+ * tier the app tells users to show a clinician.
+ *
+ * The rule this module enforces:
+ *
+ *   > An ML response is used only if it is a complete, in-range result.
+ *   > A partial one is a failure, and a failure means the rule-based engine.
+ *
+ * These are deliberately *strict*. Being lenient here — filling a missing
+ * `confidence` with a default, coercing a bad `averageCycleLength` to 28 —
+ * would manufacture a result that neither engine actually computed. Rejecting
+ * costs nothing, because the fallback is always available and always correct.
+ *
+ * Every parser returns a discriminated result rather than throwing:
+ *
+ *     { ok: true,  value }            // validated and normalised
+ *     { ok: false, reason }           // a short machine-readable cause
+ *
+ * No imports beyond the shared risk contract, so this is usable from Route
+ * Handlers, Client Components and plain Node scripts alike.
+ */
+
+import { normaliseRiskResult } from './pcod-risk-result.js'
+
+/** Cycle lengths outside this range are rejected, matching the fallback engine. */
+export const MIN_CYCLE_LENGTH = 21
+export const MAX_CYCLE_LENGTH = 45
+
+/** Machine-readable rejection causes, surfaced in logs. */
+export const SCHEMA_REJECTIONS = {
+  NOT_AN_OBJECT: 'not_an_object',
+  MISSING_ENVELOPE: 'missing_envelope',
+  BAD_DATE: 'bad_next_period_date',
+  BAD_CONFIDENCE: 'bad_confidence',
+  BAD_CYCLE_LENGTH: 'bad_average_cycle_length',
+  BAD_RISK: 'bad_risk_result',
+}
+
+/**
+ * True when `value` is a plain object we can read keys off.
+ *
+ * Arrays are excluded on purpose: `[]` is truthy and `[].prediction` is
+ * `undefined`, which is exactly the class of value the old truthiness check let
+ * through.
+ *
+ * @param {unknown} value
+ * @returns {boolean}
+ */
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}
+
+/**
+ * Normalises a confidence value onto the `"NN%"` string the UI renders.
+ *
+ * Accepts the two shapes an ML implementation plausibly emits — the string
+ * `"85%"` and the number `85` — plus a `0..1` probability, which is the most
+ * likely thing a model actually produces. Anything else is rejected rather than
+ * guessed at.
+ *
+ * @param {unknown} raw
+ * @returns {string|null} `"85%"`, or `null` when unusable
+ */
+export function normaliseConfidence(raw) {
+  if (typeof raw === 'number') {
+    if (!Number.isFinite(raw)) return null
+    // A model returning 0..1 is a probability; anything above 1 is already a
+    // percentage. 1 itself is ambiguous, and is read as 1% rather than 100%
+    // because claiming perfect certainty from an ambiguous value is the more
+    // damaging of the two mistakes.
+    const percent = raw > 0 && raw < 1 ? raw * 100 : raw
+    if (percent < 0 || percent > 100) return null
+    return `${Math.round(percent)}%`
+  }
+
+  if (typeof raw !== 'string') return null
+
+  const trimmed = raw.trim()
+  if (!trimmed) return null
+
+  const match = trimmed.match(/^(\d{1,3}(?:\.\d+)?)\s*%?$/)
+  if (!match) return null
+
+  const percent = Number(match[1])
+  if (!Number.isFinite(percent) || percent < 0 || percent > 100) return null
+
+  return `${Math.round(percent)}%`
+}
+
+/**
+ * Validates the human-readable next-period date.
+ *
+ * The fallback engine emits `"Aug 12, 2026"`, so the contract is "a string that
+ * a Date can actually parse" rather than a fixed format — an ML service written
+ * in Python will more naturally emit `"2026-08-12"`, and both are renderable.
+ *
+ * A date the browser cannot parse is exactly the payload that produced
+ * `Invalid Date` in the prediction card, so it is rejected here.
+ *
+ * @param {unknown} raw
+ * @returns {string|null} the original string, or `null`
+ */
+export function normalisePredictionDate(raw) {
+  if (typeof raw !== 'string') return null
+
+  const trimmed = raw.trim()
+  if (!trimmed) return null
+
+  const parsed = new Date(trimmed)
+  if (Number.isNaN(parsed.getTime())) return null
+
+  return trimmed
+}
+
+/**
+ * Validates a cycle length against the same range the fallback engine clamps to.
+ *
+ * Out-of-range is rejected rather than clamped: a service claiming a 90-day
+ * average is either broken or looking at someone else's data, and silently
+ * rewriting it to 45 would hide that.
+ *
+ * @param {unknown} raw
+ * @returns {number|null}
+ */
+export function normaliseCycleLength(raw) {
+  const parsed = Number(raw)
+  if (!Number.isFinite(parsed)) return null
+
+  const rounded = Math.round(parsed)
+  if (rounded < MIN_CYCLE_LENGTH || rounded > MAX_CYCLE_LENGTH) return null
+
+  return rounded
+}
+
+/**
+ * Copies through the optional enrichment fields the fallback engine also
+ * produces, dropping anything of the wrong type.
+ *
+ * These are optional by design: an ML service that only answers the three core
+ * fields is still perfectly usable, and the UI already treats every one of these
+ * as "render if present".
+ *
+ * @param {Record<string, unknown>} source
+ * @param {Record<string, unknown>} target mutated in place
+ */
+function copyOptionalPredictionFields(source, target) {
+  if (Number.isFinite(Number(source.missedCycles))) {
+    target.missedCycles = Math.max(0, Math.round(Number(source.missedCycles)))
+  }
+  if (typeof source.isStale === 'boolean') {
+    target.isStale = source.isStale
+  }
+  if (typeof source.hasEnoughRecentData === 'boolean') {
+    target.hasEnoughRecentData = source.hasEnoughRecentData
+  }
+  if (typeof source.lastLoggedDate === 'string' && source.lastLoggedDate.trim()) {
+    target.lastLoggedDate = source.lastLoggedDate.trim()
+  }
+  if (typeof source.isIrregular === 'boolean') {
+    target.isIrregular = source.isIrregular
+    target.regularityLabel = typeof source.regularityLabel === 'string' && source.regularityLabel.trim()
+      ? source.regularityLabel.trim()
+      : (source.isIrregular ? 'Irregular Cycle' : 'Regular Cycle')
+  }
+  if (Number.isFinite(Number(source.varianceStdDev))) {
+    target.varianceStdDev = Math.round(Number(source.varianceStdDev) * 10) / 10
+  }
+
+  // The window is only carried through when *both* ends are renderable dates.
+  // A half-populated range renders as "Aug 12, 2026 – undefined".
+  const window = source.predictionWindow
+  if (isPlainObject(window)) {
+    const from = normalisePredictionDate(window.from)
+    const to = normalisePredictionDate(window.to)
+    if (from && to) target.predictionWindow = { from, to }
+  }
+}
+
+/**
+ * Validates a `/predict-cycle` response body.
+ *
+ * Accepts either the enveloped form the current code expects
+ * (`{ prediction: {...} }`) or a bare prediction object, so an ML
+ * implementation is not forced into one convention.
+ *
+ * @param {unknown} raw the parsed JSON body
+ * @returns {{ok: true, value: object}|{ok: false, reason: string}}
+ */
+export function parseMlPrediction(raw) {
+  if (!isPlainObject(raw)) {
+    return { ok: false, reason: SCHEMA_REJECTIONS.NOT_AN_OBJECT }
+  }
+
+  const candidate = isPlainObject(raw.prediction) ? raw.prediction : raw
+
+  // Distinguish "wrong envelope" from "bad fields" so the log says which.
+  if (!isPlainObject(candidate)) {
+    return { ok: false, reason: SCHEMA_REJECTIONS.MISSING_ENVELOPE }
+  }
+
+  const nextPeriodDate = normalisePredictionDate(candidate.nextPeriodDate)
+  if (!nextPeriodDate) {
+    return { ok: false, reason: SCHEMA_REJECTIONS.BAD_DATE }
+  }
+
+  const confidence = normaliseConfidence(candidate.confidence)
+  if (!confidence) {
+    return { ok: false, reason: SCHEMA_REJECTIONS.BAD_CONFIDENCE }
+  }
+
+  const averageCycleLength = normaliseCycleLength(candidate.averageCycleLength)
+  if (averageCycleLength === null) {
+    return { ok: false, reason: SCHEMA_REJECTIONS.BAD_CYCLE_LENGTH }
+  }
+
+  const value = { nextPeriodDate, confidence, averageCycleLength }
+  copyOptionalPredictionFields(candidate, value)
+
+  return { ok: true, value }
+}
+
+/**
+ * Validates a `/pcod-risk` response body.
+ *
+ * Delegates the actual shape rules to {@link normaliseRiskResult}, which is
+ * already the single contract for a risk result everywhere else in the app —
+ * so an ML-sourced assessment and a locally-computed one are guaranteed to be
+ * indistinguishable downstream.
+ *
+ * @param {unknown} raw the parsed JSON body
+ * @returns {{ok: true, value: object}|{ok: false, reason: string}}
+ */
+export function parseMlRisk(raw) {
+  if (!isPlainObject(raw)) {
+    return { ok: false, reason: SCHEMA_REJECTIONS.NOT_AN_OBJECT }
+  }
+
+  const candidate = isPlainObject(raw.risk) ? raw.risk : raw
+
+  const normalised = normaliseRiskResult(candidate)
+  if (!normalised) {
+    return { ok: false, reason: SCHEMA_REJECTIONS.BAD_RISK }
+  }
+
+  // The fallback engine always supplies a recommendation, and the risk card
+  // renders it unconditionally. Fill only this one field, because unlike a
+  // score or a tier it carries no clinical claim of its own.
+  if (!normalised.recommendation) {
+    normalised.recommendation = normalised.tier === 'HIGH RISK'
+      ? 'Consider consulting with a healthcare provider for detailed assessment.'
+      : 'Keep tracking your cycle and maintaining healthy habits.'
+  }
+
+  return { ok: true, value: normalised }
+}

--- a/scripts/test-ml-client.js
+++ b/scripts/test-ml-client.js
@@ -1,0 +1,804 @@
+/**
+ * Regression suite for lib/ml-client.js and lib/ml-schemas.js — the transport
+ * policy and the response contract for the optional ML microservice.
+ *
+ * Guards the three failures that lived in the old inline `fetch()` inside
+ * lib/api-helpers.js:
+ *
+ *   1. No timeout. There was no AbortController and no signal, so an ML
+ *      container that accepted the connection and never answered left the
+ *      route's `await` pending until the platform killed the function.
+ *   2. No retry and no breaker. A single transient 502 discarded the ML result,
+ *      while a permanently dead service was re-dialled on every request.
+ *   3. No validation. `if (data && data.prediction)` accepted any truthy value,
+ *      and that value was returned verbatim to the UI.
+ *
+ * Everything here runs without a network: `fetch`, the clock, the jitter source
+ * and the backoff sleep are all injected.
+ *
+ *   node scripts/test-ml-client.js
+ */
+
+import {
+  BREAKER_CLOSED,
+  BREAKER_HALF_OPEN,
+  BREAKER_OPEN,
+  DEFAULT_ML_RETRIES,
+  DEFAULT_ML_TIMEOUT_MS,
+  MAX_ML_BACKOFF_MS,
+  ML_FAILURE_REASONS,
+  callMlService,
+  classifyMlResponse,
+  computeMlBackoffMs,
+  createCircuitBreaker,
+  isMlServiceConfigured,
+  resolveMlConfig,
+} from '../lib/ml-client.js'
+
+import {
+  SCHEMA_REJECTIONS,
+  normaliseConfidence,
+  normaliseCycleLength,
+  normalisePredictionDate,
+  parseMlPrediction,
+  parseMlRisk,
+} from '../lib/ml-schemas.js'
+
+let passed = 0
+let failed = 0
+
+function check(actual, expected, label) {
+  if (Object.is(actual, expected)) {
+    passed += 1
+    return
+  }
+  failed += 1
+  console.error(`  ❌ ${label}`)
+  console.error(`       expected: ${JSON.stringify(expected)}`)
+  console.error(`       actual:   ${JSON.stringify(actual)}`)
+}
+
+function checkDeep(actual, expected, label) {
+  const a = JSON.stringify(actual)
+  const b = JSON.stringify(expected)
+  if (a === b) {
+    passed += 1
+    return
+  }
+  failed += 1
+  console.error(`  ❌ ${label}`)
+  console.error(`       expected: ${b}`)
+  console.error(`       actual:   ${a}`)
+}
+
+function checkTrue(actual, label) {
+  check(Boolean(actual), true, label)
+}
+
+function section(name) {
+  console.log(`\n— ${name}`)
+}
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * Test doubles
+ * ────────────────────────────────────────────────────────────────────────── */
+
+/** A minimal stand-in for a fetch Response. */
+function fakeResponse(status, body) {
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    async json() {
+      if (body === '__invalid_json__') throw new SyntaxError('Unexpected token')
+      return body
+    },
+  }
+}
+
+/**
+ * Builds a fetch double that replays a scripted list of outcomes and records
+ * how many times it was called — which is how the "does not retry" assertions
+ * are made.
+ *
+ * An outcome is either a Response-alike, an Error to throw, or the string
+ * `'hang'` to never settle until the caller's signal aborts.
+ */
+function scriptedFetch(outcomes) {
+  const calls = []
+  const impl = (url, init) => {
+    calls.push({ url, init })
+    const outcome = outcomes[Math.min(calls.length - 1, outcomes.length - 1)]
+
+    if (outcome === 'hang') {
+      return new Promise((_resolve, reject) => {
+        const signal = init?.signal
+        if (!signal) return
+        if (signal.aborted) {
+          reject(Object.assign(new Error('Aborted'), { name: 'AbortError' }))
+          return
+        }
+        signal.addEventListener(
+          'abort',
+          () => reject(Object.assign(new Error('Aborted'), { name: 'AbortError' })),
+          { once: true }
+        )
+      })
+    }
+
+    if (outcome instanceof Error) return Promise.reject(outcome)
+    return Promise.resolve(outcome)
+  }
+
+  impl.calls = calls
+  return impl
+}
+
+/** Swallows the module's warn output so the suite log stays readable. */
+const quietLog = { warn() {}, debug() {} }
+
+/** Zero-delay backoff, so retry tests do not actually wait. */
+const instantSleep = async () => {}
+
+const BASE_ENV = { ML_SERVICE_URL: 'http://ml.test', ML_SERVICE_TIMEOUT_MS: '250' }
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * resolveMlConfig
+ * ────────────────────────────────────────────────────────────────────────── */
+
+section('configuration is clamped, never trusted')
+{
+  const empty = resolveMlConfig({})
+  check(empty.baseUrl, null, 'no URL configured -> baseUrl is null')
+  check(empty.timeoutMs, DEFAULT_ML_TIMEOUT_MS, 'timeout falls back to the default')
+  check(empty.retries, DEFAULT_ML_RETRIES, 'retries falls back to the default')
+  check(isMlServiceConfigured({}), false, 'isMlServiceConfigured is false with no URL')
+
+  const publicOnly = resolveMlConfig({ NEXT_PUBLIC_ML_SERVICE_URL: 'http://public.test' })
+  check(publicOnly.baseUrl, 'http://public.test', 'NEXT_PUBLIC_ML_SERVICE_URL is honoured')
+
+  const bothSet = resolveMlConfig({
+    ML_SERVICE_URL: 'http://server.test',
+    NEXT_PUBLIC_ML_SERVICE_URL: 'http://public.test',
+  })
+  check(bothSet.baseUrl, 'http://server.test', 'the server-side URL wins when both are set')
+
+  // A trailing slash plus the leading slash on the path yields `//predict-cycle`,
+  // which some routers 404 on.
+  check(
+    resolveMlConfig({ ML_SERVICE_URL: 'http://ml.test///' }).baseUrl,
+    'http://ml.test',
+    'trailing slashes are stripped from the base URL'
+  )
+  check(
+    resolveMlConfig({ ML_SERVICE_URL: '   ' }).baseUrl,
+    null,
+    'a whitespace-only URL counts as not configured'
+  )
+
+  // The point of clamping: a typo must degrade to a sane value rather than
+  // disable the timeout or spin the retry loop.
+  check(
+    resolveMlConfig({ ML_SERVICE_TIMEOUT_MS: '0' }).timeoutMs, 250,
+    'a zero timeout is clamped up, never left as "no timeout"'
+  )
+  check(
+    resolveMlConfig({ ML_SERVICE_TIMEOUT_MS: '999999' }).timeoutMs, 30000,
+    'an absurd timeout is clamped down'
+  )
+  check(
+    resolveMlConfig({ ML_SERVICE_TIMEOUT_MS: '4s' }).timeoutMs, DEFAULT_ML_TIMEOUT_MS,
+    'a non-numeric timeout falls back to the default'
+  )
+  check(
+    resolveMlConfig({ ML_SERVICE_RETRIES: '99' }).retries, 5,
+    'the retry budget is capped'
+  )
+  check(
+    resolveMlConfig({ ML_SERVICE_RETRIES: '0' }).retries, 0,
+    'retries may legitimately be disabled'
+  )
+  check(
+    resolveMlConfig({ ML_SERVICE_BREAKER_THRESHOLD: '-4' }).breakerThreshold, 1,
+    'a negative breaker threshold is clamped to 1'
+  )
+}
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * classifyMlResponse
+ * ────────────────────────────────────────────────────────────────────────── */
+
+section('response classification')
+{
+  check(classifyMlResponse(null), 'transient', 'a thrown request is transient')
+  check(classifyMlResponse(undefined), 'transient', 'an absent response is transient')
+  check(classifyMlResponse({ status: 200 }), 'success', '200 is success')
+  check(classifyMlResponse({ status: 204 }), 'success', '204 is success')
+  check(classifyMlResponse({ status: 299 }), 'success', 'the top of the 2xx range is success')
+
+  // These will not change on retry, so retrying only delays a correct fallback.
+  for (const status of [400, 401, 403, 404, 405, 409, 415, 422]) {
+    check(classifyMlResponse({ status }), 'permanent', `${status} is permanent`)
+  }
+
+  for (const status of [408, 425, 429, 500, 502, 503, 504]) {
+    check(classifyMlResponse({ status }), 'transient', `${status} is transient`)
+  }
+
+  check(classifyMlResponse({ status: 418 }), 'permanent', 'an unlisted 4xx defaults to permanent')
+  check(classifyMlResponse({ status: 302 }), 'transient', 'an unfollowed redirect is transient')
+  check(classifyMlResponse({ status: 'oops' }), 'transient', 'a non-numeric status is transient')
+}
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * computeMlBackoffMs
+ * ────────────────────────────────────────────────────────────────────────── */
+
+section('retry backoff')
+{
+  const noJitter = () => 0
+  const fullJitter = () => 1
+
+  check(computeMlBackoffMs(1, noJitter, 100), 50, 'attempt 1 floors at half the ceiling')
+  check(computeMlBackoffMs(1, fullJitter, 100), 100, 'attempt 1 tops out at the ceiling')
+  check(computeMlBackoffMs(2, noJitter, 100), 100, 'attempt 2 doubles the ceiling')
+  check(computeMlBackoffMs(3, noJitter, 100), 200, 'attempt 3 doubles again')
+
+  checkTrue(
+    computeMlBackoffMs(40, fullJitter, 100) <= MAX_ML_BACKOFF_MS,
+    'a corrupted attempt counter cannot exceed the backoff ceiling'
+  )
+  check(
+    computeMlBackoffMs(0, noJitter, 100), 50,
+    'a zero attempt count is treated as the first attempt'
+  )
+  check(
+    computeMlBackoffMs(NaN, noJitter, 100), 50,
+    'a NaN attempt count is treated as the first attempt'
+  )
+
+  // Jitter has to actually vary, or a fleet retries in lockstep.
+  const spread = new Set([0, 0.25, 0.5, 0.75, 1].map((r) => computeMlBackoffMs(2, () => r, 100)))
+  checkTrue(spread.size > 1, 'jitter produces a spread of delays, not a fixed one')
+}
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * Circuit breaker
+ * ────────────────────────────────────────────────────────────────────────── */
+
+section('circuit breaker state machine')
+{
+  const breaker = createCircuitBreaker({ threshold: 3, cooldownMs: 1000 })
+  const t0 = 1_000_000
+
+  check(breaker.state(t0), BREAKER_CLOSED, 'a fresh breaker is closed')
+  check(breaker.allowRequest(t0), true, 'a closed breaker allows requests')
+
+  breaker.onFailure(t0)
+  check(breaker.state(t0), BREAKER_CLOSED, 'one failure does not open the breaker')
+  breaker.onFailure(t0 + 1)
+  check(breaker.state(t0 + 1), BREAKER_CLOSED, 'two failures do not open the breaker')
+  breaker.onFailure(t0 + 2)
+  check(breaker.state(t0 + 2), BREAKER_OPEN, 'the threshold-th failure opens the breaker')
+  check(breaker.allowRequest(t0 + 3), false, 'an open breaker refuses requests')
+
+  // Short of the cooldown it stays open...
+  check(breaker.state(t0 + 999), BREAKER_OPEN, 'the breaker stays open during the cooldown')
+
+  // ...and reading it after the cooldown is what promotes it. No timers.
+  check(breaker.state(t0 + 1002), BREAKER_HALF_OPEN, 'the cooldown elapsing half-opens it')
+
+  check(breaker.allowRequest(t0 + 1002), true, 'half-open lets one probe through')
+  check(
+    breaker.allowRequest(t0 + 1002), false,
+    'half-open refuses a second concurrent probe — a recovering service sees one request'
+  )
+
+  // A failed probe re-opens and restarts the cooldown from the probe time.
+  breaker.onFailure(t0 + 1002)
+  check(breaker.state(t0 + 1002), BREAKER_OPEN, 'a failed probe re-opens the breaker')
+  check(
+    breaker.state(t0 + 1500), BREAKER_OPEN,
+    'the cooldown restarts from the failed probe, not from the original opening'
+  )
+  check(breaker.state(t0 + 2003), BREAKER_HALF_OPEN, 'the restarted cooldown eventually elapses')
+
+  // A successful probe closes it and forgets the failure history entirely.
+  breaker.allowRequest(t0 + 2003)
+  breaker.onSuccess()
+  check(breaker.state(t0 + 2003), BREAKER_CLOSED, 'a successful probe closes the breaker')
+  checkDeep(
+    breaker.snapshot(t0 + 2003).consecutiveFailures, 0,
+    'closing the breaker clears the failure counter'
+  )
+
+  breaker.onFailure(t0 + 3000)
+  breaker.reset()
+  check(breaker.state(t0 + 3000), BREAKER_CLOSED, 'reset() returns the breaker to closed')
+}
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * Schema: field normalisers
+ * ────────────────────────────────────────────────────────────────────────── */
+
+section('confidence normalisation')
+{
+  check(normaliseConfidence('85%'), '85%', 'a percent string passes through')
+  check(normaliseConfidence('85'), '85%', 'a bare numeric string gains the sign')
+  check(normaliseConfidence(' 85 % '), '85%', 'surrounding whitespace is tolerated')
+  check(normaliseConfidence(85), '85%', 'a number is rendered as a percentage')
+  check(normaliseConfidence(85.4), '85%', 'a fractional percentage is rounded')
+  check(normaliseConfidence(0.85), '85%', 'a 0..1 probability is scaled to a percentage')
+  check(normaliseConfidence(0), '0%', 'zero confidence is a legitimate value')
+  check(normaliseConfidence(100), '100%', 'full confidence is a legitimate value')
+
+  // Every one of these previously reached the UI and rendered as "undefined%".
+  check(normaliseConfidence(null), null, 'null is rejected')
+  check(normaliseConfidence(undefined), null, 'undefined is rejected')
+  check(normaliseConfidence(''), null, 'an empty string is rejected')
+  check(normaliseConfidence('high'), null, 'a non-numeric word is rejected')
+  check(normaliseConfidence(101), null, 'an out-of-range percentage is rejected')
+  check(normaliseConfidence(-5), null, 'a negative percentage is rejected')
+  check(normaliseConfidence(NaN), null, 'NaN is rejected')
+  check(normaliseConfidence(Infinity), null, 'Infinity is rejected')
+  check(normaliseConfidence({}), null, 'an object is rejected')
+}
+
+section('prediction date normalisation')
+{
+  check(
+    normalisePredictionDate('Aug 12, 2026'), 'Aug 12, 2026',
+    'the fallback engine\'s own format is accepted'
+  )
+  check(
+    normalisePredictionDate('2026-08-12'), '2026-08-12',
+    'an ISO date is accepted — a Python service would naturally emit this'
+  )
+  check(normalisePredictionDate('  2026-08-12  '), '2026-08-12', 'whitespace is trimmed')
+
+  // This is the payload that rendered as "Invalid Date".
+  check(normalisePredictionDate('soon'), null, 'an unparseable string is rejected')
+  check(normalisePredictionDate(''), null, 'an empty string is rejected')
+  check(normalisePredictionDate(null), null, 'null is rejected')
+  check(normalisePredictionDate(1754000000000), null, 'a raw timestamp number is rejected')
+}
+
+section('cycle length normalisation')
+{
+  check(normaliseCycleLength(28), 28, 'a typical cycle length is accepted')
+  check(normaliseCycleLength('30'), 30, 'a numeric string is coerced')
+  check(normaliseCycleLength(28.6), 29, 'a fractional length is rounded')
+  check(normaliseCycleLength(21), 21, 'the lower bound is inclusive')
+  check(normaliseCycleLength(45), 45, 'the upper bound is inclusive')
+
+  // Rejected rather than clamped: a service claiming 90 days is broken or
+  // looking at someone else's data, and clamping to 45 would hide that.
+  check(normaliseCycleLength(90), null, 'an out-of-range length is rejected, not clamped')
+  check(normaliseCycleLength(3), null, 'an implausibly short length is rejected')
+  check(normaliseCycleLength('twenty-eight'), null, 'a non-numeric length is rejected')
+  check(normaliseCycleLength(null), null, 'null is rejected')
+}
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * Schema: parseMlPrediction
+ * ────────────────────────────────────────────────────────────────────────── */
+
+section('prediction payload validation')
+{
+  const good = { nextPeriodDate: 'Aug 12, 2026', confidence: '85%', averageCycleLength: 28 }
+
+  const enveloped = parseMlPrediction({ prediction: good })
+  check(enveloped.ok, true, 'an enveloped prediction is accepted')
+  checkDeep(enveloped.value, good, 'the enveloped value is returned normalised')
+
+  const bare = parseMlPrediction(good)
+  check(bare.ok, true, 'a bare prediction object is also accepted')
+
+  // The exact values the old truthiness check let through.
+  check(parseMlPrediction('ok').ok, false, 'a string body is rejected')
+  check(parseMlPrediction('ok').reason, SCHEMA_REJECTIONS.NOT_AN_OBJECT, '…as not-an-object')
+  check(parseMlPrediction(null).ok, false, 'a null body is rejected')
+  check(parseMlPrediction([]).ok, false, 'an array body is rejected — [] is truthy')
+  check(parseMlPrediction({}).ok, false, 'an empty object is rejected')
+  check(parseMlPrediction({ prediction: {} }).ok, false, 'an empty envelope is rejected')
+
+  check(
+    parseMlPrediction({ ...good, nextPeriodDate: 'soon' }).reason,
+    SCHEMA_REJECTIONS.BAD_DATE,
+    'an unparseable date is reported as such'
+  )
+  check(
+    parseMlPrediction({ ...good, confidence: null }).reason,
+    SCHEMA_REJECTIONS.BAD_CONFIDENCE,
+    'a null confidence is reported as such'
+  )
+  check(
+    parseMlPrediction({ ...good, averageCycleLength: 0 }).reason,
+    SCHEMA_REJECTIONS.BAD_CYCLE_LENGTH,
+    'a zero cycle length is reported as such'
+  )
+  check(
+    parseMlPrediction({ nextPeriodDate: 'Aug 12, 2026', confidence: '85%' }).ok, false,
+    'a partial payload is a failure, not a result to be topped up with defaults'
+  )
+
+  // Optional enrichment fields ride along when well-formed.
+  const rich = parseMlPrediction({
+    ...good,
+    missedCycles: 2,
+    isStale: true,
+    hasEnoughRecentData: false,
+    lastLoggedDate: '2026-05-01',
+    isIrregular: true,
+    varianceStdDev: 6.44,
+    predictionWindow: { from: 'Aug 6, 2026', to: 'Aug 18, 2026' },
+  })
+  check(rich.ok, true, 'a rich payload is accepted')
+  check(rich.value.missedCycles, 2, 'missedCycles is carried through')
+  check(rich.value.isStale, true, 'isStale is carried through')
+  check(rich.value.varianceStdDev, 6.4, 'varianceStdDev is rounded to one decimal')
+  check(
+    rich.value.regularityLabel, 'Irregular Cycle',
+    'regularityLabel is derived when the service omits it'
+  )
+  checkDeep(
+    rich.value.predictionWindow, { from: 'Aug 6, 2026', to: 'Aug 18, 2026' },
+    'a complete prediction window is carried through'
+  )
+
+  // A half-populated range renders as "Aug 12, 2026 – undefined".
+  const halfWindow = parseMlPrediction({ ...good, predictionWindow: { from: 'Aug 6, 2026' } })
+  check(halfWindow.ok, true, 'a bad optional field does not invalidate the whole payload')
+  check(
+    halfWindow.value.predictionWindow, undefined,
+    'a half-populated prediction window is dropped rather than half-rendered'
+  )
+
+  const junkOptional = parseMlPrediction({ ...good, missedCycles: 'lots', isStale: 'yes' })
+  check(junkOptional.ok, true, 'wrongly-typed optional fields do not invalidate the payload')
+  check(junkOptional.value.missedCycles, undefined, 'a non-numeric missedCycles is dropped')
+  check(junkOptional.value.isStale, undefined, 'a non-boolean isStale is dropped')
+}
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * Schema: parseMlRisk
+ * ────────────────────────────────────────────────────────────────────────── */
+
+section('risk payload validation')
+{
+  const good = { score: 62, tier: 'HIGH RISK', factors: ['Irregular cycle patterns detected'] }
+
+  const enveloped = parseMlRisk({ risk: good })
+  check(enveloped.ok, true, 'an enveloped risk result is accepted')
+  check(enveloped.value.score, 62, 'the score is carried through')
+  check(enveloped.value.tier, 'HIGH RISK', 'the tier is carried through')
+  checkTrue(
+    enveloped.value.recommendation.length > 0,
+    'a missing recommendation is filled — it carries no clinical claim of its own'
+  )
+
+  check(parseMlRisk(good).ok, true, 'a bare risk object is also accepted')
+  check(
+    parseMlRisk({ score: 40, label: 'MEDIUM' }).value.tier, 'MEDIUM RISK',
+    'the legacy `label` alias is normalised onto `tier`'
+  )
+
+  check(parseMlRisk({}).ok, false, 'an empty object is rejected')
+  check(parseMlRisk({ score: 62 }).ok, false, 'a score with no tier is rejected')
+  check(parseMlRisk({ tier: 'HIGH RISK' }).ok, false, 'a tier with no score is rejected')
+  check(parseMlRisk({ score: 200, tier: 'HIGH RISK' }).ok, false, 'an out-of-range score is rejected')
+  check(parseMlRisk({ score: -1, tier: 'LOW RISK' }).ok, false, 'a negative score is rejected')
+  check(
+    parseMlRisk({ score: 40, tier: 'PROBABLY FINE' }).ok, false,
+    'an unrecognised tier is rejected rather than defaulted to LOW RISK'
+  )
+  check(parseMlRisk({ score: 62, tier: 'HIGH RISK' }).reason, undefined, 'a valid result has no reason')
+  check(
+    parseMlRisk('LOW RISK').reason, SCHEMA_REJECTIONS.NOT_AN_OBJECT,
+    'a string body is rejected as not-an-object'
+  )
+  checkDeep(
+    parseMlRisk({ score: 10, tier: 'LOW RISK', factors: ['a', 2, null, 'b'] }).value.factors,
+    ['a', 'b'],
+    'non-string factors are filtered out'
+  )
+}
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * callMlService — the end-to-end policy
+ * ────────────────────────────────────────────────────────────────────────── */
+
+async function runTransportTests() {
+  section('callMlService: the service is optional')
+  {
+    const fetchImpl = scriptedFetch([fakeResponse(200, { ok: true })])
+    const result = await callMlService('/predict-cycle', {}, {
+      env: {}, fetchImpl, log: quietLog, parse: () => ({ ok: true, value: 1 }),
+    })
+    check(result.ok, false, 'an unconfigured ML service is a clean failure, not an error')
+    check(result.reason, ML_FAILURE_REASONS.DISABLED, '…reported as `disabled`')
+    check(fetchImpl.calls.length, 0, 'no request is made when the service is not configured')
+
+    // Simulates a runtime where `globalThis.fetch` is absent (Node < 18 with no
+    // polyfill), which is what the default parameter would resolve to there.
+    const noFetch = await callMlService('/predict-cycle', {}, {
+      env: BASE_ENV, fetchImpl: null, log: quietLog, parse: () => ({ ok: true, value: 1 }),
+    })
+    check(
+      noFetch.reason, ML_FAILURE_REASONS.DISABLED,
+      'a runtime with no global fetch degrades instead of throwing a ReferenceError'
+    )
+  }
+
+  section('callMlService: happy path')
+  {
+    const good = { prediction: { nextPeriodDate: 'Aug 12, 2026', confidence: '85%', averageCycleLength: 28 } }
+    const fetchImpl = scriptedFetch([fakeResponse(200, good)])
+    const breaker = createCircuitBreaker()
+
+    const result = await callMlService('/predict-cycle', { cycle_history: [] }, {
+      env: BASE_ENV, fetchImpl, breaker, log: quietLog, parse: parseMlPrediction,
+    })
+
+    check(result.ok, true, 'a valid 2xx is used')
+    check(result.attempts, 1, 'the happy path takes exactly one attempt')
+    check(result.value.confidence, '85%', 'the validated value is returned')
+    check(fetchImpl.calls.length, 1, 'exactly one request is issued')
+    check(fetchImpl.calls[0].url, 'http://ml.test/predict-cycle', 'the URL is joined correctly')
+    check(fetchImpl.calls[0].init.method, 'POST', 'the request is a POST')
+    checkTrue(fetchImpl.calls[0].init.signal, 'every request carries an abort signal')
+    checkDeep(
+      JSON.parse(fetchImpl.calls[0].init.body), { cycle_history: [] },
+      'the payload is serialised as JSON'
+    )
+  }
+
+  section('callMlService: a hanging service is bounded by the timeout')
+  {
+    // The original bug: no AbortController meant this await never settled.
+    const fetchImpl = scriptedFetch(['hang'])
+    const breaker = createCircuitBreaker()
+    const started = Date.now()
+
+    const result = await callMlService('/predict-cycle', {}, {
+      env: { ...BASE_ENV, ML_SERVICE_RETRIES: '0' },
+      fetchImpl, breaker, log: quietLog, sleep: instantSleep, parse: parseMlPrediction,
+    })
+    const elapsed = Date.now() - started
+
+    check(result.ok, false, 'a hanging service fails rather than hanging the route')
+    check(result.reason, ML_FAILURE_REASONS.TIMEOUT, '…reported as a timeout')
+    checkTrue(elapsed < 3000, `the call returned in ${elapsed}ms rather than hanging`)
+  }
+
+  section('callMlService: transient faults are retried')
+  {
+    const good = { risk: { score: 30, tier: 'MEDIUM RISK', factors: [] } }
+    const fetchImpl = scriptedFetch([fakeResponse(502, null), fakeResponse(200, good)])
+    const breaker = createCircuitBreaker()
+
+    const result = await callMlService('/pcod-risk', {}, {
+      env: BASE_ENV, fetchImpl, breaker, log: quietLog, sleep: instantSleep, parse: parseMlRisk,
+    })
+
+    check(result.ok, true, 'a 502 followed by a 200 succeeds on the retry')
+    check(result.attempts, 2, 'it took two attempts')
+    check(fetchImpl.calls.length, 2, 'two requests were issued')
+    check(breaker.snapshot(0).consecutiveFailures, 0, 'a recovered call leaves the breaker clean')
+  }
+
+  section('callMlService: the retry budget is finite')
+  {
+    const fetchImpl = scriptedFetch([fakeResponse(503, null)])
+    const breaker = createCircuitBreaker()
+
+    const result = await callMlService('/pcod-risk', {}, {
+      env: { ...BASE_ENV, ML_SERVICE_RETRIES: '2' },
+      fetchImpl, breaker, log: quietLog, sleep: instantSleep, parse: parseMlRisk,
+    })
+
+    check(result.ok, false, 'a persistently failing service gives up')
+    check(result.reason, ML_FAILURE_REASONS.TRANSIENT, '…reported as transient')
+    check(fetchImpl.calls.length, 3, 'retries=2 means three attempts, not an unbounded loop')
+  }
+
+  section('callMlService: network errors are transient')
+  {
+    const fetchImpl = scriptedFetch([new TypeError('fetch failed'), fakeResponse(200, {
+      prediction: { nextPeriodDate: '2026-08-12', confidence: 90, averageCycleLength: 29 },
+    })])
+    const result = await callMlService('/predict-cycle', {}, {
+      env: BASE_ENV, fetchImpl, breaker: createCircuitBreaker(), log: quietLog,
+      sleep: instantSleep, parse: parseMlPrediction,
+    })
+
+    check(result.ok, true, 'a thrown fetch is retried and can still succeed')
+    check(result.value.confidence, '90%', 'a numeric confidence is normalised on the way out')
+  }
+
+  section('callMlService: permanent rejections are not retried')
+  {
+    for (const status of [400, 401, 404, 422]) {
+      const fetchImpl = scriptedFetch([fakeResponse(status, { error: 'nope' })])
+      const result = await callMlService('/pcod-risk', {}, {
+        env: { ...BASE_ENV, ML_SERVICE_RETRIES: '3' },
+        fetchImpl, breaker: createCircuitBreaker(), log: quietLog,
+        sleep: instantSleep, parse: parseMlRisk,
+      })
+
+      check(result.reason, ML_FAILURE_REASONS.PERMANENT, `${status} fails as permanent`)
+      check(result.status, status, `${status} is reported on the result`)
+      check(fetchImpl.calls.length, 1, `${status} is not retried — retrying only delays the fallback`)
+    }
+  }
+
+  section('callMlService: an unusable 2xx body is not retried either')
+  {
+    // A 200 the schema rejects is the service's answer, not a connection fault.
+    const fetchImpl = scriptedFetch([fakeResponse(200, { prediction: 'looks fine to me' })])
+    const breaker = createCircuitBreaker()
+
+    const result = await callMlService('/predict-cycle', {}, {
+      env: { ...BASE_ENV, ML_SERVICE_RETRIES: '3' },
+      fetchImpl, breaker, log: quietLog, sleep: instantSleep, parse: parseMlPrediction,
+    })
+
+    check(result.ok, false, 'a 200 with an unusable body does not become a result')
+    check(result.reason, ML_FAILURE_REASONS.INVALID_RESPONSE, '…reported as an invalid response')
+    check(fetchImpl.calls.length, 1, 'retrying would return the same body, so it is not retried')
+    check(
+      breaker.snapshot(0).consecutiveFailures, 1,
+      'a service emitting garbage still counts as unhealthy'
+    )
+  }
+
+  section('callMlService: a 200 carrying HTML does not crash the route')
+  {
+    // An ingress error page or a followed login redirect is a real shape.
+    const fetchImpl = scriptedFetch([fakeResponse(200, '__invalid_json__')])
+    const result = await callMlService('/predict-cycle', {}, {
+      env: BASE_ENV, fetchImpl, breaker: createCircuitBreaker(), log: quietLog,
+      sleep: instantSleep, parse: parseMlPrediction,
+    })
+    check(result.reason, ML_FAILURE_REASONS.INVALID_RESPONSE, 'an unparseable body is an invalid response')
+  }
+
+  section('callMlService: the breaker short-circuits a dead service')
+  {
+    const fetchImpl = scriptedFetch([fakeResponse(500, null)])
+    const breaker = createCircuitBreaker({ threshold: 2, cooldownMs: 1000 })
+    let clock = 5_000_000
+    const now = () => clock
+    const opts = {
+      env: { ...BASE_ENV, ML_SERVICE_RETRIES: '0' },
+      fetchImpl, breaker, now, log: quietLog, sleep: instantSleep, parse: parseMlPrediction,
+    }
+
+    const first = await callMlService('/predict-cycle', {}, opts)
+    check(first.reason, ML_FAILURE_REASONS.TRANSIENT, 'the first failure goes to the wire')
+    const second = await callMlService('/predict-cycle', {}, opts)
+    check(second.reason, ML_FAILURE_REASONS.TRANSIENT, 'the second failure goes to the wire')
+    check(fetchImpl.calls.length, 2, 'two requests reached the service')
+
+    const third = await callMlService('/predict-cycle', {}, opts)
+    check(third.reason, ML_FAILURE_REASONS.CIRCUIT_OPEN, 'the third call is short-circuited')
+    check(third.attempts, 0, 'a short-circuited call makes no attempt')
+    check(
+      fetchImpl.calls.length, 2,
+      'a dead service costs nothing per request once the breaker is open'
+    )
+
+    // After the cooldown a single probe is allowed through.
+    clock += 1500
+    const probe = await callMlService('/predict-cycle', {}, opts)
+    check(probe.reason, ML_FAILURE_REASONS.TRANSIENT, 'the half-open probe reaches the service')
+    check(fetchImpl.calls.length, 3, 'exactly one probe was issued')
+
+    // A failed probe re-opens, so the next call is short-circuited again.
+    const afterProbe = await callMlService('/predict-cycle', {}, opts)
+    check(afterProbe.reason, ML_FAILURE_REASONS.CIRCUIT_OPEN, 'a failed probe re-opens the breaker')
+  }
+
+  section('callMlService: a recovered service closes the breaker')
+  {
+    const good = { prediction: { nextPeriodDate: 'Aug 12, 2026', confidence: '85%', averageCycleLength: 28 } }
+    const fetchImpl = scriptedFetch([
+      fakeResponse(500, null), fakeResponse(500, null), fakeResponse(200, good),
+    ])
+    const breaker = createCircuitBreaker({ threshold: 2, cooldownMs: 1000 })
+    let clock = 7_000_000
+    const opts = {
+      env: { ...BASE_ENV, ML_SERVICE_RETRIES: '0' },
+      fetchImpl, breaker, now: () => clock, log: quietLog, sleep: instantSleep,
+      parse: parseMlPrediction,
+    }
+
+    await callMlService('/predict-cycle', {}, opts)
+    await callMlService('/predict-cycle', {}, opts)
+    check(breaker.state(clock), BREAKER_OPEN, 'the breaker opened')
+
+    clock += 1500
+    const recovered = await callMlService('/predict-cycle', {}, opts)
+    check(recovered.ok, true, 'the probe succeeded')
+    check(breaker.state(clock), BREAKER_CLOSED, 'a successful probe closes the breaker')
+  }
+}
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * predictNextPeriod / calculatePCODRisk — the callers still fall back
+ * ────────────────────────────────────────────────────────────────────────── */
+
+async function runCallerTests() {
+  const { predictNextPeriod, calculatePCODRisk } = await import('../lib/api-helpers.js')
+
+  section('api-helpers falls back to the rule-based engine')
+  {
+    const history = [
+      { start_date: '2026-05-01', cycle_length: 28 },
+      { start_date: '2026-05-29', cycle_length: 28 },
+      { start_date: '2026-06-26', cycle_length: 28 },
+    ]
+
+    // A dead service must still produce a real, correct prediction.
+    const dead = scriptedFetch([fakeResponse(503, null)])
+    const prediction = await predictNextPeriod(history, new Date('2026-07-01T12:00:00Z'), {
+      env: { ...BASE_ENV, ML_SERVICE_RETRIES: '0' },
+      fetchImpl: dead, breaker: createCircuitBreaker(), log: quietLog, sleep: instantSleep,
+    })
+    check(prediction.averageCycleLength, 28, 'the fallback engine still computes a cycle length')
+    checkTrue(prediction.nextPeriodDate.length > 0, 'the fallback engine still names a date')
+    checkTrue(/^\d{1,3}%$/.test(prediction.confidence), 'the fallback confidence is well-formed')
+
+    // The unvalidated-payload bug: this used to be returned verbatim.
+    const garbage = scriptedFetch([fakeResponse(200, { prediction: { confidence: null } })])
+    const fromGarbage = await predictNextPeriod(history, new Date('2026-07-01T12:00:00Z'), {
+      env: BASE_ENV, fetchImpl: garbage, breaker: createCircuitBreaker(),
+      log: quietLog, sleep: instantSleep,
+    })
+    check(
+      fromGarbage.confidence === null, false,
+      'a malformed ML payload never reaches the caller — the fallback answers instead'
+    )
+    check(fromGarbage.averageCycleLength, 28, 'the fallback prediction is complete')
+
+    // A valid ML payload is preferred over the fallback.
+    const mlGood = scriptedFetch([fakeResponse(200, {
+      prediction: { nextPeriodDate: 'Sep 01, 2026', confidence: '91%', averageCycleLength: 30 },
+    })])
+    const fromMl = await predictNextPeriod(history, new Date('2026-07-01T12:00:00Z'), {
+      env: BASE_ENV, fetchImpl: mlGood, breaker: createCircuitBreaker(),
+      log: quietLog, sleep: instantSleep,
+    })
+    check(fromMl.confidence, '91%', 'a valid ML prediction is preferred over the fallback')
+    check(fromMl.averageCycleLength, 30, '…including its cycle length')
+
+    const riskDead = scriptedFetch([new TypeError('fetch failed')])
+    const risk = await calculatePCODRisk(history, ['acne', 'fatigue'], {
+      env: { ...BASE_ENV, ML_SERVICE_RETRIES: '0' },
+      fetchImpl: riskDead, breaker: createCircuitBreaker(), log: quietLog, sleep: instantSleep,
+    })
+    checkTrue(['LOW RISK', 'MEDIUM RISK', 'HIGH RISK'].includes(risk.tier), 'the fallback risk tier is real')
+    checkTrue(Number.isFinite(risk.score), 'the fallback risk score is numeric')
+
+    const riskMl = scriptedFetch([fakeResponse(200, { risk: { score: 71, tier: 'HIGH RISK', factors: ['x'] } })])
+    const mlRisk = await calculatePCODRisk(history, ['acne'], {
+      env: BASE_ENV, fetchImpl: riskMl, breaker: createCircuitBreaker(),
+      log: quietLog, sleep: instantSleep,
+    })
+    check(mlRisk.score, 71, 'a valid ML risk result is preferred over the fallback')
+    check(mlRisk.tier, 'HIGH RISK', '…including its tier')
+  }
+}
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * Run
+ * ────────────────────────────────────────────────────────────────────────── */
+
+await runTransportTests()
+await runCallerTests()
+
+console.log('')
+if (failed > 0) {
+  console.error(`❌ ${failed} ML client assertion(s) failed (${passed} passed).`)
+  process.exit(1)
+}
+console.log(`✅ All ${passed} ML client assertions passed.`)


### PR DESCRIPTION
## Linked Issue
Fixes #492

## Description

The ML microservice path in `lib/api-helpers.js` was six lines of bare `fetch()` shared by both `predictNextPeriod()` and `calculatePCODRisk()`, and it carried three separate faults.

**No timeout.** There was no `AbortController` and no `signal`. An ML container that accepts the TCP connection and then never writes a byte — an OOM, a deadlock, a paused task — left that `await` pending forever, so `/api/predict-cycle` and `/api/pcod-risk` hung until the platform killed the function. A correct rule-based answer was available on the very next line the whole time.

**No retry, and no breaker.** A single transient 502 threw the ML result away entirely. At the other extreme, a permanently dead service was re-dialled on every single request, so every prediction paid the full connect-and-fail cost before falling back. Both ends of that are wrong.

**No validation.** `if (data && data.prediction)` was the only check. The string `"ok"`, an empty object, and `{ confidence: null }` all pass it, and whatever passed was returned straight out of the route into `PredictionCard` — which renders `confidence` and `nextPeriodDate` directly, producing `undefined%` next to `Invalid Date`. The same held for the PCOD risk payload that users are told to show a clinician.

### What this changes

Two new modules and a rewire. No behavioural change when the ML service is healthy, and no change to the public return shape of either helper.

**`lib/ml-client.js`** — the transport policy:

| condition | classification | effect |
|---|---|---|
| 2xx with a schema-valid body | `success` | use the ML result |
| 2xx with a body the schema rejects | `invalid` | fall back, do **not** retry |
| 400, 401, 403, 404, 409, 422 | `permanent` | fall back, do **not** retry |
| 408, 425, 429, 5xx, network error, timeout | `transient` | retry with jittered backoff |

Not retrying `permanent` and `invalid` is the point: those answers do not change on a second attempt, so retrying only adds latency to a fallback that was already correct.

Consecutive failures trip a three-state circuit breaker. While it is open, calls short-circuit immediately — which turns a dead ML service from "every request is slow" into "every request is fast and rule-based". After a cooldown it half-opens and lets exactly **one** probe through, so a recovering service does not get the full request volume the instant the cooldown expires.

Every knob is read from the environment and clamped rather than trusted, so `ML_SERVICE_TIMEOUT_MS=0` degrades to the minimum instead of disabling the timeout:

| Variable | Default | Range |
|---|---|---|
| `ML_SERVICE_TIMEOUT_MS` | 4000 | 250 – 30000 |
| `ML_SERVICE_RETRIES` | 1 | 0 – 5 |
| `ML_SERVICE_BREAKER_THRESHOLD` | 3 | 1 – 50 |
| `ML_SERVICE_BREAKER_COOLDOWN_MS` | 30000 | 1000 – 600000 |

None of them are required. With no `ML_SERVICE_URL` set — the default deployment — the client returns `disabled` without issuing a request, exactly as before.

**`lib/ml-schemas.js`** — the response contract. Strict on purpose: a partial payload is a failure, not something to top up with defaults, because filling in a missing `confidence` would manufacture a number neither engine computed. Rejecting costs nothing since the fallback is always available.

It is lenient about *format* where that is genuinely ambiguous — `confidence` is accepted as `"85%"`, `"85"`, `85` or `0.85`, since a Python service naturally emits the last of those — and it accepts both the enveloped `{ prediction: {...} }` and a bare object. The risk parser delegates to the existing `normaliseRiskResult()`, so an ML-sourced assessment and a locally-computed one are indistinguishable downstream.

**`lib/api-helpers.js`** — `predictNextPeriod` and `calculatePCODRisk` now call `callMlService()` and fall back on any non-`ok` result. Both gained an optional third `options` argument used only as a test seam; every existing call site passes two arguments and is unaffected. The `disabled` and `circuit_open` reasons are deliberately not logged — they are the steady state of a deployment without an ML service, and logging them would emit a line per request.

The contract throughout: **the ML service is an optimisation, never a correctness dependency.** Nothing in the new client throws, and every failure path ends at the deterministic rule-based engine.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (clean code updates, no behavior modifications)
- [ ] Documentation update
- [x] Performance optimization
- [ ] Security patch

## Files Modified

| File | Change |
|---|---|
| `lib/ml-client.js` | **new** — timeout, retry policy, backoff, circuit breaker, env config |
| `lib/ml-schemas.js` | **new** — validation and normalisation of both ML response shapes |
| `lib/api-helpers.js` | rewired both ML entry points; removed the inline `fetch` blocks |
| `scripts/test-ml-client.js` | **new** — 197-assertion regression suite |

## Testing

```
node scripts/test-ml-client.js     # ✅ All 197 ML client assertions passed.
npm run test:e2e                   # ✅ 7 / 7 suites passed
npm run build                      # ✅ compiled successfully
```

The suite runs with no network at all — `fetch`, the clock, the jitter source and the backoff sleep are injected. Coverage:

- **Timeout.** A fetch double that hangs until its signal aborts; asserts the call returns in well under the old unbounded behaviour and reports `timeout`. This is the regression test for the original bug.
- **Retry.** 502-then-200 succeeds on the second attempt; `retries=2` issues exactly three requests and no more.
- **No-retry paths.** 400/401/404/422 and an unusable 2xx body each issue exactly **one** request — asserted by call count, not by timing.
- **Breaker.** Full state machine: closed → open at the threshold, short-circuits with zero attempts, half-opens after the cooldown, allows exactly one concurrent probe, re-opens and restarts the cooldown on a failed probe, closes on a successful one.
- **Schema.** Every value the old truthiness check let through (`"ok"`, `[]`, `{}`, `{ confidence: null }`) is rejected; partial payloads are rejected; a half-populated `predictionWindow` is dropped rather than half-rendered; a 200 carrying HTML is an invalid response rather than a crash.
- **Callers.** `predictNextPeriod` and `calculatePCODRisk` return a complete, correct rule-based result when the service is dead *and* when it returns garbage, and prefer a valid ML result when it is healthy.

Also re-ran the neighbouring suites: `test-stale-prediction.js`, `test-prediction-bug.js` and `test-pcod-risk-result.js` all pass. `test-invalid-dates.js`, `test-pcod-recurrence.js` and `test-date-utils.js` fail identically on `main` before this branch — those are pre-existing and untouched here.

## Screenshots (if UI changes are made)
N/A — backend only, no UI modifications.

## Checklist
- [x] This PR is submitted under ECSOC.
- [x] Added the required **ECSoc26** label to this Pull Request.
- [x] Linked issue using `Fixes #492`.
- [x] Tested locally.
- [x] `npm run build` completes successfully.
- [x] `npm run test:e2e` passes (7/7).
- [x] No breaking changes introduced.
- [x] New behaviour documented in module docstrings.
