### PR TITLE
[ECSoC26] Frontend: Preserve daily log dates in offline PCOD risk assessment

### DIFF
--- a/lib/OfflineContext.jsx
+++ b/lib/OfflineContext.jsx
@@ -509,10 +509,9 @@ export function OfflineProvider({ children }) {
       try {
         const cachedCycles = await getAllFromStore('cycles');
         const cachedLogs = await getAllFromStore('daily_logs');
-        const allSymptoms = cachedLogs.flatMap(log => log.symptoms || []);
 
         if (cachedCycles.length > 0) {
-          const localRisk = normaliseRiskResult(await calculatePCODRisk(cachedCycles, allSymptoms));
+          const localRisk = normaliseRiskResult(await calculatePCODRisk(cachedCycles, cachedLogs));
           if (localRisk) return { success: true, data: localRisk };
         }
       } catch (e) {


### PR DESCRIPTION
## Linked Issue
Fixes #502

## Description
Preserved daily log date metadata during offline PCOD risk calculations in lib/OfflineContext.jsx.

- Passes cachedLogs directly to calculatePCODRisk(cachedCycles, cachedLogs) instead of flattening into symptom strings without dates.
- Enables detectConsecutiveRecurrence to correctly identify 3+ day consecutive symptom recurrence offline.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (clean code updates, no behavior modifications)
- [ ] Performance optimization

## Files Modified (1 file)
- lib/OfflineContext.jsx

## Testing
1. Save daily logs containing high-risk symptoms over consecutive days.
2. Go offline and trigger local PCOD risk calculation.
3. Verify consecutive symptom recurrence risk factors are detected correctly.

## Checklist
- [x] This PR is submitted under ECSOC.
- [x] Added the required **ECSoc26** label to this Pull Request.
- [x] Linked issue using Fixes #502.
- [x] Tested locally.
- [x] No breaking changes introduced.