### PR TITLE
[ECSoC26] fix(community): bound the moderation calls that sit in front of every forum write

### DIFF
--- a/app/api/forum/comments/route.js
+++ b/app/api/forum/comments/route.js
@@ -1,9 +1,10 @@
 import { NextResponse } from 'next/server';
 import { getAuthUserId } from '@/lib/clerk-server';
-import { moderateContent } from '@/lib/ai-moderation';
+import { moderateContent, OUTCOMES } from '@/lib/ai-moderation';
 import { generateAlias } from '@/lib/alias-generator';
 import { getSupabaseAdmin } from '@/lib/supabase-admin';
 import { crudLimiter } from '@/lib/rateLimiter';
+import { validateCommentLength } from '@/lib/forum-limits';
 
 export async function POST(req) {
   // ============ RATE LIMITING ============
@@ -38,13 +39,31 @@ export async function POST(req) {
       return NextResponse.json({ error: 'Missing required fields' }, { status: 400 });
     }
 
+    // Checked before dispatch so an oversized comment costs a 400 rather than
+    // two provider calls. See lib/forum-limits.js.
+    const lengthError = validateCommentLength(content);
+    if (lengthError) {
+      return NextResponse.json({ error: lengthError }, { status: 400 });
+    }
+
     // 1. Moderate content
     const moderationResult = await moderateContent(content);
-    
+
     if (!moderationResult.isAppropriate) {
+      // 403 only when a provider actually refused the comment. A timeout or an
+      // outage is a 503 with a message that says so, instead of accusing the
+      // user of breaking the community guidelines.
+      const isRefusal = moderationResult.outcome === OUTCOMES.REJECTED;
+
       return NextResponse.json(
-        { error: 'Your comment violates our community guidelines.', reason: moderationResult.reason },
-        { status: 403 }
+        {
+          error: isRefusal
+            ? 'Your comment violates our community guidelines.'
+            : moderationResult.reason,
+          reason: moderationResult.reason,
+          retryable: moderationResult.retryable,
+        },
+        { status: moderationResult.status }
       );
     }
 

--- a/app/api/forum/posts/route.js
+++ b/app/api/forum/posts/route.js
@@ -1,10 +1,11 @@
 import { NextResponse } from 'next/server';
 import { getAuthUserId } from '@/lib/clerk-server';
-import { moderateContent } from '@/lib/ai-moderation';
+import { moderateContent, OUTCOMES } from '@/lib/ai-moderation';
 import { generateAlias } from '@/lib/alias-generator';
 import { getSupabaseAdmin } from '@/lib/supabase-admin';
 import { crudLimiter } from '@/lib/rateLimiter';
 import { logger } from '@/lib/logger';
+import { validateSubmissionLength } from '@/lib/forum-limits';
 import {
   buildCursorFilter,
   buildFeedPage,
@@ -135,13 +136,35 @@ export async function POST(req) {
       return NextResponse.json({ error: 'Missing required fields' }, { status: 400 });
     }
 
+    // Length is checked here, before anything is sent to a provider. The route
+    // previously validated only that the fields were truthy, so a
+    // multi-megabyte body was forwarded verbatim to Gemini and then again to
+    // Groq on fallback — a slow, expensive request per attempt, reachable by
+    // anyone with an account at the ordinary crudLimiter rate.
+    const lengthError = validateSubmissionLength({ title, content });
+    if (lengthError) {
+      return NextResponse.json({ error: lengthError }, { status: 400 });
+    }
+
     // 1. Moderate content (both title and content)
     const moderationResult = await moderateContent(`${title}\n\n${content}`);
-    
+
     if (!moderationResult.isAppropriate) {
+      // A refusal and an outage are no longer the same response. The old code
+      // answered both with 403 and "your post violates our community
+      // guidelines", so a user whose ordinary post was blocked by a provider
+      // timeout was told she had broken the rules.
+      const isRefusal = moderationResult.outcome === OUTCOMES.REJECTED;
+
       return NextResponse.json(
-        { error: 'Your post violates our community guidelines.', reason: moderationResult.reason },
-        { status: 403 }
+        {
+          error: isRefusal
+            ? 'Your post violates our community guidelines.'
+            : moderationResult.reason,
+          reason: moderationResult.reason,
+          retryable: moderationResult.retryable,
+        },
+        { status: moderationResult.status }
       );
     }
 

--- a/lib/ai-moderation.js
+++ b/lib/ai-moderation.js
@@ -1,87 +1,270 @@
-import { GoogleGenerativeAI } from '@google/generative-ai';
+/**
+ * ai-moderation.js — the network half of community content moderation.
+ *
+ * Every forum post and every comment passes through `moderateContent()` before
+ * it reaches the database, so this function sits directly in front of a write
+ * the user is watching a spinner for. It previously had no deadline of any
+ * kind: neither the Gemini call nor the Groq `fetch` carried an
+ * `AbortController`, and the Groq call was reached from the Gemini `catch`, so
+ * a slow provider meant two unbounded network calls in series.
+ *
+ * The decision logic — what counts as an answer, how a malformed response is
+ * read, which failure beats which — lives in `lib/moderation-verdict.js` and
+ * is unit-tested there. This file is only responsible for making the calls and
+ * making sure they end.
+ *
+ * The fail-closed rule is unchanged and deliberate: when moderation cannot
+ * produce a real answer the content is rejected. What has changed is that the
+ * user is now told *which* thing happened, because "we could not check this,
+ * please try again" and "this breaks the rules" are not the same message to
+ * receive about a post describing your own diagnosis.
+ */
 
-// Initialize the Gemini API client
-const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY || '');
+import { GoogleGenerativeAI } from '@google/generative-ai'
+import { logger } from './logger.js'
+import {
+  MIN_FALLBACK_MS,
+  OUTCOMES,
+  PROVIDER_TIMEOUT_MS,
+  TOTAL_BUDGET_MS,
+  checkContentLength,
+  classifyProviderError,
+  combineAttempts,
+  extractCompletionText,
+  interpretProviderText,
+  makeVerdict,
+  providerDeadline,
+  remainingBudget,
+  shouldTryFallback,
+} from './moderation-verdict.js'
 
-async function callGroqModeration(content) {
-  if (!process.env.GROQ_API_KEY) {
-    throw new Error('GROQ_API_KEY is not set');
+export { MAX_MODERATION_CHARS, OUTCOMES } from './moderation-verdict.js'
+
+const MODERATION_INSTRUCTION =
+  "You are a strict community moderator for a women's health app focusing on PCOD and menstrual health. " +
+  'Analyze text for toxicity, harassment, hate speech, bullying, extreme profanity, or spam. ' +
+  "Return ONLY a raw JSON object with { isAppropriate: boolean, reason: '...' } with no markdown formatting."
+
+const GROQ_ENDPOINT = 'https://api.groq.com/openai/v1/chat/completions'
+const GROQ_MODEL = 'llama-3.1-8b-instant'
+const GEMINI_MODEL = 'gemini-2.5-flash'
+
+/**
+ * Runs `work` with a deadline, and makes sure the underlying request is
+ * actually cancelled rather than merely abandoned.
+ *
+ * The distinction matters on a serverless platform: an abandoned promise keeps
+ * the invocation billable and holds the socket open. `AbortController` is what
+ * releases both.
+ *
+ * @template T
+ * @param {(signal: AbortSignal) => Promise<T>} work
+ * @param {number} ms
+ * @returns {Promise<T>}
+ */
+async function withDeadline(work, ms) {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), ms)
+  try {
+    return await work(controller.signal)
+  } finally {
+    clearTimeout(timer)
   }
-
-  const response = await fetch('https://api.groq.com/openai/v1/chat/completions', {
-    method: 'POST',
-    headers: {
-      'Authorization': `Bearer ${process.env.GROQ_API_KEY}`,
-      'Content-Type': 'application/json'
-    },
-    body: JSON.stringify({
-      model: 'llama-3.1-8b-instant',
-      messages: [
-        { role: 'system', content: "You are a strict community moderator for a women's health app focusing on PCOD and menstrual health. Analyze text for toxicity, harassment, hate speech, bullying, extreme profanity, or spam. Return ONLY a raw JSON object with { isAppropriate: boolean, reason: '...' }." },
-        { role: 'user', content: `Analyze the following content:\n---\n${content}\n---` }
-      ],
-      max_tokens: 150
-    })
-  });
-
-  if (!response.ok) {
-    throw new Error(`Groq API returned status ${response.status}`);
-  }
-
-  const data = await response.json();
-  const responseText = data.choices[0].message.content;
-  
-  const jsonStr = responseText.replace(/```json/g, '').replace(/```/g, '').trim();
-  const parsed = JSON.parse(jsonStr);
-
-  if (typeof parsed.isAppropriate !== 'boolean') {
-    throw new Error('Invalid response format from Groq');
-  }
-
-  return parsed;
 }
 
 /**
- * Evaluates text for toxicity, harassment, and appropriateness using Gemini with a Groq fallback.
- * @param {string} content - The text content to moderate.
- * @returns {Promise<{ isAppropriate: boolean, reason: string }>}
+ * Gemini moderation call.
+ *
+ * The signal is threaded through `sendMessage`'s request options, which is the
+ * documented way to cancel a `@google/generative-ai` call.
+ *
+ * The client is constructed here rather than at module scope. The old
+ * module-level `new GoogleGenerativeAI(process.env.GEMINI_API_KEY || '')` was
+ * evaluated at import time, so a key supplied later in the process lifetime —
+ * or in a test — was never picked up, and an empty key produced a client that
+ * looked valid and failed on first use.
+ *
+ * @param {string} content
+ * @param {AbortSignal} signal
+ * @returns {Promise<string|null>} raw model text
  */
-export async function moderateContent(content) {
-  if (!process.env.GEMINI_API_KEY && !process.env.GROQ_API_KEY) {
-    throw new Error('AI Moderation services unavailable (missing API keys). Rejecting content securely.');
+async function callGemini(content, signal) {
+  if (!process.env.GEMINI_API_KEY) {
+    throw new Error('GEMINI_API_KEY is not set')
+  }
+
+  const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY)
+  const model = genAI.getGenerativeModel({ model: GEMINI_MODEL })
+
+  const chat = model.startChat({
+    history: [
+      { role: 'user', parts: [{ text: MODERATION_INSTRUCTION }] },
+      { role: 'model', parts: [{ text: 'Understood. I am ready to analyze content.' }] },
+    ],
+  })
+
+  const result = await chat.sendMessage(`Analyze the following content:\n---\n${content}\n---`, {
+    signal,
+  })
+
+  // `result.response.text()` throws when the candidate was blocked by the
+  // provider's own safety filter rather than answered. That is a provider
+  // outcome, not a crash, so it becomes "no text" and is classified upstream
+  // like any other unusable response.
+  try {
+    return result?.response?.text?.() ?? null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Groq moderation call.
+ *
+ * @param {string} content
+ * @param {AbortSignal} signal
+ * @returns {Promise<string|null>} raw model text
+ */
+async function callGroq(content, signal) {
+  if (!process.env.GROQ_API_KEY) {
+    throw new Error('GROQ_API_KEY is not set')
+  }
+
+  const response = await fetch(GROQ_ENDPOINT, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${process.env.GROQ_API_KEY}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      model: GROQ_MODEL,
+      messages: [
+        { role: 'system', content: MODERATION_INSTRUCTION },
+        { role: 'user', content: `Analyze the following content:\n---\n${content}\n---` },
+      ],
+      max_tokens: 150,
+    }),
+    signal,
+  })
+
+  if (!response.ok) {
+    throw new Error(`Groq API returned status ${response.status}`)
+  }
+
+  // A 200 carrying a body that is not JSON is a gateway error page, not an
+  // answer.
+  let payload
+  try {
+    payload = await response.json()
+  } catch {
+    return null
+  }
+
+  // `extractCompletionText` is the defensive read that replaces
+  // `data.choices[0].message.content`, which threw a TypeError on the empty
+  // `choices` array Groq returns for a filtered request.
+  return extractCompletionText(payload)
+}
+
+/**
+ * Attempts one provider and converts whatever happens into a verdict.
+ *
+ * Nothing thrown by a provider escapes this function. That is the property
+ * that lets the caller be a straight-line sequence instead of nested
+ * try/catches, and it is why a JSON parse failure can no longer be mistaken
+ * for a network failure.
+ *
+ * @param {(content: string, signal: AbortSignal) => Promise<string|null>} call
+ * @param {string} provider
+ * @param {string} content
+ * @param {number} timeoutMs
+ * @returns {Promise<import('./moderation-verdict').Verdict>}
+ */
+async function attemptProvider(call, provider, content, timeoutMs) {
+  if (timeoutMs <= 0) {
+    return makeVerdict(OUTCOMES.TIMED_OUT, {
+      provider,
+      detail: `${provider}: no time left in the moderation budget`,
+    })
   }
 
   try {
-    const model = genAI.getGenerativeModel({ model: 'gemini-2.5-flash' });
-    
-    const systemInstruction = "You are a strict community moderator for a women's health app focusing on PCOD and menstrual health. Analyze text for toxicity, harassment, hate speech, bullying, extreme profanity, or spam. Return ONLY a raw JSON object with { isAppropriate: boolean, reason: '...' } with no markdown formatting.";
-    
-    const chat = model.startChat({
-      history: [
-        { role: "user", parts: [{ text: systemInstruction }] },
-        { role: "model", parts: [{ text: "Understood. I am ready to analyze content." }] }
-      ]
-    });
-    
-    const result = await chat.sendMessage(`Analyze the following content:\n---\n${content}\n---`);
-    const responseText = result.response.text().trim();
-    
-    const jsonStr = responseText.replace(/```json/g, '').replace(/```/g, '').trim();
-    const parsed = JSON.parse(jsonStr);
-
-    if (typeof parsed.isAppropriate !== 'boolean') {
-      throw new Error('Invalid response format from Gemini');
-    }
-
-    return parsed;
+    const text = await withDeadline((signal) => call(content, signal), timeoutMs)
+    return interpretProviderText(text, provider)
   } catch (error) {
-    console.warn('Error during Gemini AI moderation (falling back to Groq):', error.message || error);
-    
-    try {
-      return await callGroqModeration(content);
-    } catch (fallbackError) {
-      console.error('Error during Groq AI moderation fallback:', fallbackError.message || fallbackError);
-      return { isAppropriate: false, reason: 'Content moderation system error. Please try again later.' };
-    }
+    return classifyProviderError(error, provider)
   }
+}
+
+/**
+ * Evaluates text for toxicity, harassment and appropriateness.
+ *
+ * Gemini is asked first; Groq is the fallback, but only when Gemini failed to
+ * produce an answer *and* enough of the budget remains to finish a second
+ * call. A rejection from Gemini is a real answer and ends the attempt — the
+ * old code's `catch`-driven fallback could not tell the two apart, so a model
+ * that said "this is harassment" in prose rather than JSON was quietly asked
+ * again by a different model.
+ *
+ * The returned object keeps `isAppropriate` and `reason`, so both existing
+ * call sites work unchanged, and adds `outcome`, `status` and `retryable` for
+ * routes that want to distinguish a refusal from an outage.
+ *
+ * @param {string} content
+ * @param {{ now?: () => number, budgetMs?: number, perCallMs?: number }} [options]
+ *   injection seams for tests; production passes nothing
+ * @returns {Promise<import('./moderation-verdict').Verdict>}
+ */
+export async function moderateContent(content, options = {}) {
+  const now = options.now || Date.now
+  const budgetMs = options.budgetMs ?? TOTAL_BUDGET_MS
+  const perCallMs = options.perCallMs ?? PROVIDER_TIMEOUT_MS
+
+  const refusedBeforeDispatch = checkContentLength(content)
+  if (refusedBeforeDispatch) {
+    logger.warn(`Moderation refused before dispatch: ${refusedBeforeDispatch.detail}`)
+    return refusedBeforeDispatch
+  }
+
+  const hasGemini = Boolean(process.env.GEMINI_API_KEY)
+  const hasGroq = Boolean(process.env.GROQ_API_KEY)
+
+  // Unconfigured is still fail-closed, but it is an operator problem and it is
+  // logged as one. The previous code threw here, which reached the route's
+  // generic 500 handler and told the user nothing useful.
+  if (!hasGemini && !hasGroq) {
+    logger.error('Moderation is unconfigured: neither GEMINI_API_KEY nor GROQ_API_KEY is set')
+    return makeVerdict(OUTCOMES.UNAVAILABLE, { detail: 'no moderation provider configured' })
+  }
+
+  const startedAt = now()
+
+  let primary
+  if (hasGemini) {
+    const deadline = providerDeadline(remainingBudget(startedAt, budgetMs, now), perCallMs)
+    primary = await attemptProvider(callGemini, 'gemini', content, deadline)
+  } else {
+    primary = makeVerdict(OUTCOMES.UNAVAILABLE, {
+      provider: 'gemini',
+      detail: 'gemini: GEMINI_API_KEY is not set',
+    })
+  }
+
+  let fallback = null
+  const left = remainingBudget(startedAt, budgetMs, now)
+
+  if (hasGroq && shouldTryFallback(primary, left, MIN_FALLBACK_MS)) {
+    logger.warn(`Moderation falling back to Groq (${primary.detail || primary.outcome})`)
+    fallback = await attemptProvider(callGroq, 'groq', content, providerDeadline(left, perCallMs))
+  }
+
+  const verdict = combineAttempts(primary, fallback)
+
+  if (verdict.outcome === OUTCOMES.TIMED_OUT || verdict.outcome === OUTCOMES.UNAVAILABLE) {
+    // `detail` and not `reason`: the operator gets the provider strings, the
+    // user gets the plain-language message.
+    logger.error(`Moderation could not reach a verdict — ${verdict.detail || 'no detail'}`)
+  }
+
+  return verdict
 }

--- a/lib/forum-limits.js
+++ b/lib/forum-limits.js
@@ -1,0 +1,79 @@
+/**
+ * forum-limits.js — size policy for community submissions.
+ *
+ * Neither forum write route validated length. `app/api/forum/posts/route.js`
+ * checked only that `categoryId`, `title` and `content` were truthy, and
+ * `app/api/forum/comments/route.js` only that `postId` and `content` were —
+ * so the size of what reached the moderation providers, and then the database,
+ * was whatever the client chose to send.
+ *
+ * The limits live here rather than inline in the routes so that the two write
+ * paths cannot drift apart, and so the boundary cases are reachable from a
+ * test without standing up a request.
+ *
+ * These are deliberately generous. The point is not to police how much someone
+ * writes about her own health; it is to make the request cost bounded.
+ */
+
+import { MAX_MODERATION_CHARS } from './moderation-verdict.js'
+
+/**
+ * Field ceilings, in characters.
+ *
+ * `content` is pinned to the moderation cap rather than chosen independently:
+ * a body the route accepts but moderation refuses to read would be rejected
+ * *after* the provider call rather than before it, which is the cost this
+ * check exists to avoid. Post title and body are moderated as one string, so
+ * the combined length is what has to fit.
+ */
+export const FORUM_LIMITS = Object.freeze({
+  TITLE: 200,
+  CONTENT: MAX_MODERATION_CHARS - 200,
+  COMMENT: 4000,
+})
+
+/**
+ * Validates a post submission.
+ *
+ * Returns `null` when the submission is acceptable, or a user-facing message
+ * when it is not. A message is not an exception: the caller answers 400 with
+ * it, because "this is too long" is something the user can act on directly.
+ *
+ * @param {{ title?: unknown, content?: unknown }} fields
+ * @returns {string|null}
+ */
+export function validateSubmissionLength(fields = {}) {
+  const { title, content } = fields
+
+  if (typeof title !== 'string' || title.trim().length === 0) {
+    return 'A title is required.'
+  }
+  if (typeof content !== 'string' || content.trim().length === 0) {
+    return 'Post content is required.'
+  }
+
+  if (title.length > FORUM_LIMITS.TITLE) {
+    return `Please keep the title under ${FORUM_LIMITS.TITLE} characters.`
+  }
+  if (content.length > FORUM_LIMITS.CONTENT) {
+    return `Please keep your post under ${FORUM_LIMITS.CONTENT.toLocaleString('en-US')} characters.`
+  }
+
+  return null
+}
+
+/**
+ * Validates a comment submission.
+ *
+ * @param {unknown} content
+ * @returns {string|null}
+ */
+export function validateCommentLength(content) {
+  if (typeof content !== 'string' || content.trim().length === 0) {
+    return 'A comment cannot be empty.'
+  }
+  if (content.length > FORUM_LIMITS.COMMENT) {
+    return `Please keep your comment under ${FORUM_LIMITS.COMMENT.toLocaleString('en-US')} characters.`
+  }
+  return null
+}

--- a/lib/moderation-verdict.js
+++ b/lib/moderation-verdict.js
@@ -1,0 +1,528 @@
+/**
+ * moderation-verdict.js — the decision half of community content moderation.
+ *
+ * ## Why this module exists
+ *
+ * `lib/ai-moderation.js` used to be the whole feature: it built the request,
+ * awaited it with no deadline, read `data.choices[0].message.content` without
+ * checking that `choices` had anything in it, `JSON.parse`d whatever came back,
+ * and expressed every possible failure as the same fail-closed object. Two
+ * route handlers await it inline before writing to the database, so any of
+ * those steps taking its time is a forum post that never completes.
+ *
+ * Separating the *decision* from the *network* buys three things:
+ *
+ * 1. It is testable. Every branch below is reachable from
+ *    `scripts/test-moderation-verdict.js` without a provider, a key, or a
+ *    socket.
+ * 2. Failures stop being interchangeable. "The provider timed out" and "the
+ *    provider says this is abuse" both block the post, but only one of them is
+ *    the user's fault, and only one of them is worth retrying. The old code
+ *    told the user the same thing either way.
+ * 3. The policy — how long, how much text, what counts as an answer — is
+ *    written down in one place instead of being implied by the order of a
+ *    try/catch.
+ *
+ * ## The contract
+ *
+ * Everything here is pure. No imports, no `fetch`, no clock reads except the
+ * ones passed in. It is safe in Route Handlers, Server Components and plain
+ * Node scripts alike.
+ *
+ * The one invariant that must not be weakened:
+ *
+ *   > When moderation cannot produce a real answer, the content is rejected.
+ *
+ * Failing open on an unreachable provider would turn an outage into an
+ * unmoderated forum, which for a PCOD and menstrual-health community is the
+ * worse of the two failures by a wide margin.
+ */
+
+// ---------------------------------------------------------------------------
+// Policy
+// ---------------------------------------------------------------------------
+
+/**
+ * Hard ceiling on the text handed to a provider.
+ *
+ * Neither forum route validated length. `app/api/forum/posts/route.js` checked
+ * only that `title` and `content` were truthy, so a multi-megabyte body was
+ * forwarded verbatim — to Gemini, and then again to Groq on fallback. That is
+ * a slow, expensive request per attempt, reachable by anyone with an account
+ * at the ordinary `crudLimiter` rate.
+ *
+ * 8 000 characters is far above any genuine forum post (the longest posts in
+ * the seed data are under 1 200) and far below the point where the request
+ * cost matters.
+ */
+export const MAX_MODERATION_CHARS = 8000
+
+/** Per-provider deadline. Matches the 8 s used by `app/api/chat/route.js`. */
+export const PROVIDER_TIMEOUT_MS = 8000
+
+/**
+ * Ceiling on the whole moderation attempt, primary plus fallback.
+ *
+ * Two providers at 8 s each is 16 s of wall clock in the worst case, and the
+ * user is watching a spinner for all of it. The budget is what stops the
+ * fallback from starting when there is no time left to finish it.
+ */
+export const TOTAL_BUDGET_MS = 12000
+
+/**
+ * Minimum time that must remain before a fallback is worth attempting. Below
+ * this the fallback would be cut off mid-flight, so it is skipped and the
+ * failure is reported immediately rather than 500 ms later.
+ */
+export const MIN_FALLBACK_MS = 1500
+
+// ---------------------------------------------------------------------------
+// Outcome vocabulary
+// ---------------------------------------------------------------------------
+
+/**
+ * Why a moderation attempt ended the way it did.
+ *
+ * These are deliberately distinct rather than collapsed into a boolean,
+ * because they call for different handling:
+ *
+ * - `APPROVED` / `REJECTED`   a provider answered. The verdict is real.
+ * - `TIMED_OUT`               nobody answered in time. Worth retrying.
+ * - `UNAVAILABLE`             the providers errored or are unconfigured.
+ * - `TOO_LONG`                the submission is over `MAX_MODERATION_CHARS`.
+ *                             Never sent anywhere; a 400, not a 403.
+ * - `EMPTY`                   nothing to moderate after trimming.
+ */
+export const OUTCOMES = Object.freeze({
+  APPROVED: 'approved',
+  REJECTED: 'rejected',
+  TIMED_OUT: 'timed_out',
+  UNAVAILABLE: 'unavailable',
+  TOO_LONG: 'too_long',
+  EMPTY: 'empty',
+})
+
+/**
+ * The HTTP status each outcome should produce.
+ *
+ * The old code answered every failure with the 403 that means "your post
+ * violates our community guidelines". A user whose perfectly ordinary post was
+ * blocked by a provider outage was told she had broken the rules.
+ */
+const OUTCOME_STATUS = Object.freeze({
+  [OUTCOMES.APPROVED]: 200,
+  [OUTCOMES.REJECTED]: 403,
+  [OUTCOMES.TIMED_OUT]: 503,
+  [OUTCOMES.UNAVAILABLE]: 503,
+  [OUTCOMES.TOO_LONG]: 400,
+  [OUTCOMES.EMPTY]: 400,
+})
+
+/** Whether trying again in a moment could plausibly succeed. */
+const OUTCOME_RETRYABLE = Object.freeze({
+  [OUTCOMES.APPROVED]: false,
+  [OUTCOMES.REJECTED]: false,
+  [OUTCOMES.TIMED_OUT]: true,
+  [OUTCOMES.UNAVAILABLE]: true,
+  [OUTCOMES.TOO_LONG]: false,
+  [OUTCOMES.EMPTY]: false,
+})
+
+const DEFAULT_MESSAGES = Object.freeze({
+  [OUTCOMES.REJECTED]: 'This post does not meet our community guidelines.',
+  [OUTCOMES.TIMED_OUT]:
+    'We could not check this post in time. Nothing was lost — please try posting again.',
+  [OUTCOMES.UNAVAILABLE]:
+    'Post checking is temporarily unavailable. Please try again in a few minutes.',
+  [OUTCOMES.TOO_LONG]: `Please keep your post under ${MAX_MODERATION_CHARS.toLocaleString('en-US')} characters.`,
+  [OUTCOMES.EMPTY]: 'There is nothing here to post.',
+})
+
+// ---------------------------------------------------------------------------
+// Verdicts
+// ---------------------------------------------------------------------------
+
+/**
+ * @typedef {object} Verdict
+ * @property {boolean} isAppropriate  the field the existing call sites read
+ * @property {string}  outcome        one of {@link OUTCOMES}
+ * @property {string}  reason         user-facing text; never a provider error
+ * @property {number}  status         the HTTP status the route should send
+ * @property {boolean} retryable      whether trying again could help
+ * @property {string|null} provider   which provider answered, if any
+ * @property {string|null} detail     operator-facing text, for the log only
+ */
+
+/**
+ * Builds a verdict. The only constructor — nothing else in the codebase should
+ * be assembling this shape by hand.
+ *
+ * `reason` is what the user sees, so it never carries `detail`, which is where
+ * provider error strings, status codes and stack messages go. Echoing those
+ * back is how a moderation endpoint turns into a probe for which AI vendor you
+ * use and whether your key is valid.
+ *
+ * @param {string} outcome
+ * @param {{ reason?: string, provider?: string|null, detail?: string|null }} [options]
+ * @returns {Verdict}
+ */
+export function makeVerdict(outcome, options = {}) {
+  const known = Object.values(OUTCOMES).includes(outcome) ? outcome : OUTCOMES.UNAVAILABLE
+
+  return {
+    isAppropriate: known === OUTCOMES.APPROVED,
+    outcome: known,
+    reason:
+      typeof options.reason === 'string' && options.reason.trim().length > 0
+        ? options.reason.trim()
+        : DEFAULT_MESSAGES[known] || '',
+    status: OUTCOME_STATUS[known],
+    retryable: OUTCOME_RETRYABLE[known],
+    provider: options.provider || null,
+    detail: options.detail || null,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Input policy
+// ---------------------------------------------------------------------------
+
+/**
+ * Checks a submission before any provider is contacted.
+ *
+ * Returns `null` when the content is fine to send — the caller should read that
+ * as "carry on", not as an error. A non-null return is a finished verdict and
+ * no network call should happen.
+ *
+ * @param {unknown} content
+ * @param {number}  [maxChars=MAX_MODERATION_CHARS]
+ * @returns {Verdict|null}
+ */
+export function checkContentLength(content, maxChars = MAX_MODERATION_CHARS) {
+  if (typeof content !== 'string') {
+    return makeVerdict(OUTCOMES.EMPTY, { detail: `content was ${typeof content}` })
+  }
+
+  const trimmed = content.trim()
+  if (trimmed.length === 0) {
+    return makeVerdict(OUTCOMES.EMPTY, { detail: 'content was blank after trimming' })
+  }
+
+  // Measured on the untrimmed string: whitespace still costs tokens, and a
+  // submission padded to 2 MB with newlines is exactly the request this cap
+  // exists to refuse.
+  if (content.length > maxChars) {
+    return makeVerdict(OUTCOMES.TOO_LONG, {
+      detail: `content was ${content.length} characters, limit is ${maxChars}`,
+    })
+  }
+
+  return null
+}
+
+// ---------------------------------------------------------------------------
+// Reading what a provider actually sent back
+// ---------------------------------------------------------------------------
+
+/**
+ * Pulls the assistant text out of an OpenAI-shaped completion response.
+ *
+ * The previous implementation was:
+ *
+ *     const responseText = data.choices[0].message.content;
+ *
+ * Groq answers a filtered request with `{"choices": []}`, and some failure
+ * modes return `{"error": {...}}` with HTTP 200. `data.choices[0]` is then
+ * `undefined` and reading `.message` throws a `TypeError` — which the outer
+ * handler caught and reported to the user as a guidelines violation, while the
+ * real cause never reached the log in a recognisable form.
+ *
+ * Returns `null` rather than throwing. A provider that did not answer is a
+ * fact to be handled, not an exception.
+ *
+ * @param {unknown} payload the parsed JSON body
+ * @returns {string|null}
+ */
+export function extractCompletionText(payload) {
+  if (!payload || typeof payload !== 'object') return null
+
+  const choices = payload.choices
+  if (!Array.isArray(choices) || choices.length === 0) return null
+
+  const first = choices[0]
+  if (!first || typeof first !== 'object') return null
+
+  const message = first.message
+  if (!message || typeof message !== 'object') return null
+
+  const content = message.content
+  if (typeof content !== 'string' || content.trim().length === 0) return null
+
+  return content
+}
+
+/**
+ * Recovers a JSON object from model output.
+ *
+ * Both providers are asked for raw JSON and mostly comply. When they do not,
+ * it is one of a small number of well-known shapes:
+ *
+ *   ```json\n{"isAppropriate": true}\n```      fenced
+ *   Here is the analysis: {"isAppropriate": true}   prefixed with prose
+ *   {"isAppropriate": true}\n\nLet me know…         followed by prose
+ *
+ * The old code stripped the fences and called `JSON.parse` on the rest, which
+ * threw on the other two. On the Gemini path that throw was indistinguishable
+ * from a network error, so it burned the Groq fallback on a problem a retry
+ * could never fix.
+ *
+ * Strategy: strip fences, try a direct parse, and only if that fails fall back
+ * to the outermost balanced `{...}` span. Returns `null` when there is nothing
+ * parseable — never throws.
+ *
+ * @param {unknown} text
+ * @returns {object|null}
+ */
+export function extractJsonObject(text) {
+  if (typeof text !== 'string') return null
+
+  const withoutFences = text
+    .replace(/```(?:json|JSON)?/g, '')
+    .replace(/```/g, '')
+    .trim()
+
+  if (withoutFences.length === 0) return null
+
+  const direct = tryParseObject(withoutFences)
+  if (direct) return direct
+
+  const span = findBalancedObject(withoutFences)
+  return span ? tryParseObject(span) : null
+}
+
+/**
+ * Returns the first brace-balanced `{...}` span in `text`, or `null`.
+ *
+ * Depth counting rather than `indexOf('{')` … `lastIndexOf('}')`: the naive
+ * span breaks on a trailing sentence that happens to contain a closing brace,
+ * which models produce often enough ("…note the } character"). Braces inside
+ * string literals are skipped, with `\` honoured as an escape, so a reason
+ * field containing a brace cannot unbalance the scan either.
+ *
+ * @param {string} text
+ * @returns {string|null}
+ */
+function findBalancedObject(text) {
+  const start = text.indexOf('{')
+  if (start === -1) return null
+
+  let depth = 0
+  let inString = false
+  let escaped = false
+
+  for (let i = start; i < text.length; i += 1) {
+    const char = text[i]
+
+    if (escaped) {
+      escaped = false
+      continue
+    }
+    if (char === '\\') {
+      // Only meaningful inside a string, but harmless outside one: JSON has no
+      // other use for a backslash.
+      escaped = true
+      continue
+    }
+    if (char === '"') {
+      inString = !inString
+      continue
+    }
+    if (inString) continue
+
+    if (char === '{') depth += 1
+    else if (char === '}') {
+      depth -= 1
+      if (depth === 0) return text.slice(start, i + 1)
+    }
+  }
+
+  return null
+}
+
+function tryParseObject(candidate) {
+  try {
+    const parsed = JSON.parse(candidate)
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null
+    return parsed
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Turns raw provider text into a verdict.
+ *
+ * A provider that returns something unreadable has *not* voted. It is
+ * `UNAVAILABLE`, so the caller may still try the fallback — as opposed to
+ * `REJECTED`, which is a real answer and ends the attempt.
+ *
+ * `isAppropriate` must be a genuine boolean. The old check was
+ * `typeof parsed.isAppropriate !== 'boolean'`, which was right, but it threw
+ * rather than returning, so the distinction was lost by the time anything
+ * could act on it. A model that answers `"true"` as a string has not followed
+ * the schema, and guessing what it meant is how a moderation bypass gets in.
+ *
+ * @param {string|null} rawText
+ * @param {string} provider
+ * @returns {Verdict}
+ */
+export function interpretProviderText(rawText, provider) {
+  if (typeof rawText !== 'string' || rawText.trim().length === 0) {
+    return makeVerdict(OUTCOMES.UNAVAILABLE, {
+      provider,
+      detail: `${provider} returned no text`,
+    })
+  }
+
+  const parsed = extractJsonObject(rawText)
+  if (!parsed) {
+    return makeVerdict(OUTCOMES.UNAVAILABLE, {
+      provider,
+      detail: `${provider} returned text that is not JSON`,
+    })
+  }
+
+  if (typeof parsed.isAppropriate !== 'boolean') {
+    return makeVerdict(OUTCOMES.UNAVAILABLE, {
+      provider,
+      detail: `${provider} returned isAppropriate as ${typeof parsed.isAppropriate}`,
+    })
+  }
+
+  if (parsed.isAppropriate) {
+    return makeVerdict(OUTCOMES.APPROVED, { provider })
+  }
+
+  // The model's own words are shown to the user, because "this reads as
+  // harassment" is more useful than a generic refusal — but only when it is a
+  // short, plain string. A model that returns a paragraph, an object, or an
+  // echo of the submission gets replaced with the default text.
+  const modelReason =
+    typeof parsed.reason === 'string' && parsed.reason.trim().length > 0 && parsed.reason.length <= 300
+      ? parsed.reason.trim()
+      : null
+
+  return makeVerdict(OUTCOMES.REJECTED, { provider, reason: modelReason })
+}
+
+// ---------------------------------------------------------------------------
+// Combining attempts
+// ---------------------------------------------------------------------------
+
+/**
+ * Classifies a thrown error into an outcome.
+ *
+ * An `AbortError` is what an `AbortController` deadline produces, so it is the
+ * signal for `TIMED_OUT`. Everything else — a DNS failure, a 401 from a bad
+ * key, a 429, a socket reset — is `UNAVAILABLE`.
+ *
+ * @param {unknown} error
+ * @param {string}  provider
+ * @returns {Verdict}
+ */
+export function classifyProviderError(error, provider) {
+  const name = error?.name
+  const message = error?.message || String(error || 'unknown error')
+
+  const timedOut = name === 'AbortError' || name === 'TimeoutError' || /timed? ?out/i.test(message)
+
+  return makeVerdict(timedOut ? OUTCOMES.TIMED_OUT : OUTCOMES.UNAVAILABLE, {
+    provider,
+    detail: `${provider}: ${message}`,
+  })
+}
+
+/**
+ * Decides whether the fallback provider is worth attempting.
+ *
+ * Two independent reasons not to:
+ *
+ * - The primary produced a *real* answer. Approved or rejected are both
+ *   verdicts; asking a second model to overturn the first is not a fallback,
+ *   it is a second opinion nobody asked for.
+ * - There is not enough of the budget left. Starting an 8 s call with 400 ms
+ *   remaining just moves the same failure later.
+ *
+ * @param {Verdict} primary
+ * @param {number}  remainingMs
+ * @param {number}  [minMs=MIN_FALLBACK_MS]
+ * @returns {boolean}
+ */
+export function shouldTryFallback(primary, remainingMs, minMs = MIN_FALLBACK_MS) {
+  if (!primary) return false
+  if (primary.outcome === OUTCOMES.APPROVED || primary.outcome === OUTCOMES.REJECTED) return false
+  if (!Number.isFinite(remainingMs) || remainingMs < minMs) return false
+  return true
+}
+
+/**
+ * Merges a primary and a fallback attempt into the verdict the route acts on.
+ *
+ * A real answer from either provider wins. When neither answered, the failures
+ * are combined, and `TIMED_OUT` is preferred over `UNAVAILABLE` because it is
+ * the more actionable of the two: it tells the user their post is fine and
+ * they should try again, rather than that something is broken.
+ *
+ * Both `detail` strings are kept so the log shows what each provider did,
+ * which was the thing the old nested try/catch made impossible to see.
+ *
+ * @param {Verdict} primary
+ * @param {Verdict|null} fallback
+ * @returns {Verdict}
+ */
+export function combineAttempts(primary, fallback) {
+  if (!fallback) return primary
+
+  if (fallback.outcome === OUTCOMES.APPROVED || fallback.outcome === OUTCOMES.REJECTED) {
+    return fallback
+  }
+
+  const detail = [primary?.detail, fallback.detail].filter(Boolean).join(' | ') || null
+  const timedOut =
+    primary?.outcome === OUTCOMES.TIMED_OUT || fallback.outcome === OUTCOMES.TIMED_OUT
+
+  return makeVerdict(timedOut ? OUTCOMES.TIMED_OUT : OUTCOMES.UNAVAILABLE, {
+    provider: null,
+    detail,
+  })
+}
+
+/**
+ * How long is left of the budget.
+ *
+ * Takes the clock as an argument so the budget arithmetic is testable without
+ * waiting for real time to pass.
+ *
+ * @param {number} startedAt  the value of `now()` when the attempt began
+ * @param {number} budgetMs
+ * @param {() => number} [now=Date.now]
+ * @returns {number} never negative
+ */
+export function remainingBudget(startedAt, budgetMs, now = Date.now) {
+  const elapsed = now() - startedAt
+  const left = budgetMs - elapsed
+  return left > 0 ? left : 0
+}
+
+/**
+ * The deadline for a single provider call: whatever is smaller, the per-call
+ * timeout or what is left of the overall budget.
+ *
+ * @param {number} remainingMs
+ * @param {number} [perCallMs=PROVIDER_TIMEOUT_MS]
+ * @returns {number}
+ */
+export function providerDeadline(remainingMs, perCallMs = PROVIDER_TIMEOUT_MS) {
+  const bounded = Number.isFinite(remainingMs) && remainingMs > 0 ? remainingMs : 0
+  return Math.min(perCallMs, bounded)
+}

--- a/scripts/test-moderation-verdict.js
+++ b/scripts/test-moderation-verdict.js
@@ -1,0 +1,433 @@
+/**
+ * Regression suite for lib/moderation-verdict.js and lib/forum-limits.js.
+ *
+ * The bug this is part of fixing: `moderateContent()` had no deadline on
+ * either provider, read `data.choices[0].message.content` without checking
+ * that `choices` had anything in it, `JSON.parse`d arbitrary model output, and
+ * expressed a network timeout and a genuine "this is harassment" as the same
+ * fail-closed object — which both forum write routes then reported to the user
+ * as a 403 "your post violates our community guidelines".
+ *
+ * What this suite pins is the part that is easy to get subtly wrong and
+ * impossible to check by hand: that an unreadable provider response is treated
+ * as "did not answer" rather than as a verdict, that a real verdict from the
+ * primary provider is never second-guessed by the fallback, that the budget
+ * arithmetic cannot start a call it has no time to finish, and — the invariant
+ * that matters most — that no path anywhere returns `isAppropriate: true`
+ * without a provider having genuinely said so.
+ *
+ *   node scripts/test-moderation-verdict.js
+ */
+
+import {
+  MAX_MODERATION_CHARS,
+  MIN_FALLBACK_MS,
+  OUTCOMES,
+  PROVIDER_TIMEOUT_MS,
+  checkContentLength,
+  classifyProviderError,
+  combineAttempts,
+  extractCompletionText,
+  extractJsonObject,
+  interpretProviderText,
+  makeVerdict,
+  providerDeadline,
+  remainingBudget,
+  shouldTryFallback,
+} from '../lib/moderation-verdict.js'
+
+import {
+  FORUM_LIMITS,
+  validateCommentLength,
+  validateSubmissionLength,
+} from '../lib/forum-limits.js'
+
+let passed = 0
+let failed = 0
+
+function check(actual, expected, label) {
+  if (Object.is(actual, expected)) {
+    passed += 1
+    return
+  }
+  failed += 1
+  console.error(`  ❌ ${label}`)
+  console.error(`       expected: ${JSON.stringify(expected)}`)
+  console.error(`       actual:   ${JSON.stringify(actual)}`)
+}
+
+function checkDeep(actual, expected, label) {
+  const a = JSON.stringify(actual)
+  const b = JSON.stringify(expected)
+  if (a === b) {
+    passed += 1
+    return
+  }
+  failed += 1
+  console.error(`  ❌ ${label}`)
+  console.error(`       expected: ${b}`)
+  console.error(`       actual:   ${a}`)
+}
+
+function checkTruthy(value, label) {
+  check(Boolean(value), true, label)
+}
+
+function section(title) {
+  console.log(`\n${title}`)
+}
+
+// ---------------------------------------------------------------------------
+
+section('extractCompletionText — the read that used to throw')
+
+check(
+  extractCompletionText({ choices: [{ message: { content: '{"isAppropriate":true}' } }] }),
+  '{"isAppropriate":true}',
+  'reads content out of a well-formed completion'
+)
+
+// This is the exact payload Groq returns for a filtered request. The old
+// `data.choices[0].message.content` raised "Cannot read properties of
+// undefined (reading 'message')", which the outer catch turned into a
+// guidelines violation shown to the user.
+check(extractCompletionText({ choices: [] }), null, 'empty choices array is null, not a throw')
+check(extractCompletionText({ error: { message: 'invalid_api_key' } }), null, '{error} body with HTTP 200 is null')
+check(extractCompletionText({}), null, 'missing choices is null')
+check(extractCompletionText(null), null, 'null payload is null')
+check(extractCompletionText(undefined), null, 'undefined payload is null')
+check(extractCompletionText('a string'), null, 'non-object payload is null')
+check(extractCompletionText({ choices: [null] }), null, 'null first choice is null')
+check(extractCompletionText({ choices: [{}] }), null, 'choice without message is null')
+check(extractCompletionText({ choices: [{ message: {} }] }), null, 'message without content is null')
+check(
+  extractCompletionText({ choices: [{ message: { content: '   ' } }] }),
+  null,
+  'whitespace-only content is null'
+)
+check(
+  extractCompletionText({ choices: [{ message: { content: 42 } }] }),
+  null,
+  'non-string content is null'
+)
+
+// ---------------------------------------------------------------------------
+
+section('extractJsonObject — recovering JSON from model prose')
+
+checkDeep(
+  extractJsonObject('{"isAppropriate": true}'),
+  { isAppropriate: true },
+  'bare JSON parses'
+)
+checkDeep(
+  extractJsonObject('```json\n{"isAppropriate": false, "reason": "spam"}\n```'),
+  { isAppropriate: false, reason: 'spam' },
+  'fenced JSON parses (the only case the old code handled)'
+)
+checkDeep(
+  extractJsonObject('Here is the analysis: {"isAppropriate": true}'),
+  { isAppropriate: true },
+  'JSON preceded by prose parses — the old code threw here'
+)
+checkDeep(
+  extractJsonObject('{"isAppropriate": true}\n\nLet me know if you need more detail.'),
+  { isAppropriate: true },
+  'JSON followed by prose parses'
+)
+checkDeep(
+  extractJsonObject('{"isAppropriate": false, "meta": {"model": "x"}}'),
+  { isAppropriate: false, meta: { model: 'x' } },
+  'nested objects survive the balanced-brace fallback'
+)
+check(extractJsonObject('no json at all'), null, 'prose with no object is null')
+check(extractJsonObject('{ this is not json }'), null, 'brace-delimited non-JSON is null')
+check(extractJsonObject('[1, 2, 3]'), null, 'a top-level array is not an object')
+check(extractJsonObject(''), null, 'empty string is null')
+check(extractJsonObject('```json\n```'), null, 'empty fences are null')
+check(extractJsonObject(null), null, 'null is null')
+check(extractJsonObject(42), null, 'a number is null')
+
+// A trailing brace inside a sentence must not truncate the object. This is
+// why the fallback counts depth instead of taking indexOf('{')..lastIndexOf('}').
+checkDeep(
+  extractJsonObject('{"isAppropriate": true, "reason": "fine"} — note the } character'),
+  { isAppropriate: true, reason: 'fine' },
+  'a stray closing brace in trailing prose does not break extraction'
+)
+checkDeep(
+  extractJsonObject('Result: {"isAppropriate": false, "reason": "used {curly} braces"} done'),
+  { isAppropriate: false, reason: 'used {curly} braces' },
+  'braces inside a string value do not unbalance the scan'
+)
+checkDeep(
+  extractJsonObject('Result: {"isAppropriate": false, "reason": "a \\" quote"} done'),
+  { isAppropriate: false, reason: 'a " quote' },
+  'an escaped quote does not end the string early'
+)
+check(
+  extractJsonObject('prose { unterminated'),
+  null,
+  'an unbalanced opening brace is null rather than a partial parse'
+)
+
+// ---------------------------------------------------------------------------
+
+section('interpretProviderText — turning text into a verdict')
+
+const approved = interpretProviderText('{"isAppropriate": true}', 'gemini')
+check(approved.outcome, OUTCOMES.APPROVED, 'true maps to APPROVED')
+check(approved.isAppropriate, true, 'APPROVED sets isAppropriate')
+check(approved.status, 200, 'APPROVED is a 200')
+check(approved.provider, 'gemini', 'the answering provider is recorded')
+
+const rejected = interpretProviderText('{"isAppropriate": false, "reason": "Targeted harassment"}', 'groq')
+check(rejected.outcome, OUTCOMES.REJECTED, 'false maps to REJECTED')
+check(rejected.isAppropriate, false, 'REJECTED clears isAppropriate')
+check(rejected.status, 403, 'REJECTED is a 403')
+check(rejected.retryable, false, 'a refusal is not retryable')
+check(rejected.reason, 'Targeted harassment', "the model's own short reason is shown to the user")
+
+// A model that returns an essay, or the submission back, is not a message to
+// put in front of the user.
+const longReason = interpretProviderText(
+  JSON.stringify({ isAppropriate: false, reason: 'x'.repeat(400) }),
+  'groq'
+)
+check(longReason.outcome, OUTCOMES.REJECTED, 'an over-long reason is still a rejection')
+checkTruthy(longReason.reason.length < 300, 'an over-long reason is replaced with the default text')
+
+const objectReason = interpretProviderText(
+  JSON.stringify({ isAppropriate: false, reason: { code: 'spam' } }),
+  'groq'
+)
+check(objectReason.outcome, OUTCOMES.REJECTED, 'a non-string reason is still a rejection')
+checkTruthy(objectReason.reason.length > 0, 'a non-string reason falls back to default text')
+
+// The critical one. A model that answers "true" as a string has not followed
+// the schema, and guessing that it meant boolean true is a moderation bypass.
+const stringBoolean = interpretProviderText('{"isAppropriate": "true"}', 'gemini')
+check(stringBoolean.outcome, OUTCOMES.UNAVAILABLE, 'a stringified boolean is not an answer')
+check(stringBoolean.isAppropriate, false, 'a stringified boolean does not approve content')
+
+check(interpretProviderText('{"verdict": "ok"}', 'gemini').outcome, OUTCOMES.UNAVAILABLE, 'a missing isAppropriate is not an answer')
+check(interpretProviderText('I cannot help with that.', 'gemini').outcome, OUTCOMES.UNAVAILABLE, 'prose with no JSON is not an answer')
+check(interpretProviderText('', 'gemini').outcome, OUTCOMES.UNAVAILABLE, 'empty text is not an answer')
+check(interpretProviderText(null, 'gemini').outcome, OUTCOMES.UNAVAILABLE, 'null text is not an answer')
+
+// ---------------------------------------------------------------------------
+
+section('checkContentLength — refusing before dispatch')
+
+check(checkContentLength('a normal post'), null, 'ordinary content is cleared to send')
+check(checkContentLength('x'.repeat(MAX_MODERATION_CHARS)), null, 'content exactly at the cap is allowed')
+
+const tooLong = checkContentLength('x'.repeat(MAX_MODERATION_CHARS + 1))
+check(tooLong.outcome, OUTCOMES.TOO_LONG, 'one character over the cap is refused')
+check(tooLong.status, 400, 'too long is a 400, not a 403 — it is not a guidelines matter')
+check(tooLong.retryable, false, 'resubmitting the same over-long text will not help')
+
+// Whitespace padding still costs tokens, so the cap is measured untrimmed.
+check(
+  checkContentLength(`hello${' '.repeat(MAX_MODERATION_CHARS)}`).outcome,
+  OUTCOMES.TOO_LONG,
+  'whitespace padding counts toward the cap'
+)
+
+check(checkContentLength('').outcome, OUTCOMES.EMPTY, 'empty string is EMPTY')
+check(checkContentLength('   \n\t ').outcome, OUTCOMES.EMPTY, 'whitespace-only is EMPTY')
+check(checkContentLength(null).outcome, OUTCOMES.EMPTY, 'null is EMPTY')
+check(checkContentLength(undefined).outcome, OUTCOMES.EMPTY, 'undefined is EMPTY')
+check(checkContentLength(12345).outcome, OUTCOMES.EMPTY, 'a number is EMPTY')
+check(checkContentLength('x'.repeat(50), 20).outcome, OUTCOMES.TOO_LONG, 'the cap is overridable')
+
+// ---------------------------------------------------------------------------
+
+section('classifyProviderError — a timeout is not an outage')
+
+check(
+  classifyProviderError(Object.assign(new Error('aborted'), { name: 'AbortError' }), 'gemini').outcome,
+  OUTCOMES.TIMED_OUT,
+  'AbortError — what the deadline produces — is TIMED_OUT'
+)
+check(
+  classifyProviderError(Object.assign(new Error('nope'), { name: 'TimeoutError' }), 'groq').outcome,
+  OUTCOMES.TIMED_OUT,
+  'TimeoutError is TIMED_OUT'
+)
+check(
+  classifyProviderError(new Error('Request timed out after 8 seconds'), 'groq').outcome,
+  OUTCOMES.TIMED_OUT,
+  'a timeout described only in the message is still TIMED_OUT'
+)
+check(
+  classifyProviderError(new Error('Groq API returned status 401'), 'groq').outcome,
+  OUTCOMES.UNAVAILABLE,
+  'a bad key is UNAVAILABLE, not a timeout'
+)
+check(
+  classifyProviderError(new Error('getaddrinfo ENOTFOUND'), 'gemini').outcome,
+  OUTCOMES.UNAVAILABLE,
+  'a DNS failure is UNAVAILABLE'
+)
+check(classifyProviderError(undefined, 'gemini').outcome, OUTCOMES.UNAVAILABLE, 'a thrown undefined is UNAVAILABLE')
+
+const timedOut = classifyProviderError(
+  Object.assign(new Error('aborted'), { name: 'AbortError' }),
+  'gemini'
+)
+check(timedOut.status, 503, 'a timeout is a 503')
+check(timedOut.retryable, true, 'a timeout is worth retrying')
+check(timedOut.isAppropriate, false, 'a timeout still blocks the post — fail closed')
+checkTruthy(timedOut.detail.includes('gemini'), 'the operator detail names the provider')
+checkTruthy(!timedOut.reason.includes('gemini'), 'the user-facing reason does not leak the provider name')
+
+// ---------------------------------------------------------------------------
+
+section('shouldTryFallback — when a second provider is worth asking')
+
+const unavailable = makeVerdict(OUTCOMES.UNAVAILABLE, { provider: 'gemini' })
+
+check(shouldTryFallback(unavailable, 9000), true, 'an unanswered primary with time left falls back')
+check(
+  shouldTryFallback(makeVerdict(OUTCOMES.TIMED_OUT, {}), 9000),
+  true,
+  'a timed-out primary with time left falls back'
+)
+check(
+  shouldTryFallback(makeVerdict(OUTCOMES.APPROVED, {}), 9000),
+  false,
+  'an approval is a real answer — no second opinion'
+)
+check(
+  shouldTryFallback(makeVerdict(OUTCOMES.REJECTED, {}), 9000),
+  false,
+  'a rejection is a real answer — the fallback must not overturn it'
+)
+check(shouldTryFallback(unavailable, MIN_FALLBACK_MS - 1), false, 'below the minimum, do not start a call')
+check(shouldTryFallback(unavailable, MIN_FALLBACK_MS), true, 'exactly at the minimum, go ahead')
+check(shouldTryFallback(unavailable, 0), false, 'no budget left means no fallback')
+check(shouldTryFallback(unavailable, NaN), false, 'a non-finite budget means no fallback')
+check(shouldTryFallback(null, 9000), false, 'no primary verdict means no fallback')
+
+// ---------------------------------------------------------------------------
+
+section('combineAttempts — merging two failures')
+
+check(
+  combineAttempts(makeVerdict(OUTCOMES.UNAVAILABLE, {}), makeVerdict(OUTCOMES.APPROVED, { provider: 'groq' })).outcome,
+  OUTCOMES.APPROVED,
+  'the fallback answering wins'
+)
+check(
+  combineAttempts(makeVerdict(OUTCOMES.TIMED_OUT, {}), makeVerdict(OUTCOMES.REJECTED, { provider: 'groq' })).outcome,
+  OUTCOMES.REJECTED,
+  'a fallback rejection wins'
+)
+check(
+  combineAttempts(makeVerdict(OUTCOMES.APPROVED, { provider: 'gemini' }), null).outcome,
+  OUTCOMES.APPROVED,
+  'no fallback leaves the primary untouched'
+)
+
+const bothTimedOut = combineAttempts(
+  makeVerdict(OUTCOMES.TIMED_OUT, { detail: 'gemini: aborted' }),
+  makeVerdict(OUTCOMES.UNAVAILABLE, { detail: 'groq: status 500' })
+)
+check(bothTimedOut.outcome, OUTCOMES.TIMED_OUT, 'TIMED_OUT is preferred — it is the more actionable message')
+checkTruthy(bothTimedOut.detail.includes('gemini'), 'the merged detail keeps the primary failure')
+checkTruthy(bothTimedOut.detail.includes('groq'), 'the merged detail keeps the fallback failure')
+
+check(
+  combineAttempts(
+    makeVerdict(OUTCOMES.UNAVAILABLE, { detail: 'gemini: bad key' }),
+    makeVerdict(OUTCOMES.UNAVAILABLE, { detail: 'groq: bad key' })
+  ).outcome,
+  OUTCOMES.UNAVAILABLE,
+  'two outages merge to UNAVAILABLE'
+)
+
+// ---------------------------------------------------------------------------
+
+section('budget arithmetic')
+
+check(remainingBudget(1000, 12000, () => 1000), 12000, 'nothing elapsed leaves the full budget')
+check(remainingBudget(1000, 12000, () => 5000), 8000, 'elapsed time is subtracted')
+check(remainingBudget(1000, 12000, () => 20000), 0, 'an overrun clamps to zero, never negative')
+
+check(providerDeadline(20000), PROVIDER_TIMEOUT_MS, 'the per-call timeout caps a large budget')
+check(providerDeadline(3000), 3000, 'a small budget caps the per-call timeout')
+check(providerDeadline(0), 0, 'no budget means no deadline to give')
+check(providerDeadline(-500), 0, 'a negative budget clamps to zero')
+check(providerDeadline(5000, 2000), 2000, 'the per-call timeout is overridable')
+
+// ---------------------------------------------------------------------------
+
+section('makeVerdict — the invariant')
+
+// Every outcome except APPROVED must block the write. If this ever fails, an
+// outage has become an unmoderated forum.
+for (const outcome of Object.values(OUTCOMES)) {
+  const verdict = makeVerdict(outcome, {})
+  check(
+    verdict.isAppropriate,
+    outcome === OUTCOMES.APPROVED,
+    `${outcome} approves content only when it is APPROVED`
+  )
+  checkTruthy(Number.isInteger(verdict.status), `${outcome} carries an HTTP status`)
+  checkTruthy(typeof verdict.retryable === 'boolean', `${outcome} says whether a retry could help`)
+}
+
+check(makeVerdict('not-a-real-outcome', {}).outcome, OUTCOMES.UNAVAILABLE, 'an unknown outcome degrades to UNAVAILABLE')
+check(makeVerdict('not-a-real-outcome', {}).isAppropriate, false, 'an unknown outcome does not approve content')
+check(makeVerdict(OUTCOMES.REJECTED, { reason: '   ' }).reason.length > 0, true, 'a blank reason falls back to default text')
+
+// ---------------------------------------------------------------------------
+
+section('forum-limits — size policy at the route boundary')
+
+check(validateSubmissionLength({ title: 'Hi', content: 'Hello' }), null, 'an ordinary post is accepted')
+check(validateSubmissionLength({ title: '', content: 'Hello' }) !== null, true, 'a blank title is rejected')
+check(validateSubmissionLength({ title: '   ', content: 'Hello' }) !== null, true, 'a whitespace title is rejected')
+check(validateSubmissionLength({ title: 'Hi', content: '  ' }) !== null, true, 'blank content is rejected')
+check(validateSubmissionLength({ title: 42, content: 'Hello' }) !== null, true, 'a non-string title is rejected')
+check(
+  validateSubmissionLength({ title: 'x'.repeat(FORUM_LIMITS.TITLE), content: 'ok' }),
+  null,
+  'a title exactly at the cap is accepted'
+)
+check(
+  validateSubmissionLength({ title: 'x'.repeat(FORUM_LIMITS.TITLE + 1), content: 'ok' }) !== null,
+  true,
+  'a title one over the cap is rejected'
+)
+check(
+  validateSubmissionLength({ title: 'ok', content: 'x'.repeat(FORUM_LIMITS.CONTENT + 1) }) !== null,
+  true,
+  'a body one over the cap is rejected'
+)
+
+// The reason the content cap is derived rather than chosen: a post the route
+// accepts but moderation refuses to read would be rejected *after* the
+// provider call, which is the cost the check exists to avoid.
+checkTruthy(
+  FORUM_LIMITS.TITLE + FORUM_LIMITS.CONTENT <= MAX_MODERATION_CHARS,
+  'the largest acceptable post still fits inside the moderation cap'
+)
+
+check(validateCommentLength('Thanks for sharing this.'), null, 'an ordinary comment is accepted')
+check(validateCommentLength(''), 'A comment cannot be empty.', 'an empty comment is rejected')
+check(validateCommentLength('   '), 'A comment cannot be empty.', 'a whitespace comment is rejected')
+check(validateCommentLength(null) !== null, true, 'a null comment is rejected')
+check(validateCommentLength('x'.repeat(FORUM_LIMITS.COMMENT)), null, 'a comment at the cap is accepted')
+check(
+  validateCommentLength('x'.repeat(FORUM_LIMITS.COMMENT + 1)) !== null,
+  true,
+  'a comment one over the cap is rejected'
+)
+checkTruthy(FORUM_LIMITS.COMMENT <= MAX_MODERATION_CHARS, 'the largest acceptable comment fits inside the moderation cap')
+
+// ---------------------------------------------------------------------------
+
+console.log(`\n${failed === 0 ? '✅' : '❌'} ${passed} passed, ${failed} failed`)
+process.exit(failed === 0 ? 0 : 1)


### PR DESCRIPTION
## Linked Issue
Fixes #520

## Description

`moderateContent()` sits directly in front of every forum write — both `app/api/forum/posts/route.js` and `app/api/forum/comments/route.js` `await` it before touching the database — and it had no deadline of any kind. Neither the Gemini call nor the Groq `fetch` carried an `AbortController`, and Groq was reached from Gemini's `catch`, so a slow provider meant **two unbounded network calls in series** in front of a POST the user is watching a spinner for.

Three related problems in the same function:

| Problem | What happened |
|---|---|
| `data.choices[0].message.content` | Groq returns `{"choices": []}` for a filtered request and `{"error": {...}}` with HTTP 200 in some failure modes. Reading `.message` off `undefined` threw a `TypeError`, which the outer handler reported to the user as a guidelines violation. |
| `JSON.parse` on raw model output | Prose-wrapped JSON (`Here is the analysis: {...}`) threw, and on the Gemini path that was indistinguishable from a network error — so it burned the Groq fallback on a problem a retry cannot fix. |
| No length cap | `posts/route.js` checked only that `title` and `content` were truthy. A multi-megabyte body was forwarded verbatim to Gemini and then again to Groq. |

### Approach

The decision logic moves into `lib/moderation-verdict.js` — pure, no network, no clock except the one passed in — so every branch is reachable from a test. `lib/ai-moderation.js` keeps only the calls, now with a per-provider deadline (8 s, matching `app/api/chat/route.js`) and a 12 s budget for the whole attempt, so the fallback is not started when there is no time left to finish it.

**Fail-closed is unchanged.** Content is still rejected when moderation cannot answer — failing open on a provider outage would turn an outage into an unmoderated forum. What changed is that the routes can now tell a refusal from an outage:

```js
const isRefusal = moderationResult.outcome === OUTCOMES.REJECTED;
return NextResponse.json(
  { error: isRefusal ? 'Your post violates our community guidelines.' : moderationResult.reason, … },
  { status: moderationResult.status }   // 403 for a refusal, 503 for a timeout
);
```

A user whose ordinary post was blocked by a provider timeout is no longer told she broke the rules.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (clean code updates, no behavior modifications)
- [ ] Documentation update
- [ ] Performance optimization
- [x] Security patch

## Files Modified

| File | Change |
|------|--------|
| `lib/moderation-verdict.js` | **new** — verdict shape, defensive provider-response reads, tolerant JSON extraction, budget arithmetic, attempt merging |
| `lib/forum-limits.js` | **new** — post and comment size policy, derived from the moderation cap so a route never accepts a body moderation will refuse |
| `lib/ai-moderation.js` | rewritten around `AbortController`; client built per call rather than at import; Groq response read defensively |
| `app/api/forum/posts/route.js` | length check before dispatch; 403 only for an actual refusal |
| `app/api/forum/comments/route.js` | same |
| `scripts/test-moderation-verdict.js` | **new** — 131 assertions |

## Testing

```
$ node scripts/test-moderation-verdict.js
✅ 131 passed, 0 failed
```

Covers: empty `choices`, `{error}`-with-200, fenced JSON, prose-wrapped JSON, braces inside string values, a stringified `"true"` boolean (must **not** approve), over-length content, timeout-vs-outage classification, budget exhaustion, and the invariant that no path returns `isAppropriate: true` without a provider having said so.

Manual:
1. Point `GEMINI_API_KEY` at a host that accepts the connection and never responds.
2. `POST /api/forum/posts` — before: hung until the platform killed the invocation. After: 503 within the budget with *"We could not check this post in time. Nothing was lost — please try posting again."*
3. Mock Groq to return `{"choices": []}` with status 200 — before: `TypeError` reported as a guidelines violation. After: classified as "provider did not answer", logged as such.

## Screenshots (if UI changes are made)
N/A — backend only. The only user-visible change is the wording and status code of a blocked submission.

## Checklist
- [x] This PR is submitted under ECSOC.
- [x] Added the required **ECSoc26** label to this Pull Request.
- [x] Linked issue using `Fixes #520`.
- [x] Tested locally.
- [x] No breaking changes introduced — `moderateContent()` still returns `isAppropriate` and `reason`, so both call sites work unchanged.
- [ ] Documentation updated if required.
