### PR TITLE
[ECSoC26] Accessibility: Add ARIA labels and keyboard navigation to HeatmapCalendar grid cells

### DIFF
--- a/components/challenges/HeatmapCalendar.jsx
+++ b/components/challenges/HeatmapCalendar.jsx
@@ -50,12 +50,15 @@ export default function HeatmapCalendar() {
           {Object.values(counts).filter((c) => c > 0).length} active days
         </span>
       </div>
-      <div className="grid grid-cols-10 gap-1.5 heatmap-grid">
+      <div className="grid grid-cols-10 gap-1.5 heatmap-grid" role="grid" aria-label="Activity heatmap last 30 days">
         {days.map((day) => (
           <div
             key={day.key}
+            role="gridcell"
+            tabIndex={0}
+            aria-label={`${day.label}: ${day.count} completion${day.count === 1 ? '' : 's'}`}
             title={`${day.label} — ${day.count} completion${day.count === 1 ? '' : 's'}`}
-            className="aspect-square rounded-md transition-transform hover:scale-110"
+            className="aspect-square rounded-md transition-transform hover:scale-110 focus:outline-none focus:ring-2 focus:ring-[var(--rose-bright)]"
             style={{ background: getIntensity(day.count) }}
           />
         ))}


### PR DESCRIPTION
## Linked Issue
Fixes #506

## Description
Enhanced accessibility in components/challenges/HeatmapCalendar.jsx by adding ARIA grid roles, dynamic ria-label text, focus rings, and 	abIndex={0} to heatmap day cells.

- Container elements now explicitly specify ole="grid" and ria-label="Activity heatmap last 30 days".
- Each activity day cell includes ole="gridcell", 	abIndex={0}, and dynamic ria-label outputting completion counts and formatted date labels for screen-reader users.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (clean code updates, no behavior modifications)
- [x] Accessibility improvement

## Files Modified (1 file)
- components/challenges/HeatmapCalendar.jsx

## Testing
1. Navigate to Challenge Heatmap Calendar using keyboard focus (Tab key).
2. Verify screen-reader announces completed activity count and date label for each focused cell.

## Checklist
- [x] This PR is submitted under ECSOC.
- [x] Added the required **ECSoc26** label to this Pull Request.
- [x] Linked issue using Fixes #506.
- [x] Tested locally.
- [x] No breaking changes introduced.