### PR TITLE
[ECSoC26] Backend: Add null guard for unstarted challenge progress calculations in challenge-streaks

### DIFF
--- a/lib/challenge-streaks.js
+++ b/lib/challenge-streaks.js
@@ -26,7 +26,9 @@ import { addDaysISO, diffInDays } from './date-utils.js'
  * @returns {number}
  */
 export function calculateCurrentStreak(completedRows, today) {
-  const days = new Set((completedRows || []).map((row) => row?.date))
+  if (!today || typeof today !== 'string') return 0
+  const safeRows = Array.isArray(completedRows) ? completedRows.filter(Boolean) : []
+  const days = new Set(safeRows.map((row) => typeof row?.date === 'string' ? row.date : null).filter(Boolean))
 
   let streak = 0
   let cursor = today
@@ -46,7 +48,8 @@ export function calculateCurrentStreak(completedRows, today) {
  * @returns {number}
  */
 export function calculateBestStreak(rows) {
-  const days = [...new Set((rows || []).map((row) => row?.date).filter(Boolean))].sort()
+  const safeRows = Array.isArray(rows) ? rows.filter(Boolean) : []
+  const days = [...new Set(safeRows.map((row) => typeof row?.date === 'string' ? row.date : null).filter(Boolean))].sort()
 
   let best = 0
   let current = 0


### PR DESCRIPTION
## Linked Issue
Fixes #505

## Description
Added type sanitization and null guards across challenge streak calculation functions in lib/challenge-streaks.js.

- Checks array validity (Array.isArray) and string type (	ypeof row?.date === 'string') before building streak dates.
- Prevents TypeError crashes when unstarted or null challenge progress parameters are passed.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (clean code updates, no behavior modifications)
- [ ] Performance optimization

## Files Modified (1 file)
- lib/challenge-streaks.js

## Testing
1. Execute 
ode scripts/test-challenge-days.js.
2. Verify all 336 assertions pass cleanly across 8 timezone matrices.

## Checklist
- [x] This PR is submitted under ECSOC.
- [x] Added the required **ECSoc26** label to this Pull Request.
- [x] Linked issue using Fixes #505.
- [x] Tested locally.
- [x] No breaking changes introduced.