### PR TITLE
[ECSoC26] Backend: Add rate limiting protection on data export API route

### DIFF
--- a/app/api/export-data/route.js
+++ b/app/api/export-data/route.js
@@ -3,11 +3,24 @@ import { getSupabaseAdmin } from '@/lib/supabase-admin'
 import { logger } from '@/lib/logger'
 import { formatDateForCSV } from '@/lib/utils'
 import { toCsv } from '@/lib/csv'
+import { crudLimiter } from '@/lib/rateLimiter'
 const archiver = require('archiver')
 
 export const dynamic = 'force-dynamic'
 
 export async function GET(request) {
+  // ============ RATE LIMITING ============
+  try {
+    await crudLimiter.check(request)
+  } catch (rateLimitError) {
+    logger.warn(`[Rate Limit] Data export endpoint: ${rateLimitError.message}`)
+    return new Response(JSON.stringify({ error: 'Too many requests, please slow down.' }), {
+      status: 429,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+  // =======================================
+
   try {
     const userId = await getAuthUserId()
     if (!userId) {


### PR DESCRIPTION
## Linked Issue
Fixes #504

## Description
Enforced crudLimiter.check(request) rate limiting checks at the beginning of GET /api/export-data.

- Protects server resource exhaustion from unthrottled CPU/memory-heavy ZIP archiving operations.
- Returns clean HTTP 429 JSON response when rate limit threshold is exceeded.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (clean code updates, no behavior modifications)
- [x] Security patch

## Files Modified (1 file)
- pp/api/export-data/route.js

## Testing
1. Trigger rapid GET requests to /api/export-data.
2. Verify rate limiter responds with HTTP 429 when threshold is reached.

## Checklist
- [x] This PR is submitted under ECSOC.
- [x] Added the required **ECSoc26** label to this Pull Request.
- [x] Linked issue using Fixes #504.
- [x] Tested locally.
- [x] No breaking changes introduced.