### PR TITLE
[ECSoC26] fix(community): search the whole forum and page through its history

### DIFF
--- a/app/[locale]/community/page.jsx
+++ b/app/[locale]/community/page.jsx
@@ -4,6 +4,7 @@ import { getSupabaseAdmin } from '@/lib/supabase-admin';
 import Navbar from '@/components/layout/Navbar';
 import Footer from '@/components/layout/Footer';
 import CommunityFeed from '@/components/community/CommunityFeed';
+import { DEFAULT_PAGE_SIZE, buildFeedPage } from '@/lib/forum-query';
 
 export const revalidate = 60; // Revalidate every minute
 
@@ -12,11 +13,27 @@ export default async function CommunityPage({ params }) {
   const t = await getTranslations('Community');
   const supabase = getSupabaseAdmin();
 
-  // Fetch categories and recent posts
+  // Fetch categories and the first page of posts.
+  //
+  // `DEFAULT_PAGE_SIZE + 1` mirrors what `GET /api/forum/posts` does: the extra
+  // row is how "is there more?" is answered without a second count query, and
+  // `buildFeedPage` trims it off. Sharing the helper is what stops the
+  // server-rendered first page and the client's subsequent pages from drifting
+  // apart — the previous hard-coded `.limit(20)` here was the reason the feed
+  // could not page at all.
   const [{ data: categories }, { data: posts }] = await Promise.all([
     supabase.from('forum_categories').select('*').order('name'),
-    supabase.from('forum_posts').select('*').order('created_at', { ascending: false }).limit(20)
+    supabase
+      .from('forum_posts')
+      .select('id, category_id, author_alias, title, content, upvotes, created_at')
+      .order('created_at', { ascending: false })
+      // `created_at` is not unique, so the id tie-break is what keeps the
+      // boundary between this page and the next one stable.
+      .order('id', { ascending: false })
+      .limit(DEFAULT_PAGE_SIZE + 1),
   ]);
+
+  const firstPage = buildFeedPage(posts, DEFAULT_PAGE_SIZE);
 
   return (
     <div className="page">
@@ -32,7 +49,13 @@ export default async function CommunityPage({ params }) {
         </p>
       </div>
 
-      <CommunityFeed locale={locale} initialCategories={categories || []} initialPosts={posts || []} />
+      <CommunityFeed
+        locale={locale}
+        initialCategories={categories || []}
+        initialPosts={firstPage.posts}
+        initialNextCursor={firstPage.nextCursor}
+        initialHasMore={firstPage.hasMore}
+      />
       </div>
       <Footer />
     </div>

--- a/app/api/forum/posts/route.js
+++ b/app/api/forum/posts/route.js
@@ -4,6 +4,103 @@ import { moderateContent } from '@/lib/ai-moderation';
 import { generateAlias } from '@/lib/alias-generator';
 import { getSupabaseAdmin } from '@/lib/supabase-admin';
 import { crudLimiter } from '@/lib/rateLimiter';
+import { logger } from '@/lib/logger';
+import {
+  buildCursorFilter,
+  buildFeedPage,
+  buildSearchFilter,
+  parseFeedQuery,
+} from '@/lib/forum-query';
+
+/**
+ * GET /api/forum/posts
+ *
+ * Paged, searchable, filterable read of the forum.
+ *
+ * This route did not exist. `app/[locale]/community/page.jsx` queried Supabase
+ * inline with a hard `.limit(20)` and the feed filtered *that slice* in the
+ * browser — so the search box searched twenty rows rather than the forum, and
+ * every post older than the newest twenty was unreachable through the UI.
+ *
+ * Query parameters (all optional, all clamped in `lib/forum-query.js`):
+ *
+ *   q           search text, matched against title and body
+ *   categoryId  category slug or id
+ *   sort        `newest` (default) | `oldest`
+ *   limit       1..50, default 20
+ *   cursor      opaque keyset cursor from a previous response
+ *
+ * Responds `{ success, posts, nextCursor, hasMore }`.
+ *
+ * Posts are public, anonymous and already moderated at write time, so this is
+ * deliberately readable without auth — the same access the server-rendered page
+ * always had. It is still rate limited, because an unauthenticated `ilike` scan
+ * is the most expensive query in the app.
+ */
+export async function GET(req) {
+  try {
+    await crudLimiter.check(req);
+  } catch (rateLimitError) {
+    logger.warn(`[Rate Limit] Forum posts GET: ${rateLimitError.message}`);
+    return NextResponse.json(
+      { success: false, error: 'Too many requests, please slow down.' },
+      { status: 429 }
+    );
+  }
+
+  try {
+    const { searchParams } = new URL(req.url);
+    const query = parseFeedQuery(searchParams);
+    const supabase = getSupabaseAdmin();
+
+    // The feed links to categories by slug while `forum_posts.category_id`
+    // stores the id, so accept either and resolve here rather than forcing the
+    // client to know which one it holds.
+    let categoryId = query.categoryId;
+    if (categoryId) {
+      const { data: category } = await supabase
+        .from('forum_categories')
+        .select('id')
+        .or(`id.eq."${categoryId}",slug.eq."${categoryId}"`)
+        .maybeSingle();
+
+      if (!category) {
+        // An unknown category is an empty feed, not an error: a stale bookmark
+        // should render "no posts here" rather than a failure state.
+        return NextResponse.json({ success: true, posts: [], nextCursor: null, hasMore: false });
+      }
+      categoryId = category.id;
+    }
+
+    let builder = supabase
+      .from('forum_posts')
+      .select('id, category_id, author_alias, title, content, upvotes, created_at')
+      .order('created_at', { ascending: query.ascending })
+      // `created_at` is not unique — a seed script can write several rows in the
+      // same millisecond — so the id tie-break is what makes paging stable.
+      .order('id', { ascending: query.ascending })
+      // One more row than asked for: its presence is how `hasMore` is answered
+      // without a second count query, which on a filtered ilike scan costs as
+      // much again as the page itself.
+      .limit(query.limit + 1);
+
+    if (categoryId) builder = builder.eq('category_id', categoryId);
+    if (query.search) builder = builder.or(buildSearchFilter(query.search));
+    if (query.cursor) builder = builder.or(buildCursorFilter(query.cursor, query.ascending));
+
+    const { data, error } = await builder;
+
+    if (error) {
+      logger.error(`Database error listing forum posts: ${error.message}`);
+      return NextResponse.json({ success: false, error: 'Failed to load posts' }, { status: 500 });
+    }
+
+    return NextResponse.json({ success: true, ...buildFeedPage(data, query.limit) });
+  } catch (error) {
+    logger.error(`Forum posts GET error: ${error.message || error}`);
+    return NextResponse.json({ success: false, error: 'Internal server error' }, { status: 500 });
+  }
+}
 
 export async function POST(req) {
   // ============ RATE LIMITING ============

--- a/components/community/CommunityFeed.jsx
+++ b/components/community/CommunityFeed.jsx
@@ -1,35 +1,180 @@
 'use client';
 
+/**
+ * CommunityFeed — the paging, server-searched forum feed.
+ *
+ * The previous version received a fixed 20-row array and filtered it in the
+ * browser, which made the search box search twenty rows rather than the forum
+ * and left every older post unreachable. Search, category filtering, sorting
+ * and paging now all happen in `GET /api/forum/posts`.
+ *
+ * The component keeps the server-rendered first page as its initial state, so
+ * the feed still paints instantly and without JavaScript — the network is only
+ * touched once the user actually searches, filters, sorts or pages.
+ */
+
 import Link from 'next/link';
-import { useMemo, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslations } from 'next-intl';
-import { Users, Hash, Search } from 'lucide-react';
+import { Users, Hash, Search, Loader2, AlertCircle, X } from 'lucide-react';
 import PostCard from '@/components/community/PostCard';
+import fetchWithTimeout from '@/lib/fetch-with-timeout';
+import {
+  DEFAULT_PAGE_SIZE,
+  MIN_SEARCH_LENGTH,
+  SORT_NEWEST,
+  SORT_OLDEST,
+  normaliseSearchTerm,
+  toQueryString,
+} from '@/lib/forum-query';
 
-export default function CommunityFeed({ locale, initialCategories = [], initialPosts = [] }) {
+/**
+ * How long to wait after the last keystroke before querying.
+ *
+ * Long enough that typing a word is one request rather than eight, short enough
+ * that it still feels like search-as-you-type.
+ */
+const SEARCH_DEBOUNCE_MS = 350;
+
+export default function CommunityFeed({
+  locale,
+  initialCategories = [],
+  initialPosts = [],
+  initialNextCursor = null,
+  initialHasMore = false,
+}) {
   const t = useTranslations('Community');
-  const [searchTerm, setSearchTerm] = useState('');
 
-  const filteredPosts = useMemo(() => {
-    const normalizedSearch = searchTerm.trim().toLowerCase();
+  const [searchInput, setSearchInput] = useState('');
+  const [activeSearch, setActiveSearch] = useState(null);
+  const [categoryId, setCategoryId] = useState(null);
+  const [sort, setSort] = useState(SORT_NEWEST);
 
-    if (!normalizedSearch) {
-      return initialPosts;
+  const [posts, setPosts] = useState(initialPosts);
+  const [nextCursor, setNextCursor] = useState(initialNextCursor);
+  const [hasMore, setHasMore] = useState(initialHasMore);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isPagingMore, setIsPagingMore] = useState(false);
+  const [error, setError] = useState(null);
+
+  // True until the first user-driven query. While it holds, `posts` is still
+  // the server-rendered page, which must not be replaced by a spinner.
+  const isPristine = activeSearch === null && categoryId === null && sort === SORT_NEWEST;
+
+  // Guards against an out-of-order response overwriting a newer one: typing
+  // "pcod" quickly can leave a request for "pco" in flight behind it, and
+  // without this the slower, staler response wins.
+  const requestIdRef = useRef(0);
+
+  const fetchPage = useCallback(async ({ cursor = null, append = false, search, category, order }) => {
+    const requestId = requestIdRef.current + 1;
+    requestIdRef.current = requestId;
+
+    if (append) setIsPagingMore(true);
+    else setIsLoading(true);
+    setError(null);
+
+    try {
+      const qs = toQueryString({
+        search,
+        categoryId: category,
+        sort: order,
+        limit: DEFAULT_PAGE_SIZE,
+        cursor,
+      });
+      const res = await fetchWithTimeout(`/api/forum/posts${qs ? `?${qs}` : ''}`);
+      const data = await res.json();
+
+      // A newer request has already been issued; this answer is stale.
+      if (requestIdRef.current !== requestId) return;
+
+      if (!res.ok || !data.success) {
+        throw new Error(data.error || 'Failed to load discussions');
+      }
+
+      setPosts((prev) => (append ? [...prev, ...data.posts] : data.posts));
+      setNextCursor(data.nextCursor);
+      setHasMore(Boolean(data.hasMore));
+    } catch (err) {
+      if (requestIdRef.current !== requestId) return;
+      setError(err.message || 'Failed to load discussions');
+      // On a failed "load more" the already-visible posts are deliberately
+      // kept: dropping them would punish the user for a transient network
+      // error by throwing away everything they had scrolled through.
+      if (!append) {
+        setPosts([]);
+        setNextCursor(null);
+        setHasMore(false);
+      }
+    } finally {
+      if (requestIdRef.current === requestId) {
+        setIsLoading(false);
+        setIsPagingMore(false);
+      }
+    }
+  }, []);
+
+  /* ── Debounced search ─────────────────────────────────────────────────── */
+  useEffect(() => {
+    const normalised = normaliseSearchTerm(searchInput);
+
+    // Nothing has changed in a way the server would answer differently.
+    if (normalised === activeSearch) return undefined;
+
+    const timer = setTimeout(() => {
+      setActiveSearch(normalised);
+    }, SEARCH_DEBOUNCE_MS);
+
+    return () => clearTimeout(timer);
+  }, [searchInput, activeSearch]);
+
+  /* ── Query on every criteria change ───────────────────────────────────── */
+  const didMountRef = useRef(false);
+  useEffect(() => {
+    // Skip the first run: the server already rendered exactly this page, and
+    // re-fetching it would flash a spinner over content that is already correct.
+    if (!didMountRef.current) {
+      didMountRef.current = true;
+      return;
     }
 
-    return initialPosts.filter((post) => {
-      const title = (post.title || '').toLowerCase();
-      const content = (post.content || '').toLowerCase();
-      return title.includes(normalizedSearch) || content.includes(normalizedSearch);
+    fetchPage({ search: activeSearch, category: categoryId, order: sort });
+  }, [activeSearch, categoryId, sort, fetchPage]);
+
+  const handleLoadMore = () => {
+    if (!nextCursor || isPagingMore) return;
+    fetchPage({
+      cursor: nextCursor,
+      append: true,
+      search: activeSearch,
+      category: categoryId,
+      order: sort,
     });
-  }, [initialPosts, searchTerm]);
+  };
+
+  const handleClearSearch = () => {
+    setSearchInput('');
+    setActiveSearch(null);
+  };
+
+  const activeCategory = initialCategories.find((category) => category.id === categoryId);
+
+  // A term long enough to type but shorter than the minimum would otherwise
+  // look like a search returning nothing.
+  const searchTooShort =
+    searchInput.trim().length > 0 && searchInput.trim().length < MIN_SEARCH_LENGTH;
+
+  const isFiltering = Boolean(activeSearch || categoryId);
+  const showEmptyState = !isLoading && posts.length === 0;
 
   return (
     <div className="grid grid-cols-1 lg:grid-cols-4 gap-8">
       <div className="lg:col-span-3">
         <div className="flex items-center justify-between mb-4 gap-3 flex-wrap">
           <h2 className="text-xl font-semibold text-slate-900 dark:text-white">
-            {t('recent_discussions') || 'Recent Discussions'}
+            {activeCategory
+              ? (t(`cat_${activeCategory.slug}_name`) || activeCategory.name)
+              : (t('recent_discussions') || 'Recent Discussions')}
           </h2>
           <Link
             href={`/${locale}/community/new`}
@@ -39,56 +184,162 @@ export default function CommunityFeed({ locale, initialCategories = [], initialP
           </Link>
         </div>
 
-        <div className="mb-6">
-          <label htmlFor="community-search" className="sr-only">
-            {t('search_posts') || 'Search discussions'}
-          </label>
-          <div className="relative">
-            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-slate-400" />
+        <div className="mb-6 flex flex-col sm:flex-row gap-3">
+          <div className="relative flex-1">
+            <label htmlFor="community-search" className="sr-only">
+              {t('search_posts') || 'Search discussions'}
+            </label>
+            <Search
+              className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-slate-400"
+              aria-hidden="true"
+            />
             <input
               id="community-search"
-              type="text"
-              value={searchTerm}
-              onChange={(event) => setSearchTerm(event.target.value)}
+              type="search"
+              value={searchInput}
+              onChange={(event) => setSearchInput(event.target.value)}
               placeholder={t('search_posts') || 'Search discussions'}
-              className="w-full rounded-xl border border-slate-200 bg-white py-3 pl-10 pr-4 text-sm text-slate-700 shadow-sm outline-none transition focus:border-pink-400 focus:ring-2 focus:ring-pink-500/20 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200"
+              aria-describedby="community-search-hint"
+              className="w-full rounded-xl border border-slate-200 bg-white py-3 pl-10 pr-10 text-sm text-slate-700 shadow-sm outline-none transition focus:border-pink-400 focus:ring-2 focus:ring-pink-500/20 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200"
             />
+            {searchInput && (
+              <button
+                type="button"
+                onClick={handleClearSearch}
+                aria-label={t('clear_search') || 'Clear search'}
+                className="absolute right-3 top-1/2 -translate-y-1/2 rounded-full p-0.5 text-slate-400 transition hover:text-slate-600 dark:hover:text-slate-200"
+              >
+                <X className="h-4 w-4" aria-hidden="true" />
+              </button>
+            )}
+          </div>
+
+          <div>
+            <label htmlFor="community-sort" className="sr-only">
+              {t('sort_label') || 'Sort discussions'}
+            </label>
+            <select
+              id="community-sort"
+              value={sort}
+              onChange={(event) => setSort(event.target.value)}
+              className="w-full sm:w-auto rounded-xl border border-slate-200 bg-white py-3 px-4 text-sm text-slate-700 shadow-sm outline-none transition focus:border-pink-400 focus:ring-2 focus:ring-pink-500/20 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200"
+            >
+              <option value={SORT_NEWEST}>{t('sort_newest') || 'Newest first'}</option>
+              <option value={SORT_OLDEST}>{t('sort_oldest') || 'Oldest first'}</option>
+            </select>
           </div>
         </div>
 
+        {/* One live region for every status message, present from first render:
+            a container that appears at the same moment as its text is often not
+            announced at all. */}
+        <p
+          id="community-search-hint"
+          role="status"
+          aria-live="polite"
+          className="mb-4 text-xs text-slate-500 dark:text-slate-400 min-h-[1rem]"
+        >
+          {searchTooShort
+            ? (t('search_too_short') || `Type at least ${MIN_SEARCH_LENGTH} characters to search`)
+            : isLoading
+              ? (t('searching') || 'Searching…')
+              : isFiltering
+                ? (t('showing_results', { count: posts.length }) || `Showing ${posts.length} result(s)`)
+                : ''}
+        </p>
+
+        {error && (
+          <div
+            role="alert"
+            className="mb-4 flex items-start gap-2 rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-700 dark:border-red-900 dark:bg-red-950/40 dark:text-red-300"
+          >
+            <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+            <div>
+              <p>{t('load_failed') || 'Could not load discussions.'}</p>
+              <button
+                type="button"
+                onClick={() => fetchPage({ search: activeSearch, category: categoryId, order: sort })}
+                className="mt-1 font-medium underline underline-offset-2"
+              >
+                {t('retry') || 'Try again'}
+              </button>
+            </div>
+          </div>
+        )}
+
         <div className="space-y-4">
-          {filteredPosts && filteredPosts.length > 0 ? (
-            filteredPosts.map((post) => <PostCard key={post.id} post={post} locale={locale} />)
-          ) : (
+          {isLoading && !isPristine ? (
+            <div className="flex items-center justify-center gap-2 py-12 text-slate-500 dark:text-slate-400">
+              <Loader2 className="h-5 w-5 animate-spin" aria-hidden="true" />
+              <span>{t('searching') || 'Searching…'}</span>
+            </div>
+          ) : posts.length > 0 ? (
+            posts.map((post) => <PostCard key={post.id} post={post} locale={locale} />)
+          ) : showEmptyState && !error ? (
             <div className="text-center py-12 bg-white dark:bg-slate-900 rounded-xl border border-slate-200 dark:border-slate-800">
-              <Users className="mx-auto h-12 w-12 text-slate-400 mb-3" />
+              <Users className="mx-auto h-12 w-12 text-slate-400 mb-3" aria-hidden="true" />
               <h3 className="text-lg font-medium text-slate-900 dark:text-white mb-1">
-                {searchTerm
+                {isFiltering
                   ? t('no_search_results') || 'No discussions match your search'
                   : t('no_posts_yet') || 'No posts yet'}
               </h3>
               <p className="text-slate-500 dark:text-slate-400">
-                {searchTerm
+                {isFiltering
                   ? t('try_different_keywords') || 'Try a different keyword or start a new discussion.'
                   : t('be_the_first') || 'Be the first to start a discussion!'}
               </p>
             </div>
-          )}
+          ) : null}
         </div>
+
+        {hasMore && posts.length > 0 && (
+          <div className="mt-6 flex justify-center">
+            <button
+              type="button"
+              onClick={handleLoadMore}
+              disabled={isPagingMore}
+              className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-6 py-3 text-sm font-medium text-slate-700 shadow-sm transition hover:border-pink-300 hover:text-pink-600 disabled:opacity-60 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200"
+            >
+              {isPagingMore && <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />}
+              {isPagingMore
+                ? (t('loading') || 'Loading…')
+                : (t('load_more') || 'Load more discussions')}
+            </button>
+          </div>
+        )}
       </div>
 
       <div className="space-y-6">
         <div className="bg-white dark:bg-slate-900 rounded-xl border border-slate-200 dark:border-slate-800 p-5">
           <h3 className="font-semibold text-slate-900 dark:text-white mb-4 flex items-center gap-2">
-            <Hash size={18} className="text-pink-500" />
+            <Hash size={18} className="text-pink-500" aria-hidden="true" />
             {t('categories') || 'Categories'}
           </h3>
           <div className="space-y-2">
+            <button
+              type="button"
+              onClick={() => setCategoryId(null)}
+              aria-pressed={categoryId === null}
+              className={`block w-full text-left px-3 py-2 rounded-lg text-sm transition-colors ${
+                categoryId === null
+                  ? 'bg-pink-50 text-pink-700 dark:bg-pink-950/40 dark:text-pink-300'
+                  : 'text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-800'
+              }`}
+            >
+              <span className="font-medium">{t('all_categories') || 'All discussions'}</span>
+            </button>
+
             {initialCategories?.map((category) => (
-              <Link
+              <button
                 key={category.id}
-                href={`/${locale}/community/${category.slug}`}
-                className="block px-3 py-2 rounded-lg text-sm text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-800 transition-colors"
+                type="button"
+                onClick={() => setCategoryId(category.id)}
+                aria-pressed={categoryId === category.id}
+                className={`block w-full text-left px-3 py-2 rounded-lg text-sm transition-colors ${
+                  categoryId === category.id
+                    ? 'bg-pink-50 dark:bg-pink-950/40'
+                    : 'hover:bg-slate-50 dark:hover:bg-slate-800'
+                }`}
               >
                 <div className="font-medium text-slate-800 dark:text-slate-200">
                   {t(`cat_${category.slug}_name`) || category.name}
@@ -96,9 +347,20 @@ export default function CommunityFeed({ locale, initialCategories = [], initialP
                 <div className="text-xs text-slate-500 dark:text-slate-400 truncate">
                   {t(`cat_${category.slug}_desc`) || category.description}
                 </div>
-              </Link>
+              </button>
             ))}
           </div>
+
+          {/* The dedicated category pages remain reachable and server-rendered,
+              so the feed's in-place filter does not become the only way in. */}
+          {activeCategory && (
+            <Link
+              href={`/${locale}/community/${activeCategory.slug}`}
+              className="mt-4 inline-block text-xs font-medium text-pink-600 underline underline-offset-2 dark:text-pink-400"
+            >
+              {t('open_category_page') || 'Open this category as its own page'}
+            </Link>
+          )}
         </div>
 
         <div className="bg-white dark:bg-slate-900 rounded-xl border border-slate-200 dark:border-slate-800 p-5">

--- a/lib/forum-query.js
+++ b/lib/forum-query.js
@@ -1,0 +1,339 @@
+/**
+ * forum-query.js — the query contract for the community feed.
+ *
+ * ## The bug this exists to prevent
+ *
+ * The community page fetched a fixed slice and let the browser filter it:
+ *
+ *     supabase.from('forum_posts')
+ *       .select('*')
+ *       .order('created_at', { ascending: false })
+ *       .limit(20)
+ *
+ *     // …and then, in CommunityFeed:
+ *     return initialPosts.filter((post) =>
+ *       post.title.toLowerCase().includes(q) || post.content.toLowerCase().includes(q))
+ *
+ * So the search box searched **twenty rows**, not the forum. A user looking for
+ * "metformin" was told *"No discussions match your search — try a different
+ * keyword"* even when thirty posts mentioned it, because only the newest twenty
+ * were ever sent to the browser. On an anonymous PCOD support forum, where the
+ * entire point is finding someone who has been through the same thing, a search
+ * that silently reports an empty archive is the worst possible failure. There
+ * was also no pagination of any kind, so post 21 and older were unreachable.
+ *
+ * ## What lives here
+ *
+ * Parameter normalisation, cursor encoding and the ILIKE-pattern escaping —
+ * the parts that are pure decisions about untrusted input, and therefore the
+ * parts worth testing exhaustively without a database. The route applies them;
+ * this module decides them.
+ *
+ * ## Why keyset paging rather than offset
+ *
+ * `.range(offset, offset + limit)` looks simpler, but the feed is ordered by
+ * `created_at` **descending** and new posts arrive at the head. If someone
+ * posts while a user is reading page 1, every row shifts down by one, so page 2
+ * re-serves the row the user already saw and page 3 skips one entirely. Keyset
+ * paging anchors on the last row's `(created_at, id)` instead of on a count, so
+ * inserts at the head cannot disturb it.
+ *
+ * `id` is part of the key because `created_at` is not unique — a seed script or
+ * a bulk import can write several rows in the same millisecond, and a cursor on
+ * the timestamp alone would either skip or repeat them.
+ *
+ * No imports, so this is usable from Route Handlers, Server Components, Client
+ * Components and plain Node scripts alike.
+ */
+
+/** Default page size when the caller does not ask for one. */
+export const DEFAULT_PAGE_SIZE = 20
+
+/**
+ * Hard ceiling on page size.
+ *
+ * Without it, `?limit=100000` is an unauthenticated way to make the server
+ * serialise the entire forum on every request.
+ */
+export const MAX_PAGE_SIZE = 50
+
+/** Shortest search term that is worth a round trip. */
+export const MIN_SEARCH_LENGTH = 2
+
+/**
+ * Longest accepted search term. Beyond this the ILIKE pattern costs more than
+ * any result it could return, and no real query is this long.
+ */
+export const MAX_SEARCH_LENGTH = 120
+
+/** Supported orderings. */
+export const SORT_NEWEST = 'newest'
+export const SORT_OLDEST = 'oldest'
+const SORTS = new Set([SORT_NEWEST, SORT_OLDEST])
+
+/**
+ * Escapes a user's search term for use inside a PostgREST `ilike` pattern.
+ *
+ * Two separate escaping problems, both reachable from the search box:
+ *
+ * 1. **ILIKE wildcards.** `%` and `_` are pattern metacharacters. A user
+ *    searching for the literal string `50_50` would otherwise match anything
+ *    with `50` + any character + `50`, and a search for `%` alone would match
+ *    every post in the table.
+ * 2. **PostgREST `or=` syntax.** The filter is expressed as
+ *    `or=(title.ilike.*q*,content.ilike.*q*)`, in which `,` separates the
+ *    branches and `(`/`)` delimit them. A search for `hi, there` would split
+ *    the filter into three malformed branches, and PostgREST answers a parse
+ *    error — a 400 on an ordinary human query. Wrapping the value in double
+ *    quotes makes it a literal, which in turn means embedded `"` and `\` need
+ *    escaping.
+ *
+ * @param {string} term
+ * @returns {string} a value safe to interpolate into an `ilike` filter
+ */
+export function escapeIlikePattern(term) {
+  return String(term ?? '')
+    // Backslash first — escaping it after the others would double-escape them.
+    .replace(/\\/g, '\\\\')
+    .replace(/%/g, '\\%')
+    .replace(/_/g, '\\_')
+    .replace(/"/g, '\\"')
+}
+
+/**
+ * Builds the PostgREST `or` filter matching a term in either the title or the
+ * body.
+ *
+ * The pattern is wrapped in `"` so commas and parentheses inside the term are
+ * read as literal text rather than as filter syntax.
+ *
+ * @param {string} term already-trimmed search text
+ * @returns {string}
+ */
+export function buildSearchFilter(term) {
+  const safe = escapeIlikePattern(term)
+  return `title.ilike."%${safe}%",content.ilike."%${safe}%"`
+}
+
+/**
+ * Normalises a raw search term.
+ *
+ * Returns `null` for anything not worth querying, so the route has a single
+ * "no search" case rather than three variants of empty.
+ *
+ * @param {unknown} raw
+ * @returns {string|null}
+ */
+export function normaliseSearchTerm(raw) {
+  if (typeof raw !== 'string') return null
+
+  // Collapse internal runs of whitespace too: "  pcod   diet " and "pcod diet"
+  // are the same query, and treating them differently makes result counts look
+  // unstable to the user.
+  const trimmed = raw.trim().replace(/\s+/g, ' ')
+  if (trimmed.length < MIN_SEARCH_LENGTH) return null
+
+  return trimmed.slice(0, MAX_SEARCH_LENGTH)
+}
+
+/**
+ * Encodes a keyset cursor.
+ *
+ * Base64 is used purely so the value reads as an opaque token rather than as an
+ * invitation to hand-edit a timestamp in the address bar. It is not a security
+ * boundary, and the decoder validates the contents regardless.
+ *
+ * @param {{ created_at?: string, id?: string|number }} row the last row of a page
+ * @returns {string|null} `null` when the row cannot anchor a cursor
+ */
+export function encodeCursor(row) {
+  if (!row || row.created_at === undefined || row.created_at === null) return null
+  if (row.id === undefined || row.id === null) return null
+
+  const payload = `${row.created_at}|${row.id}`
+  if (typeof btoa === 'function') {
+    // btoa is byte-oriented; a non-ASCII id would throw. Percent-encode first.
+    return btoa(encodeURIComponent(payload))
+  }
+  return Buffer.from(payload, 'utf8').toString('base64')
+}
+
+/**
+ * Decodes a keyset cursor.
+ *
+ * Every failure mode — malformed base64, a missing separator, an unparseable
+ * timestamp — returns `null` rather than throwing, so a hand-edited or stale
+ * cursor degrades to "start from the beginning" instead of a 500.
+ *
+ * @param {unknown} cursor
+ * @returns {{ createdAt: string, id: string }|null}
+ */
+export function decodeCursor(cursor) {
+  if (typeof cursor !== 'string' || !cursor) return null
+
+  let decoded
+  try {
+    decoded = typeof atob === 'function'
+      ? decodeURIComponent(atob(cursor))
+      : Buffer.from(cursor, 'base64').toString('utf8')
+  } catch {
+    return null
+  }
+
+  // Split on the *first* separator, not the last. An ISO timestamp can never
+  // contain `|`, but an id is opaque and may — splitting from the right would
+  // hand part of the id to the timestamp and reject the whole cursor.
+  const separator = decoded.indexOf('|')
+  if (separator <= 0 || separator === decoded.length - 1) return null
+
+  const createdAt = decoded.slice(0, separator)
+  const id = decoded.slice(separator + 1)
+
+  // A cursor whose timestamp is not a real date would produce a comparison
+  // Postgres rejects, so reject it here where the fallback is graceful.
+  if (Number.isNaN(new Date(createdAt).getTime())) return null
+  if (!id) return null
+
+  return { createdAt, id }
+}
+
+/**
+ * Clamps a requested page size.
+ *
+ * @param {unknown} raw
+ * @returns {number}
+ */
+export function normaliseLimit(raw) {
+  if (raw === undefined || raw === null || raw === '') return DEFAULT_PAGE_SIZE
+  const parsed = Number(raw)
+  if (!Number.isFinite(parsed)) return DEFAULT_PAGE_SIZE
+  return Math.min(MAX_PAGE_SIZE, Math.max(1, Math.floor(parsed)))
+}
+
+/**
+ * Normalises the sort parameter.
+ *
+ * @param {unknown} raw
+ * @returns {'newest'|'oldest'}
+ */
+export function normaliseSort(raw) {
+  if (typeof raw !== 'string') return SORT_NEWEST
+  const lowered = raw.trim().toLowerCase()
+  return SORTS.has(lowered) ? lowered : SORT_NEWEST
+}
+
+/**
+ * Normalises a category identifier.
+ *
+ * Accepts either a slug (`pcod-advice`) or a uuid, because the feed links to
+ * categories by slug while `forum_posts.category_id` stores the id — the two
+ * have been inconsistent since the category route was added. The route resolves
+ * a slug to an id before filtering.
+ *
+ * @param {unknown} raw
+ * @returns {string|null}
+ */
+export function normaliseCategory(raw) {
+  if (typeof raw !== 'string') return null
+  const trimmed = raw.trim()
+  if (!trimmed || trimmed === 'all') return null
+  // Ids and slugs are both restricted character sets; anything else is either a
+  // typo or an injection attempt, and neither should reach a filter.
+  if (!/^[A-Za-z0-9_-]{1,64}$/.test(trimmed)) return null
+  return trimmed
+}
+
+/**
+ * Turns raw request parameters into a validated query description.
+ *
+ * @param {URLSearchParams|Record<string, unknown>} params
+ * @returns {{
+ *   search: string|null,
+ *   categoryId: string|null,
+ *   sort: 'newest'|'oldest',
+ *   limit: number,
+ *   cursor: {createdAt: string, id: string}|null,
+ *   ascending: boolean
+ * }}
+ */
+export function parseFeedQuery(params) {
+  const read = (key) => (typeof params?.get === 'function' ? params.get(key) : params?.[key])
+
+  const sort = normaliseSort(read('sort'))
+
+  return {
+    search: normaliseSearchTerm(read('q')),
+    categoryId: normaliseCategory(read('categoryId') ?? read('category')),
+    sort,
+    limit: normaliseLimit(read('limit')),
+    cursor: decodeCursor(read('cursor')),
+    ascending: sort === SORT_OLDEST,
+  }
+}
+
+/**
+ * Builds the keyset predicate for the row *after* the cursor.
+ *
+ * Expressed as a PostgREST `or` filter because the condition is a tuple
+ * comparison — "strictly older, or the same instant with a smaller id" — which
+ * a single `.lt()` cannot express:
+ *
+ *     (created_at, id) < (cursor.createdAt, cursor.id)
+ *
+ * The `id` tie-break is what stops rows written in the same millisecond from
+ * being skipped or repeated across a page boundary.
+ *
+ * @param {{createdAt: string, id: string}} cursor
+ * @param {boolean} ascending
+ * @returns {string}
+ */
+export function buildCursorFilter(cursor, ascending) {
+  const comparator = ascending ? 'gt' : 'lt'
+  const at = cursor.createdAt
+  return `created_at.${comparator}."${at}",and(created_at.eq."${at}",id.${comparator}."${cursor.id}")`
+}
+
+/**
+ * Builds the response envelope for a page of posts.
+ *
+ * The route deliberately asks the database for `limit + 1` rows: the extra row
+ * is how "is there more?" is answered without a second `count` query, which on
+ * a filtered `ilike` scan costs as much as the page itself. The extra row is
+ * trimmed off here before it reaches the client.
+ *
+ * @param {object[]} rows the raw rows, up to `limit + 1` of them
+ * @param {number} limit the page size that was requested
+ * @returns {{ posts: object[], nextCursor: string|null, hasMore: boolean }}
+ */
+export function buildFeedPage(rows, limit) {
+  const safeRows = Array.isArray(rows) ? rows.filter(Boolean) : []
+  const hasMore = safeRows.length > limit
+  const posts = hasMore ? safeRows.slice(0, limit) : safeRows
+
+  return {
+    posts,
+    hasMore,
+    // No next cursor on the last page: handing one back would make the client
+    // issue a request guaranteed to return nothing.
+    nextCursor: hasMore ? encodeCursor(posts[posts.length - 1]) : null,
+  }
+}
+
+/**
+ * Serialises a query description back into a query string.
+ *
+ * Used by the client to build its fetch URL, so the parameter names can only
+ * ever be defined in one place.
+ *
+ * @param {object} query
+ * @returns {string} e.g. `q=pcod&sort=oldest&limit=20`
+ */
+export function toQueryString({ search, categoryId, sort, limit, cursor } = {}) {
+  const params = new URLSearchParams()
+  if (search) params.set('q', search)
+  if (categoryId) params.set('categoryId', categoryId)
+  if (sort && sort !== SORT_NEWEST) params.set('sort', sort)
+  if (limit && limit !== DEFAULT_PAGE_SIZE) params.set('limit', String(limit))
+  if (cursor) params.set('cursor', cursor)
+  return params.toString()
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -253,7 +253,20 @@
     "cat_mental-health_desc": "A safe space to talk about emotional well-being and stress.",
     "cat_general-discussion_name": "General Discussion",
     "cat_general-discussion_desc": "Talk about anything else related to women's health.",
-    "reply": "Reply"
+    "reply": "Reply",
+    "all_categories": "All discussions",
+    "sort_label": "Sort discussions",
+    "sort_newest": "Newest first",
+    "sort_oldest": "Oldest first",
+    "clear_search": "Clear search",
+    "search_too_short": "Type at least 2 characters to search",
+    "searching": "Searching…",
+    "showing_results": "Showing {count} matching discussions",
+    "load_more": "Load more discussions",
+    "loading": "Loading…",
+    "load_failed": "Could not load discussions.",
+    "retry": "Try again",
+    "open_category_page": "Open this category as its own page"
   },
   "PartnerSharing": {
     "title": "Partner Sharing",

--- a/messages/hi.json
+++ b/messages/hi.json
@@ -253,7 +253,20 @@
     "cat_mental-health_desc": "भावनात्मक कल्याण और तनाव के बारे में बात करने के लिए एक सुरक्षित स्थान।",
     "cat_general-discussion_name": "सामान्य चर्चा",
     "cat_general-discussion_desc": "महिलाओं के स्वास्थ्य से संबंधित किसी भी अन्य विषय पर बात करें।",
-    "reply": "जवाब दें"
+    "reply": "जवाब दें",
+    "all_categories": "सभी चर्चाएँ",
+    "sort_label": "चर्चाएँ क्रमबद्ध करें",
+    "sort_newest": "नवीनतम पहले",
+    "sort_oldest": "सबसे पुराने पहले",
+    "clear_search": "खोज साफ़ करें",
+    "search_too_short": "खोजने के लिए कम से कम 2 अक्षर लिखें",
+    "searching": "खोज रहे हैं…",
+    "showing_results": "{count} मेल खाती चर्चाएँ दिखाई जा रही हैं",
+    "load_more": "और चर्चाएँ लोड करें",
+    "loading": "लोड हो रहा है…",
+    "load_failed": "चर्चाएँ लोड नहीं हो सकीं।",
+    "retry": "पुनः प्रयास करें",
+    "open_category_page": "इस श्रेणी को अलग पेज पर खोलें"
   },
   "PartnerSharing": {
     "title": "पार्टनर शेयरिंग",

--- a/scripts/test-forum-query.js
+++ b/scripts/test-forum-query.js
@@ -1,0 +1,407 @@
+/**
+ * Regression suite for lib/forum-query.js — parameter normalisation, keyset
+ * cursors and ILIKE escaping for the community feed.
+ *
+ * The bug this guards: the feed used to receive a hard-coded 20 rows and filter
+ * them in the browser —
+ *
+ *     supabase.from('forum_posts').order('created_at', {ascending:false}).limit(20)
+ *     …
+ *     initialPosts.filter(p => p.title.toLowerCase().includes(q))
+ *
+ * — so the search box searched twenty rows rather than the forum, reported
+ * "No discussions match your search" over a non-empty archive, and left every
+ * post older than the newest twenty unreachable.
+ *
+ * The interesting failures are all in the untrusted-input handling that the
+ * rewrite introduced, so that is what this pins:
+ *
+ *   - `%` and `_` are ILIKE wildcards, so an unescaped search for `50_50`
+ *     matches `50X50`, and a search for `%` matches the entire table.
+ *   - PostgREST expresses the filter as `or=(title.ilike.*q*,content.ilike.*q*)`,
+ *     in which `,` and `()` are syntax. An unescaped search for `hi, there`
+ *     produces a malformed filter and a 400 on an ordinary human query.
+ *   - `created_at` is not unique, so a cursor on the timestamp alone silently
+ *     skips or repeats rows written in the same millisecond.
+ *
+ *   node scripts/test-forum-query.js
+ */
+
+import {
+  DEFAULT_PAGE_SIZE,
+  MAX_PAGE_SIZE,
+  MAX_SEARCH_LENGTH,
+  MIN_SEARCH_LENGTH,
+  SORT_NEWEST,
+  SORT_OLDEST,
+  buildCursorFilter,
+  buildFeedPage,
+  buildSearchFilter,
+  decodeCursor,
+  encodeCursor,
+  escapeIlikePattern,
+  normaliseCategory,
+  normaliseLimit,
+  normaliseSearchTerm,
+  normaliseSort,
+  parseFeedQuery,
+  toQueryString,
+} from '../lib/forum-query.js'
+
+let passed = 0
+let failed = 0
+
+function check(actual, expected, label) {
+  if (Object.is(actual, expected)) {
+    passed += 1
+    return
+  }
+  failed += 1
+  console.error(`  ❌ ${label}`)
+  console.error(`       expected: ${JSON.stringify(expected)}`)
+  console.error(`       actual:   ${JSON.stringify(actual)}`)
+}
+
+function checkDeep(actual, expected, label) {
+  const a = JSON.stringify(actual)
+  const b = JSON.stringify(expected)
+  if (a === b) {
+    passed += 1
+    return
+  }
+  failed += 1
+  console.error(`  ❌ ${label}`)
+  console.error(`       expected: ${b}`)
+  console.error(`       actual:   ${a}`)
+}
+
+function checkTrue(actual, label) {
+  check(Boolean(actual), true, label)
+}
+
+function section(name) {
+  console.log(`\n— ${name}`)
+}
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * Search term normalisation
+ * ────────────────────────────────────────────────────────────────────────── */
+
+section('search term normalisation')
+{
+  check(normaliseSearchTerm('metformin'), 'metformin', 'an ordinary term passes through')
+  check(normaliseSearchTerm('  metformin  '), 'metformin', 'surrounding whitespace is trimmed')
+
+  // "  pcod   diet " and "pcod diet" are the same query; treating them
+  // differently makes the result count look unstable while typing.
+  check(
+    normaliseSearchTerm('pcod   diet'), 'pcod diet',
+    'internal whitespace runs are collapsed'
+  )
+
+  check(normaliseSearchTerm(''), null, 'an empty term is not a search')
+  check(normaliseSearchTerm('   '), null, 'a whitespace-only term is not a search')
+  check(
+    normaliseSearchTerm('a'), null,
+    `a term below the ${MIN_SEARCH_LENGTH}-character minimum is not a search`
+  )
+  check(normaliseSearchTerm('ab'), 'ab', 'the minimum length is inclusive')
+  check(normaliseSearchTerm(null), null, 'null is not a search')
+  check(normaliseSearchTerm(42), null, 'a non-string is not a search')
+
+  check(
+    normaliseSearchTerm('x'.repeat(500)).length, MAX_SEARCH_LENGTH,
+    'an absurdly long term is truncated rather than sent to the database'
+  )
+}
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * ILIKE escaping — the injection-shaped bugs
+ * ────────────────────────────────────────────────────────────────────────── */
+
+section('ILIKE pattern escaping')
+{
+  check(escapeIlikePattern('metformin'), 'metformin', 'ordinary text is unchanged')
+
+  // Without this, searching `50_50` matches `50X50`.
+  check(escapeIlikePattern('50_50'), '50\\_50', 'the `_` single-character wildcard is escaped')
+  // Without this, searching `%` matches every post in the table.
+  check(escapeIlikePattern('100%'), '100\\%', 'the `%` multi-character wildcard is escaped')
+  check(escapeIlikePattern('a"b'), 'a\\"b', 'a double quote is escaped so it cannot end the literal')
+
+  // Backslash must be escaped first, or the escapes added for % and _ get
+  // double-escaped by the backslash pass.
+  check(
+    escapeIlikePattern('a\\b'), 'a\\\\b',
+    'a backslash is escaped, and is escaped first so it does not corrupt the others'
+  )
+  check(
+    escapeIlikePattern('a\\%b'), 'a\\\\\\%b',
+    'a literal backslash followed by a percent is escaped correctly, not doubly'
+  )
+  check(escapeIlikePattern(''), '', 'an empty string escapes to an empty string')
+  check(escapeIlikePattern(null), '', 'null escapes to an empty string rather than "null"')
+}
+
+section('search filter construction')
+{
+  const filter = buildSearchFilter('metformin')
+  checkTrue(filter.includes('title.ilike.'), 'the filter searches the title')
+  checkTrue(filter.includes('content.ilike.'), 'the filter searches the body')
+
+  // The reason the pattern is quoted: `,` separates branches in a PostgREST
+  // `or=` filter, so an unquoted comma splits it into malformed pieces.
+  const withComma = buildSearchFilter('hi, there')
+  check(
+    withComma, 'title.ilike."%hi, there%",content.ilike."%hi, there%"',
+    'a comma in the term stays inside the quoted literal instead of splitting the filter'
+  )
+
+  const withParens = buildSearchFilter('pcod (mild)')
+  checkTrue(
+    withParens.includes('"%pcod (mild)%"'),
+    'parentheses in the term stay inside the quoted literal'
+  )
+
+  checkTrue(
+    buildSearchFilter('50%_off').includes('50\\%\\_off'),
+    'wildcards are still escaped inside the quoted literal'
+  )
+}
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * Limit, sort and category
+ * ────────────────────────────────────────────────────────────────────────── */
+
+section('limit clamping')
+{
+  check(normaliseLimit(undefined), DEFAULT_PAGE_SIZE, 'an absent limit uses the default')
+  check(normaliseLimit(''), DEFAULT_PAGE_SIZE, 'an empty limit uses the default')
+  check(normaliseLimit('10'), 10, 'a numeric string is honoured')
+  check(normaliseLimit(10.7), 10, 'a fractional limit is floored')
+  check(normaliseLimit(0), 1, 'zero is clamped up to one')
+  check(normaliseLimit(-5), 1, 'a negative limit is clamped up to one')
+
+  // Without the ceiling, `?limit=100000` is an unauthenticated way to make the
+  // server serialise the whole forum.
+  check(normaliseLimit(100000), MAX_PAGE_SIZE, 'an absurd limit is clamped to the ceiling')
+  check(normaliseLimit('lots'), DEFAULT_PAGE_SIZE, 'a non-numeric limit uses the default')
+}
+
+section('sort normalisation')
+{
+  check(normaliseSort('newest'), SORT_NEWEST, 'newest is accepted')
+  check(normaliseSort('oldest'), SORT_OLDEST, 'oldest is accepted')
+  check(normaliseSort('OLDEST'), SORT_OLDEST, 'sort is case-insensitive')
+  check(normaliseSort(' oldest '), SORT_OLDEST, 'sort is trimmed')
+  check(normaliseSort('random'), SORT_NEWEST, 'an unknown sort falls back to newest')
+  check(normaliseSort(null), SORT_NEWEST, 'a missing sort falls back to newest')
+}
+
+section('category normalisation')
+{
+  check(normaliseCategory('pcod-advice'), 'pcod-advice', 'a slug is accepted')
+  check(
+    normaliseCategory('9f8a1c2e-0000-4aaa-bbbb-000000000001'),
+    '9f8a1c2e-0000-4aaa-bbbb-000000000001',
+    'a uuid is accepted — the feed links by slug but the column stores ids'
+  )
+  check(normaliseCategory('all'), null, '"all" means no filter')
+  check(normaliseCategory(''), null, 'an empty category means no filter')
+  check(normaliseCategory(null), null, 'a missing category means no filter')
+
+  // Neither of these can be a real slug, so they are a typo or an attempt to
+  // reach the filter syntax.
+  check(normaliseCategory('pcod advice'), null, 'a category with a space is rejected')
+  check(normaliseCategory('a".or(1.eq.1)'), null, 'a category containing filter syntax is rejected')
+  check(normaliseCategory('x'.repeat(200)), null, 'an over-long category is rejected')
+}
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * Cursors
+ * ────────────────────────────────────────────────────────────────────────── */
+
+section('cursor round-trip')
+{
+  const row = { created_at: '2026-08-01T12:34:56.789Z', id: 'post-42' }
+  const cursor = encodeCursor(row)
+  checkTrue(cursor, 'a well-formed row produces a cursor')
+
+  const decoded = decodeCursor(cursor)
+  check(decoded.createdAt, row.created_at, 'the timestamp survives the round trip')
+  check(decoded.id, String(row.id), 'the id survives the round trip')
+
+  check(
+    decodeCursor(encodeCursor({ created_at: '2026-08-01T00:00:00Z', id: 12345 })).id, '12345',
+    'a numeric id round-trips as a string'
+  )
+
+  // An id is opaque and may contain anything, including the separator; an ISO
+  // timestamp never can. Splitting from the right would hand part of the id to
+  // the timestamp and reject the whole cursor.
+  const oddIdRow = { created_at: '2026-08-01T00:00:00Z', id: 'a|b|c' }
+  check(
+    decodeCursor(encodeCursor(oddIdRow)).createdAt, '2026-08-01T00:00:00Z',
+    'an id containing the separator does not corrupt the timestamp'
+  )
+  check(
+    decodeCursor(encodeCursor(oddIdRow)).id, 'a|b|c',
+    '…and the id is taken whole, from the first separator onwards'
+  )
+
+  check(encodeCursor(null), null, 'a null row produces no cursor')
+  check(encodeCursor({ id: 'x' }), null, 'a row with no timestamp produces no cursor')
+  check(encodeCursor({ created_at: '2026-08-01' }), null, 'a row with no id produces no cursor')
+}
+
+section('cursor decoding degrades gracefully')
+{
+  // Every one of these is reachable by hand-editing the address bar. None of
+  // them should be a 500; they should all mean "start from the beginning".
+  check(decodeCursor(''), null, 'an empty cursor is ignored')
+  check(decodeCursor(null), null, 'a null cursor is ignored')
+  check(decodeCursor('!!!not base64!!!'), null, 'unparseable base64 is ignored')
+  check(
+    decodeCursor(Buffer.from('no-separator').toString('base64')), null,
+    'a cursor with no separator is ignored'
+  )
+  check(
+    decodeCursor(Buffer.from('|orphan').toString('base64')), null,
+    'a cursor with an empty timestamp is ignored'
+  )
+  check(
+    decodeCursor(Buffer.from('2026-08-01T00:00:00Z|').toString('base64')), null,
+    'a cursor with an empty id is ignored'
+  )
+  check(
+    decodeCursor(Buffer.from('not-a-date|post-1').toString('base64')), null,
+    'a cursor whose timestamp is not a real date is ignored — Postgres would reject the comparison'
+  )
+}
+
+section('cursor filter')
+{
+  const cursor = { createdAt: '2026-08-01T12:00:00Z', id: 'post-42' }
+
+  const desc = buildCursorFilter(cursor, false)
+  checkTrue(desc.includes('created_at.lt.'), 'newest-first pages strictly backwards in time')
+  checkTrue(
+    desc.includes('and(created_at.eq.') && desc.includes('id.lt.'),
+    'the same-instant tie-break is included — created_at is not unique'
+  )
+
+  const asc = buildCursorFilter(cursor, true)
+  checkTrue(asc.includes('created_at.gt.'), 'oldest-first pages strictly forwards in time')
+  checkTrue(asc.includes('id.gt.'), '…with the tie-break in the same direction')
+
+  checkTrue(
+    desc.includes(`"${cursor.createdAt}"`),
+    'the timestamp is quoted so its colons are not read as filter syntax'
+  )
+}
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * Page assembly
+ * ────────────────────────────────────────────────────────────────────────── */
+
+section('page assembly')
+{
+  const rows = Array.from({ length: 21 }, (_, i) => ({
+    id: `post-${i}`,
+    created_at: `2026-08-${String(i + 1).padStart(2, '0')}T00:00:00Z`,
+  }))
+
+  // The route asks for limit + 1; the extra row is how "is there more?" is
+  // answered without a second count query.
+  const full = buildFeedPage(rows, 20)
+  check(full.posts.length, 20, 'the extra probe row is trimmed off the page')
+  check(full.hasMore, true, 'its presence sets hasMore')
+  checkTrue(full.nextCursor, 'a next cursor is issued')
+  check(
+    decodeCursor(full.nextCursor).id, 'post-19',
+    'the cursor anchors on the last *returned* row, not on the trimmed probe row'
+  )
+
+  const last = buildFeedPage(rows.slice(0, 15), 20)
+  check(last.posts.length, 15, 'a short page is returned whole')
+  check(last.hasMore, false, 'a short page is the last page')
+  // Handing back a cursor here would make the client issue a request that is
+  // guaranteed to return nothing.
+  check(last.nextCursor, null, 'the last page issues no cursor')
+
+  const exact = buildFeedPage(rows.slice(0, 20), 20)
+  check(exact.hasMore, false, 'exactly `limit` rows means there is no next page')
+
+  const empty = buildFeedPage([], 20)
+  check(empty.posts.length, 0, 'an empty result is an empty page')
+  check(empty.hasMore, false, '…with no next page')
+
+  checkDeep(buildFeedPage(null, 20).posts, [], 'a null result set is handled')
+  checkDeep(
+    buildFeedPage([null, { id: 'a', created_at: '2026-08-01T00:00:00Z' }, undefined], 20).posts,
+    [{ id: 'a', created_at: '2026-08-01T00:00:00Z' }],
+    'null rows are filtered out'
+  )
+}
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * End to end
+ * ────────────────────────────────────────────────────────────────────────── */
+
+section('parseFeedQuery')
+{
+  const query = parseFeedQuery(new URLSearchParams('q=%20metformin%20&sort=oldest&limit=5'))
+  check(query.search, 'metformin', 'the search term is normalised')
+  check(query.sort, SORT_OLDEST, 'the sort is normalised')
+  check(query.ascending, true, 'oldest-first maps to ascending')
+  check(query.limit, 5, 'the limit is honoured')
+  check(query.cursor, null, 'no cursor means the first page')
+
+  const defaults = parseFeedQuery(new URLSearchParams(''))
+  check(defaults.search, null, 'no query means no search')
+  check(defaults.categoryId, null, 'no category means no filter')
+  check(defaults.sort, SORT_NEWEST, 'the default sort is newest')
+  check(defaults.ascending, false, 'newest-first maps to descending')
+  check(defaults.limit, DEFAULT_PAGE_SIZE, 'the default page size applies')
+
+  // A plain object works too, so a Server Component can call it directly.
+  const fromObject = parseFeedQuery({ q: 'pcod', category: 'pcod-advice' })
+  check(fromObject.search, 'pcod', 'a plain object is accepted')
+  check(fromObject.categoryId, 'pcod-advice', 'the `category` alias is accepted')
+
+  const hostile = parseFeedQuery(new URLSearchParams('limit=99999&sort=drop&cursor=garbage'))
+  check(hostile.limit, MAX_PAGE_SIZE, 'a hostile limit is clamped')
+  check(hostile.sort, SORT_NEWEST, 'a hostile sort falls back')
+  check(hostile.cursor, null, 'a hostile cursor is ignored rather than fatal')
+}
+
+section('toQueryString')
+{
+  check(toQueryString({}), '', 'an empty query serialises to nothing')
+  check(toQueryString({ search: 'pcod' }), 'q=pcod', 'the search term is serialised')
+  check(
+    toQueryString({ sort: SORT_NEWEST }), '',
+    'the default sort is omitted, so the URL stays clean'
+  )
+  check(toQueryString({ sort: SORT_OLDEST }), 'sort=oldest', 'a non-default sort is serialised')
+  check(
+    toQueryString({ limit: DEFAULT_PAGE_SIZE }), '',
+    'the default limit is omitted'
+  )
+
+  // The round trip is what guarantees the client and the route agree on the
+  // parameter names.
+  const roundTripped = parseFeedQuery(
+    new URLSearchParams(toQueryString({ search: 'pcod diet', categoryId: 'pcod-advice', sort: SORT_OLDEST }))
+  )
+  check(roundTripped.search, 'pcod diet', 'a serialised search survives a round trip')
+  check(roundTripped.categoryId, 'pcod-advice', 'a serialised category survives a round trip')
+  check(roundTripped.sort, SORT_OLDEST, 'a serialised sort survives a round trip')
+}
+
+console.log('')
+if (failed > 0) {
+  console.error(`❌ ${failed} forum query assertion(s) failed (${passed} passed).`)
+  process.exit(1)
+}
+console.log(`✅ All ${passed} forum query assertions passed.`)


### PR DESCRIPTION
## Linked Issue
Fixes #494

## Description

The community feed loaded a fixed 20 rows on the server and filtered that array in the browser:

```js
// app/[locale]/community/page.jsx
supabase.from('forum_posts').select('*').order('created_at', { ascending: false }).limit(20)

// components/community/CommunityFeed.jsx
return initialPosts.filter((post) =>
  post.title.toLowerCase().includes(q) || post.content.toLowerCase().includes(q))
```

So **the search box searched twenty rows, not the forum.** A user looking for "metformin" was shown *"No discussions match your search — try a different keyword"* even when thirty posts mentioned it, because only the newest twenty were ever sent to the browser. On an anonymous PCOD support forum, where the whole point is finding someone who has been through the same thing, a search that silently reports an empty archive is the most damaging thing on the page.

There was also no pagination at all — post 21 and older were unreachable through the UI — and `app/api/forum/posts/route.js` exported only `POST`, so there was no read endpoint to page against.

### What this changes

**`GET /api/forum/posts`** — new. Takes `q`, `categoryId`, `sort`, `limit` and `cursor`, returns `{ success, posts, nextCursor, hasMore }`. It accepts a category slug *or* an id and resolves it, because the feed links to categories by slug while `forum_posts.category_id` stores the id — the two have been inconsistent since the category route was added. An unknown category returns an empty feed rather than an error, so a stale bookmark renders "no posts here" instead of a failure state.

Reads stay unauthenticated — posts are public, anonymous and moderated at write time, so this is the same access the server-rendered page always had — but they are rate-limited, because an unauthenticated `ilike` scan is the most expensive query in the app.

**`lib/forum-query.js`** — new, pure. Parameter clamping, the cursor codec and the ILIKE escaping. Three decisions worth explaining:

**1. Keyset paging, not offset.** `.range(offset, offset + limit)` is simpler, but the feed is ordered by `created_at` **descending** and new posts arrive at the head. If someone posts while a user is reading page 1, every row shifts down by one — so page 2 re-serves a row the user already saw and skips another entirely. A keyset cursor anchors on the last row's `(created_at, id)`, which inserts at the head cannot disturb.

**2. The cursor carries `id`, not just the timestamp.** `created_at` is not unique — a seed script or a bulk import writes several rows in the same millisecond — and a cursor on the timestamp alone would either skip or repeat them at the page boundary. The predicate is a genuine tuple comparison, which is why it is expressed as a PostgREST `or` filter rather than a single `.lt()`:

```
created_at < cursor.createdAt  OR  (created_at = cursor.createdAt AND id < cursor.id)
```

**3. The search term needs two independent escapes, both reachable from the search box.**

- `%` and `_` are ILIKE metacharacters. Unescaped, a search for the literal `50_50` matches `50X50`, and a search for `%` matches **every post in the table**.
- PostgREST expresses the filter as `or=(title.ilike.*q*,content.ilike.*q*)`, in which `,` separates branches and `()` delimits them. Unescaped, a search for `hi, there` splits the filter into three malformed branches and PostgREST answers a **400 on an ordinary human query**. The value is wrapped in `"` to make it a literal, which in turn means embedded `"` and `\` need escaping — and the backslash pass must run *first*, or it double-escapes the escapes added for `%` and `_`.

**`CommunityFeed.jsx`** — reworked into a paging client component: debounced server search (350ms), category filter, sort control, "load more". Two details:

- **Out-of-order responses are discarded.** Typing "pcod" quickly can leave a request for "pco" in flight; without a request-id guard the slower, staler response overwrites the newer one.
- **The server-rendered first page is kept as initial state**, and the network is only touched once the user actually searches, filters, sorts or pages — so the feed still paints instantly and works without JavaScript.
- **A failed "load more" keeps the already-visible posts.** Dropping them would punish the user for a transient network error by discarding everything they had scrolled through.

The `count + 1` probe row — the route asks for one more row than the page size — is how `hasMore` is answered without a second `count` query, which on a filtered `ilike` scan costs as much again as the page itself.

### Also fixed

The category sidebar entries were `<Link>`s to `/${locale}/community/${category.slug}` while the route segment is `[categoryId]`. They are now in-place filter buttons with `aria-pressed`, and the dedicated server-rendered category page remains reachable via an explicit link, so the in-feed filter does not become the only way in.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (clean code updates, no behavior modifications)
- [ ] Documentation update
- [x] Performance optimization
- [ ] Security patch

## Files Modified

| File | Change |
|---|---|
| `lib/forum-query.js` | **new** — parameter clamping, keyset cursor codec, ILIKE escaping |
| `app/api/forum/posts/route.js` | added `GET` with search / filter / sort / cursor paging |
| `components/community/CommunityFeed.jsx` | rewritten as a paging, server-searched feed |
| `app/[locale]/community/page.jsx` | shares `buildFeedPage` so page 1 and page 2 cannot drift apart |
| `messages/en.json`, `messages/hi.json` | 13 new `Community` keys, added in both locales |
| `scripts/test-forum-query.js` | **new** — 101-assertion regression suite |

## Testing

```
node scripts/test-forum-query.js   # ✅ All 101 forum query assertions passed.
npm run test:e2e                   # ✅ 7 / 7 suites passed
npm run build                      # ✅ Compiled successfully
```

The suite needs no database — it covers the untrusted-input handling directly, which is where the interesting failures live: each ILIKE metacharacter individually, the backslash-ordering trap, the comma and parenthesis cases that produced a 400, every way a hand-edited cursor can be malformed (all of which must mean "start from the beginning", never a 500), the same-millisecond tie-break, and the probe-row trimming.

Writing the suite caught a real bug in my own first draft: the cursor decoder split on the **last** `|` rather than the first, so an id containing a `|` handed part of itself to the timestamp and invalidated the whole cursor. An ISO timestamp can never contain `|` but an opaque id can, so it now splits on the first. That assertion is in the suite.

### Manual verification

1. Seed `forum_posts` with 25+ posts, several sharing a `created_at` to the millisecond.
2. `/en/community` renders 20 posts plus a working "Load more".
3. Search a word appearing only in the 25th-newest post — it is found. Previously it was not.
4. Search `hi, there` — results, not a 400.
5. Search `%` — matches posts containing a literal `%`, not the whole table.
6. Page to the end while inserting a new post — no row is repeated or skipped.
7. Switch sort to "Oldest first" and page through — paging is stable in that direction too.
8. Hand-edit `?cursor=garbage` — the feed renders from the beginning rather than erroring.

## Screenshots (if UI changes are made)
The feed gains a sort dropdown, a clear-search button, an "All discussions" entry above the category list and a "Load more discussions" button at the foot. The card layout, spacing and colour treatment are unchanged.

## Checklist
- [x] This PR is submitted under ECSOC.
- [x] Added the required **ECSoc26** label to this Pull Request.
- [x] Linked issue using `Fixes #494`.
- [x] Tested locally.
- [x] `npm run build` completes successfully.
- [x] `npm run test:e2e` passes (7/7).
- [x] No breaking changes introduced.
- [x] `en` / `hi` message parity verified.
