### PR TITLE
[ECSoC26] fix(community): stop anonymous forum aliases colliding and being reversible

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,21 @@ CLERK_SECRET_KEY=sk_test_your_clerk_secret_here
 # Found in Clerk Dashboard -> Webhooks -> Add Endpoint -> Signing Secret
 CLERK_WEBHOOK_SECRET=whsec_your_clerk_webhook_signing_secret_here
 
+# Server-side key that anonymous community aliases are derived from.
+#
+# Aliases used to be an unsalted sha256() of the Clerk user id, so anyone
+# holding a user id could compute that user's forum name and find every post
+# she had written. Derivation is now HMAC-keyed with this value.
+#
+# Optional: when unset, SUPABASE_SERVICE_ROLE_KEY is used, which is already
+# required on every server that runs this code and is stable across deploys.
+# Set it explicitly if you would rather not reuse that key for two purposes.
+#
+# Must be stable — changing it renames every user. Existing posts keep the
+# alias stored on the row, so history stays consistent either way.
+# Generate with: openssl rand -base64 48
+FORUM_ALIAS_SECRET=
+
 # ------------------------------------------------------------
 # 3. AI Integrations
 # ------------------------------------------------------------

--- a/app/[locale]/community/post/[postId]/page.jsx
+++ b/app/[locale]/community/post/[postId]/page.jsx
@@ -9,6 +9,7 @@ import CommentSection from '@/components/community/CommentSection';
 import Navbar from '@/components/layout/Navbar';
 import Footer from '@/components/layout/Footer';
 import { ArrowLeft, User } from 'lucide-react';
+import { renderStoredAlias } from '@/lib/alias-display';
 
 export const revalidate = 60;
 
@@ -55,7 +56,7 @@ export default async function PostPage({ params }) {
           <div className="flex items-center gap-3 mb-4 text-sm text-slate-500 dark:text-slate-400 border-b border-slate-100 dark:border-slate-800 pb-4">
             <div className="flex items-center gap-1.5 font-medium text-slate-700 dark:text-slate-300 bg-slate-100 dark:bg-slate-800 px-3 py-1 rounded-full">
               <User size={14} />
-              {post.author_alias}
+              {renderStoredAlias(post.author_alias)}
             </div>
             <span>•</span>
             <time dateTime={post.created_at}>

--- a/components/community/CommentSection.jsx
+++ b/components/community/CommentSection.jsx
@@ -9,6 +9,7 @@ import { Send, ArrowUp, ArrowDown } from 'lucide-react';
 import fetchWithTimeout from '@/lib/fetch-with-timeout';
 import toast from 'react-hot-toast';
 import { createClient } from '@/lib/supabase-client';
+import { renderStoredAlias } from '@/lib/alias-display';
 
 // Create once at module level — stable reference, no new object on every render
 const supabase = createClient();
@@ -140,7 +141,7 @@ export default function CommentSection({ postId, initialComments = [] }) {
         </div>
         <div className="flex-1">
           <div className="flex items-center gap-2 mb-1">
-            <span className="font-semibold text-sm text-slate-800 dark:text-slate-200">{comment.author_alias}</span>
+            <span className="font-semibold text-sm text-slate-800 dark:text-slate-200">{renderStoredAlias(comment.author_alias)}</span>
             <span className="text-xs text-slate-400">•</span>
             <span className="text-xs text-slate-400">{formatDistanceToNow(new Date(comment.created_at), {
               addSuffix: true,

--- a/components/community/PostCard.jsx
+++ b/components/community/PostCard.jsx
@@ -8,6 +8,7 @@ import { formatDistanceToNow } from 'date-fns';
 import { enUS, hi } from 'date-fns/locale';
 import { ArrowUp, ArrowDown, MessageSquare } from 'lucide-react';
 import fetchWithTimeout from '@/lib/fetch-with-timeout';
+import { renderStoredAlias } from '@/lib/alias-display';
 import toast from 'react-hot-toast';
 
 export default function PostCard({ post, locale }) {
@@ -96,7 +97,7 @@ export default function PostCard({ post, locale }) {
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2 mb-2 text-xs text-slate-500 dark:text-slate-400">
             <span className="font-medium bg-slate-100 dark:bg-slate-800 px-2 py-0.5 rounded-full text-slate-700 dark:text-slate-300">
-              {post.author_alias}
+              {renderStoredAlias(post.author_alias)}
             </span>
             <span>•</span>
             <time dateTime={post.created_at}>

--- a/lib/alias-display.js
+++ b/lib/alias-display.js
@@ -1,0 +1,79 @@
+/**
+ * alias-display.js — rendering an alias that already exists on a row.
+ *
+ * Deliberately separate from `lib/alias-generator.js`, which imports Node's
+ * `crypto`. The components that display an author name — `PostCard`,
+ * `CommentSection`, the post page — are Client Components, and pulling the
+ * generator into them would drag `crypto` into the browser bundle. It would
+ * also put the *derivation* one import away from client code, which is
+ * exactly the thing that must stay on the server: an alias derived in the
+ * browser is an alias whose secret is in the browser.
+ *
+ * So the split is a boundary, not a file-size preference:
+ *
+ *   lib/alias-generator.js   server only. Derives a NEW alias for a NEW write.
+ *   lib/alias-display.js     safe anywhere. Renders a STORED alias.
+ *
+ * No imports here, by design.
+ */
+
+/**
+ * Shown when a row has no alias at all.
+ *
+ * The previous fallback was `'Anonymous User'`, which is indistinguishable
+ * from a real generated alias — so a bug that lost the author name rendered as
+ * an ordinary-looking author rather than as missing data. This one reads as
+ * what it is.
+ */
+export const MISSING_ALIAS_LABEL = 'Community member'
+
+/**
+ * Renders the `author_alias` column value.
+ *
+ * Every historical `forum_posts` and `forum_comments` row carries the alias it
+ * was written under, and that must keep rendering exactly as stored. Aliases
+ * are per-row precisely so that they cannot change under a reader — a name in
+ * a two-year-old thread should still be the name the person posted as.
+ *
+ * @param {unknown} stored
+ * @returns {string}
+ */
+export function renderStoredAlias(stored) {
+  if (typeof stored === 'string' && stored.trim().length > 0) return stored.trim()
+  return MISSING_ALIAS_LABEL
+}
+
+/**
+ * Whether an alias was produced by the pre-rotation two-word scheme
+ * (`"Brave Lotus"` rather than `"Brave Lotus 7K2QX"`).
+ *
+ * Not used to change how anything renders — old names render as themselves.
+ * It exists so the proportion of legacy names in the forum can be reported on,
+ * and so the test suite can assert the two formats are distinguishable.
+ *
+ * @param {unknown} alias
+ * @returns {boolean}
+ */
+export function isLegacyAlias(alias) {
+  if (typeof alias !== 'string') return false
+  return /^[A-Z][a-z]+ [A-Z][a-z]+$/.test(alias.trim())
+}
+
+/**
+ * Whether an alias carries the discriminator suffix added by the current
+ * scheme.
+ *
+ * The character class is written out rather than imported from
+ * `lib/alias-words.js` so that this module keeps its no-imports property and
+ * stays free to be pulled into a Client Component. It is Crockford base32 —
+ * digits and uppercase letters minus `I`, `L`, `O` and `U`. If the alphabet
+ * there ever changes, `scripts/test-alias-generator.js` fails on the
+ * round-trip check rather than letting the two drift apart quietly.
+ *
+ * @param {unknown} alias
+ * @returns {boolean}
+ */
+export function hasDiscriminator(alias) {
+  if (typeof alias !== 'string') return false
+  return /^[A-Z][a-z]+ [A-Z][a-z]+ [0-9A-HJKMNP-TV-Z]{5}$/.test(alias.trim())
+}

--- a/lib/alias-generator.js
+++ b/lib/alias-generator.js
@@ -1,35 +1,257 @@
-import crypto from 'crypto';
+/**
+ * alias-generator.js — the anonymous identity used throughout the community.
+ *
+ * `forum_posts.author_alias` and `forum_comments.author_alias` are the only
+ * author information the UI ever renders; `user_id` is never exposed. So this
+ * function is not a cosmetic nicety — it *is* the forum's identity model, and
+ * it had two problems.
+ *
+ * ## 1. It collided
+ *
+ * Two 40-word lists give 1,600 aliases for the whole user base. By the
+ * birthday bound that is 11 % at 20 users, 50 % at 47, and 96 % at 100 — and
+ * at 200 users the expected number of colliding *pairs* is about twelve.
+ *
+ * A collision here means two different people are presented to every reader as
+ * the same person, in threads where they are describing their own diagnoses.
+ * Advice gets attributed to the wrong person, and nobody — including the two
+ * users — can tell them apart. See `lib/alias-words.js` for the new space.
+ *
+ * ## 2. It was reversible
+ *
+ * The alias was an unsalted `sha256(userId)`. Clerk ids are not secret: they
+ * appear in webhook payloads, in support tooling, and in the `user_id` column
+ * of every table an admin can read. Anyone holding one could compute that
+ * user's forum name offline and find everything she had ever written. The
+ * anonymity was one `sha256()` call deep.
+ *
+ * Derivation is now `HMAC-SHA512(secret, userId)`. Without the server-side
+ * secret the mapping cannot be computed or precomputed at all.
+ *
+ * ## A note on rotation
+ *
+ * Changing the derivation changes what `generateAlias()` returns for an
+ * existing user. That is a one-time rotation and it is deliberate: the old
+ * alias was not a durable identity, because it was not unique. Nothing in the
+ * database moves — `author_alias` is stored per row, so every historical post
+ * and comment keeps the name it was written under and old threads stay
+ * internally consistent. New writes use the new name. Use
+ * {@link renderStoredAlias} for anything read back out of the database, and
+ * never re-derive an alias for a row that already has one.
+ */
 
-const adjectives = [
-  'Brave', 'Gentle', 'Fierce', 'Quiet', 'Calm', 'Bright', 'Kind', 'Wise', 'Bold', 'Swift',
-  'Happy', 'Proud', 'Strong', 'Sunny', 'Cool', 'Lucky', 'Wild', 'Silent', 'Mighty', 'Clever',
-  'Golden', 'Silver', 'Crystal', 'Crimson', 'Azure', 'Jade', 'Violet', 'Amber', 'Coral', 'Pearl',
-  'Cosmic', 'Lunar', 'Solar', 'Stellar', 'Astral', 'Mystic', 'Magic', 'Secret', 'Hidden', 'Noble'
-];
+import crypto from 'crypto'
 
-const nouns = [
-  'Lotus', 'Tulip', 'Rose', 'Lily', 'Orchid', 'Daisy', 'Iris', 'Fern', 'Ivy', 'Willow',
-  'Phoenix', 'Dragon', 'Eagle', 'Falcon', 'Hawk', 'Raven', 'Dove', 'Swan', 'Robin', 'Lark',
-  'River', 'Ocean', 'Mountain', 'Forest', 'Meadow', 'Valley', 'Star', 'Moon', 'Sun', 'Cloud',
-  'Seeker', 'Dreamer', 'Thinker', 'Wanderer', 'Traveler', 'Healer', 'Guide', 'Friend', 'Soul', 'Spirit'
-];
+import {
+  ADJECTIVES,
+  ALIAS_SPACE,
+  DISCRIMINATOR_ALPHABET,
+  DISCRIMINATOR_LENGTH,
+  DISCRIMINATOR_RANGE,
+  NOUNS,
+} from './alias-words.js'
+
+export { ALIAS_SPACE } from './alias-words.js'
+
+// Re-exported so server code has one import for both halves. The definitions
+// live in `lib/alias-display.js`, which has no `crypto` dependency and is
+// therefore safe to import from a Client Component — see the note at the top
+// of that file for why the split matters.
+export { hasDiscriminator, isLegacyAlias, renderStoredAlias } from './alias-display.js'
 
 /**
- * Generates a deterministic, anonymous alias from a user ID.
- * @param {string} userId - The unique identifier of the user (e.g., Clerk User ID).
- * @returns {string} - A two-word alias like "Brave Lotus".
+ * Namespace mixed into the HMAC message.
+ *
+ * The same secret may one day key another derivation. Domain-separating means
+ * a future `HMAC(secret, userId)` elsewhere cannot be used to recover, or be
+ * recovered from, a forum alias.
  */
-export function generateAlias(userId) {
-  if (!userId) {
-    return 'Anonymous User';
+const ALIAS_NAMESPACE = 'hercycle:forum-alias:v2'
+
+/**
+ * Development-only fallback secret.
+ *
+ * Named so that it is obvious in a log or a grep what it is, and so that
+ * shipping it to production is a visible mistake rather than a silent one.
+ * `resolveSecret` warns once when it is used.
+ */
+const DEV_FALLBACK_SECRET = 'hercycle-local-development-alias-secret-do-not-use-in-production'
+
+let warnedAboutFallback = false
+
+/**
+ * Resolves the HMAC key.
+ *
+ * `FORUM_ALIAS_SECRET` is the intended source. `SUPABASE_SERVICE_ROLE_KEY` is
+ * accepted as a fallback because it is already required on every server that
+ * runs this code, is never sent to a browser, and is stable across deploys —
+ * so an existing deployment gets non-reversible aliases without a new
+ * environment variable, and gets *stable* ones, which a random per-boot key
+ * would not.
+ *
+ * Both are read at call time rather than at module load: a module-level read
+ * captures whatever the environment happened to be at import, which in Next.js
+ * is not necessarily when the route runs.
+ *
+ * @returns {string}
+ */
+function resolveSecret() {
+  const configured = process.env.FORUM_ALIAS_SECRET || process.env.SUPABASE_SERVICE_ROLE_KEY
+
+  if (configured && configured.length > 0) return configured
+
+  if (!warnedAboutFallback) {
+    warnedAboutFallback = true
+    // console rather than lib/logger: this module is imported by plain Node
+    // scripts and must not drag a logger — and its dependency graph — in.
+    console.warn(
+      '[alias-generator] Neither FORUM_ALIAS_SECRET nor SUPABASE_SERVICE_ROLE_KEY is set. ' +
+        'Falling back to a well-known development secret — forum aliases are reversible in this process.'
+    )
   }
 
-  // Create a fast, deterministic hash of the userId
-  const hash = crypto.createHash('sha256').update(userId).digest('hex');
-  
-  // Use parts of the hash to pick indices
-  const adjIndex = parseInt(hash.substring(0, 8), 16) % adjectives.length;
-  const nounIndex = parseInt(hash.substring(8, 16), 16) % nouns.length;
+  return DEV_FALLBACK_SECRET
+}
 
-  return `${adjectives[adjIndex]} ${nouns[nounIndex]}`;
+/**
+ * A stream of uniformly distributed integers derived from a seed.
+ *
+ * The old code took `parseInt(hash.substring(0, 8), 16) % 40`. Two problems
+ * with that, one theoretical and one not:
+ *
+ * - **Modulo bias.** The 8 hex digits span 0…4,294,967,295, which is
+ *   4,294,967,296 values. `4294967296 % 40 === 16`, so the first 16 words of
+ *   the list were each one-in-107,374,183 more likely than the rest. Tiny, and
+ *   free to remove.
+ * - **Only 64 of 256 bits were used**, so the majority of the hash was
+ *   computed and thrown away — and there was nothing left to derive a
+ *   discriminator from.
+ *
+ * Rejection sampling removes the bias exactly: values in the final, partial
+ * block of the 2³² range are discarded rather than folded. When the current
+ * block of key material runs out, more is derived by re-keying with an
+ * incrementing counter, so the stream never terminates and the sampler never
+ * has to compromise.
+ */
+class UniformSampler {
+  /**
+   * @param {Buffer} seed
+   * @param {string} secret
+   */
+  constructor(seed, secret) {
+    this.secret = secret
+    this.counter = 0
+    this.block = seed
+    this.offset = 0
+  }
+
+  /** Derives the next block of key material. */
+  refill() {
+    this.counter += 1
+    this.block = crypto
+      .createHmac('sha512', this.secret)
+      .update(`${ALIAS_NAMESPACE}:stream:${this.counter}`)
+      .update(this.block)
+      .digest()
+    this.offset = 0
+  }
+
+  /** @returns {number} the next uint32 from the stream */
+  nextWord() {
+    if (this.offset + 4 > this.block.length) this.refill()
+    const word = this.block.readUInt32BE(this.offset)
+    this.offset += 4
+    return word
+  }
+
+  /**
+   * A uniformly distributed integer in `[0, max)`.
+   *
+   * @param {number} max
+   * @returns {number}
+   */
+  nextBelow(max) {
+    if (!Number.isInteger(max) || max <= 0) {
+      throw new RangeError(`nextBelow requires a positive integer, received ${max}`)
+    }
+
+    // The largest multiple of `max` that fits in a uint32. Anything at or
+    // above it is in the partial block and is discarded.
+    const limit = Math.floor(0x100000000 / max) * max
+
+    // Bounded in practice: the rejection probability per draw is under
+    // max/2³², which for our largest `max` (10,000) is about one in 429,497.
+    for (;;) {
+      const word = this.nextWord()
+      if (word < limit) return word % max
+    }
+  }
+}
+
+/**
+ * Generates the anonymous alias for a user.
+ *
+ * Deterministic: the same user id and the same secret always produce the same
+ * alias, which is what makes a user recognisable across her own thread.
+ *
+ * @param {string} userId the Clerk user id
+ * @returns {string} e.g. `"Gentle Willow 7K2QX"`
+ * @throws {TypeError} when `userId` is missing or not a string
+ */
+export function generateAlias(userId) {
+  // The old code answered a missing id with the literal string
+  // 'Anonymous User' — which is also a perfectly plausible thing to render, so
+  // a bug that lost the user id looked exactly like a normal author. Both
+  // callers already return 401 before reaching here, so a missing id at this
+  // point is a programming error and should read as one.
+  if (typeof userId !== 'string' || userId.trim().length === 0) {
+    throw new TypeError('generateAlias requires a non-empty user id')
+  }
+
+  const secret = resolveSecret()
+
+  const seed = crypto
+    .createHmac('sha512', secret)
+    .update(ALIAS_NAMESPACE)
+    .update(userId)
+    .digest()
+
+  const sampler = new UniformSampler(seed, secret)
+
+  const adjective = ADJECTIVES[sampler.nextBelow(ADJECTIVES.length)]
+  const noun = NOUNS[sampler.nextBelow(NOUNS.length)]
+
+  // Drawn symbol by symbol rather than as one integer in [0, 32^5). Both are
+  // uniform over the same space, but this way the sampler never has to handle
+  // a bound above 2³², and the zero-padding problem — where `String(7)` would
+  // silently produce a one-character discriminator — cannot arise.
+  let discriminator = ''
+  for (let i = 0; i < DISCRIMINATOR_LENGTH; i += 1) {
+    discriminator += DISCRIMINATOR_ALPHABET[sampler.nextBelow(DISCRIMINATOR_ALPHABET.length)]
+  }
+
+  return `${adjective} ${noun} ${discriminator}`
+}
+
+/**
+ * Describes the alias space, for tests and for anyone sizing the scheme
+ * against a projected user count.
+ *
+ * `collisionOdds(k)` is the standard birthday approximation
+ * `1 − e^(−k(k−1) / 2n)`, which is what "will two of our users end up with the
+ * same name" actually asks.
+ *
+ * @returns {{ adjectives: number, nouns: number, discriminators: number, total: number, collisionOdds: (users: number) => number }}
+ */
+export function describeAliasSpace() {
+  return {
+    adjectives: ADJECTIVES.length,
+    nouns: NOUNS.length,
+    discriminators: DISCRIMINATOR_RANGE,
+    total: ALIAS_SPACE,
+    collisionOdds(users) {
+      if (!Number.isFinite(users) || users < 2) return 0
+      return 1 - Math.exp((-users * (users - 1)) / (2 * ALIAS_SPACE))
+    },
+  }
 }

--- a/lib/alias-words.js
+++ b/lib/alias-words.js
@@ -1,0 +1,122 @@
+/**
+ * alias-words.js — the vocabulary anonymous forum names are built from.
+ *
+ * Kept separate from `lib/alias-generator.js` so the lists can be extended
+ * without touching the derivation, and so the derivation can be read without
+ * scrolling past two hundred words.
+ *
+ * ## Why these lists are this long
+ *
+ * The original lists held 40 adjectives and 40 nouns — 1,600 possible aliases
+ * for the entire user base. By the birthday bound that is a coin flip at 47
+ * users and a near-certainty at 100:
+ *
+ *   P(collision) ≈ 1 − e^(−k² / 2n)   with n = 1600
+ *
+ *   k =  20  →  11 %
+ *   k =  47  →  50 %
+ *   k = 100  →  96 %
+ *
+ * Two users rendered under the same name is not a cosmetic problem here. The
+ * alias is the *only* identity the forum has — `user_id` is never exposed — so
+ * a collision presents two different people to every reader as one person, in
+ * threads where they are describing their own diagnoses.
+ *
+ * 96 × 96 = 9,216 pairs, and `lib/alias-generator.js` appends a
+ * five-character discriminator, giving 309 billion distinct aliases. That
+ * moves the 50 % collision point from 47 users to roughly 654,000. See
+ * {@link DISCRIMINATOR_LENGTH} for how the width was chosen.
+ *
+ * ## Rules for editing these lists
+ *
+ * 1. **Append only.** Changing or reordering an existing entry changes the
+ *    alias of every user whose hash lands on that index.
+ * 2. **Nothing that reads as a judgement.** These names are attached to posts
+ *    about people's bodies. "Fierce" and "Gentle" are fine; anything
+ *    describing a body, a diagnosis, or a mood is not.
+ * 3. **No word that could be read as a real name** — an alias that looks like
+ *    a name undermines the point of having one.
+ * 4. Keep both lists the same length. Nothing depends on it, but an uneven
+ *    pair is a sign someone appended to one and forgot the other.
+ */
+
+/**
+ * The first 40 entries of each list are the originals, in their original
+ * order, so that a user whose hash happens to land in that range keeps a
+ * familiar-looking name.
+ */
+export const ADJECTIVES = Object.freeze([
+  // — original 40 —
+  'Brave', 'Gentle', 'Fierce', 'Quiet', 'Calm', 'Bright', 'Kind', 'Wise', 'Bold', 'Swift',
+  'Happy', 'Proud', 'Strong', 'Sunny', 'Cool', 'Lucky', 'Wild', 'Silent', 'Mighty', 'Clever',
+  'Golden', 'Silver', 'Crystal', 'Crimson', 'Azure', 'Jade', 'Violet', 'Amber', 'Coral', 'Pearl',
+  'Cosmic', 'Lunar', 'Solar', 'Stellar', 'Astral', 'Mystic', 'Magic', 'Secret', 'Hidden', 'Noble',
+  // — temperament —
+  'Radiant', 'Serene', 'Vivid', 'Steady', 'Nimble', 'Patient', 'Curious', 'Earnest', 'Humble', 'Merry',
+  'Tender', 'Fearless', 'Graceful', 'Spirited', 'Resolute', 'Warm', 'Quick', 'Keen', 'Bonny', 'Cheerful',
+  // — colour and material —
+  'Velvet', 'Copper', 'Ivory', 'Indigo', 'Scarlet', 'Emerald', 'Sapphire', 'Opal', 'Topaz', 'Ruby',
+  // — weather and light —
+  'Twilight', 'Dawning', 'Misty', 'Frosted', 'Glowing', 'Drifting', 'Rustling', 'Whispering', 'Wandering', 'Blooming',
+  // — scale and place —
+  'Ancient', 'Timeless', 'Boundless', 'Endless', 'Northern', 'Southern', 'Eastern', 'Western', 'Highland', 'Lowland',
+  // — craft —
+  'Gilded', 'Woven', 'Braided', 'Painted', 'Carved', 'Feathered',
+])
+
+export const NOUNS = Object.freeze([
+  // — original 40 —
+  'Lotus', 'Tulip', 'Rose', 'Lily', 'Orchid', 'Daisy', 'Iris', 'Fern', 'Ivy', 'Willow',
+  'Phoenix', 'Dragon', 'Eagle', 'Falcon', 'Hawk', 'Raven', 'Dove', 'Swan', 'Robin', 'Lark',
+  'River', 'Ocean', 'Mountain', 'Forest', 'Meadow', 'Valley', 'Star', 'Moon', 'Sun', 'Cloud',
+  'Seeker', 'Dreamer', 'Thinker', 'Wanderer', 'Traveler', 'Healer', 'Guide', 'Friend', 'Soul', 'Spirit',
+  // — flowers —
+  'Jasmine', 'Marigold', 'Peony', 'Poppy', 'Lavender', 'Camellia', 'Magnolia', 'Hibiscus', 'Bluebell', 'Clover',
+  // — birds —
+  'Heron', 'Kestrel', 'Wren', 'Finch', 'Swallow', 'Nightingale', 'Kingfisher', 'Osprey', 'Pelican', 'Sparrow',
+  // — landscape —
+  'Harbour', 'Lagoon', 'Canyon', 'Prairie', 'Glacier', 'Summit', 'Delta', 'Orchard', 'Grove', 'Reef',
+  // — sky —
+  'Comet', 'Nebula', 'Aurora', 'Horizon', 'Meridian', 'Ember', 'Lantern', 'Beacon', 'Compass', 'Anchor',
+  // — roles —
+  'Weaver', 'Gardener', 'Keeper', 'Listener', 'Builder', 'Runner', 'Voyager', 'Storyteller', 'Navigator', 'Harvester',
+  // — weather and terrain —
+  'Cascade', 'Monsoon', 'Zephyr', 'Thicket', 'Boulder', 'Trellis',
+])
+
+/**
+ * The alphabet the discriminator suffix is drawn from.
+ *
+ * Crockford base32: the digits plus the uppercase letters, minus `I`, `L`, `O`
+ * and `U`. The first three are dropped because they are unreadable next to
+ * `1` and `0` in the middle of a name, and `U` because excluding it keeps
+ * accidental words from forming in a five-character run.
+ */
+export const DISCRIMINATOR_ALPHABET = '0123456789ABCDEFGHJKMNPQRSTVWXYZ'
+
+/**
+ * How many characters the discriminator carries.
+ *
+ * The width is set by the birthday bound, not by taste. A derived alias cannot
+ * be *guaranteed* unique without asking the database, so the only lever is
+ * making a collision improbable enough to disregard:
+ *
+ *   n = 96 × 96 × 32^L        P(collision at k users) ≈ 1 − e^(−k² / 2n)
+ *
+ *   L = 0 (the old scheme, 40-word lists)  n = 1,600          50 % at 47 users
+ *   L = 4 (4 decimal digits)               n = 92.2 million   50 % at 11,300
+ *   L = 5 (base32)                         n = 309 billion    50 % at 654,000
+ *   L = 6 (base32)                         n = 9.9 trillion   50 % at 3.7 million
+ *
+ * Five is where the odds stop mattering for an app of this kind — at 100,000
+ * users the expected number of colliding pairs is 0.016 — while the alias
+ * still reads as a name with a tag ("Gentle Willow 7K2QX") rather than as a
+ * serial number.
+ */
+export const DISCRIMINATOR_LENGTH = 5
+
+/** The number of values the discriminator can take. */
+export const DISCRIMINATOR_RANGE = DISCRIMINATOR_ALPHABET.length ** DISCRIMINATOR_LENGTH
+
+/** Total distinct aliases the scheme can produce. */
+export const ALIAS_SPACE = ADJECTIVES.length * NOUNS.length * DISCRIMINATOR_RANGE

--- a/scripts/test-alias-generator.js
+++ b/scripts/test-alias-generator.js
@@ -1,0 +1,334 @@
+/**
+ * Regression suite for lib/alias-generator.js, lib/alias-display.js and
+ * lib/alias-words.js.
+ *
+ * The bug this is part of fixing: the forum's only identity was drawn from two
+ * 40-word lists — 1,600 possible names for the entire user base, which by the
+ * birthday bound is a coin flip at 47 users. A collision presents two
+ * different people to every reader as the same person, in threads where they
+ * are describing their own diagnoses. Separately, the alias was an unsalted
+ * `sha256(userId)`, so anyone holding a Clerk id could compute that user's
+ * forum name offline and find everything she had written.
+ *
+ * The two properties worth pinning are the ones no amount of manual testing
+ * would catch:
+ *
+ *   1. **Scale.** 100,000 synthetic ids produce 100,000 distinct aliases.
+ *      The old scheme cannot get past 1,600 no matter how many you feed it.
+ *   2. **Secrecy.** The same id under two different secrets produces two
+ *      unrelated aliases, so the mapping is not computable without the key.
+ *
+ * The distribution check is here because rejection sampling is easy to get
+ * wrong in a way that looks fine — a subtly biased sampler still returns
+ * plausible names.
+ *
+ *   node scripts/test-alias-generator.js
+ */
+
+import crypto from 'crypto'
+
+import {
+  ADJECTIVES,
+  ALIAS_SPACE,
+  DISCRIMINATOR_ALPHABET,
+  DISCRIMINATOR_LENGTH,
+  DISCRIMINATOR_RANGE,
+  NOUNS,
+} from '../lib/alias-words.js'
+import {
+  MISSING_ALIAS_LABEL,
+  hasDiscriminator,
+  isLegacyAlias,
+  renderStoredAlias,
+} from '../lib/alias-display.js'
+
+let passed = 0
+let failed = 0
+
+function check(actual, expected, label) {
+  if (Object.is(actual, expected)) {
+    passed += 1
+    return
+  }
+  failed += 1
+  console.error(`  ❌ ${label}`)
+  console.error(`       expected: ${JSON.stringify(expected)}`)
+  console.error(`       actual:   ${JSON.stringify(actual)}`)
+}
+
+function checkTruthy(value, label) {
+  check(Boolean(value), true, label)
+}
+
+function section(title) {
+  console.log(`\n${title}`)
+}
+
+/**
+ * Derives an alias under a specific secret.
+ *
+ * The generator reads `process.env` at call time rather than at import — a
+ * module-level read would capture whatever the environment happened to be when
+ * Next.js first pulled the module in — so swapping the secret needs nothing
+ * more than setting it immediately before the call. No module cache busting,
+ * and nothing left set afterwards.
+ *
+ * @param {string} secret
+ * @param {string} userId
+ * @returns {string}
+ */
+function aliasUnderSecret(secret, userId) {
+  const previous = process.env.FORUM_ALIAS_SECRET
+  process.env.FORUM_ALIAS_SECRET = secret
+  try {
+    return generateAlias(userId)
+  } finally {
+    process.env.FORUM_ALIAS_SECRET = previous
+  }
+}
+
+// A secret is set for the whole suite so the fallback warning does not fire on
+// every import and drown the output.
+process.env.FORUM_ALIAS_SECRET = 'test-secret-for-the-alias-suite'
+const { describeAliasSpace, generateAlias } = await import('../lib/alias-generator.js')
+
+// ---------------------------------------------------------------------------
+
+section('word lists')
+
+check(ADJECTIVES.length, 96, 'the adjective list holds 96 entries')
+check(NOUNS.length, 96, 'the noun list holds 96 entries')
+check(ADJECTIVES.length, NOUNS.length, 'both lists are the same length')
+check(new Set(ADJECTIVES).size, ADJECTIVES.length, 'no duplicate adjectives')
+check(new Set(NOUNS).size, NOUNS.length, 'no duplicate nouns')
+check(new Set([...ADJECTIVES, ...NOUNS]).size, ADJECTIVES.length + NOUNS.length, 'no word appears in both lists')
+
+// Rule 1 of the editing policy in lib/alias-words.js: append only. Changing an
+// existing entry changes the alias of every user whose hash lands on it.
+check(ADJECTIVES[0], 'Brave', 'the first adjective is unchanged')
+check(ADJECTIVES[39], 'Noble', 'the fortieth adjective is unchanged')
+check(NOUNS[0], 'Lotus', 'the first noun is unchanged')
+check(NOUNS[39], 'Spirit', 'the fortieth noun is unchanged')
+
+checkTruthy(
+  ADJECTIVES.every((word) => /^[A-Z][a-z]+$/.test(word)),
+  'every adjective is a single capitalised word'
+)
+checkTruthy(
+  NOUNS.every((word) => /^[A-Z][a-z]+$/.test(word)),
+  'every noun is a single capitalised word'
+)
+
+check(ALIAS_SPACE, 96 * 96 * DISCRIMINATOR_RANGE, 'the alias space is the product of the three dimensions')
+check(DISCRIMINATOR_RANGE, 32 ** 5, 'the discriminator spans 32^5 values')
+check(ALIAS_SPACE, 9216 * 33_554_432, 'the alias space is 309 billion')
+check(DISCRIMINATOR_ALPHABET.length, 32, 'the alphabet is base32')
+check(new Set(DISCRIMINATOR_ALPHABET).size, 32, 'no character appears twice in the alphabet')
+
+// ---------------------------------------------------------------------------
+
+section('shape and determinism')
+
+const alias = generateAlias('user_2abcDEF123')
+checkTruthy(hasDiscriminator(alias), `"${alias}" has the Adjective Noun XXXXX shape`)
+check(generateAlias('user_2abcDEF123'), alias, 'the same id gives the same alias')
+check(generateAlias('user_2abcDEF123'), alias, 'and again — it is a pure function of the id')
+
+const [adjective, noun, suffix] = alias.split(' ')
+checkTruthy(ADJECTIVES.includes(adjective), 'the adjective comes from the list')
+checkTruthy(NOUNS.includes(noun), 'the noun comes from the list')
+check(suffix.length, DISCRIMINATOR_LENGTH, 'the discriminator is always the full width')
+checkTruthy(
+  [...suffix].every((char) => DISCRIMINATOR_ALPHABET.includes(char)),
+  'every discriminator character comes from the alphabet'
+)
+
+// hasDiscriminator() writes the alphabet out as a regex character class rather
+// than importing it. This is the check that keeps the two from drifting apart.
+checkTruthy(
+  [...DISCRIMINATOR_ALPHABET].every((char) => hasDiscriminator(`Gentle Willow ${char.repeat(DISCRIMINATOR_LENGTH)}`)),
+  'the display regex accepts every character the generator can emit'
+)
+checkTruthy(
+  ['I', 'L', 'O', 'U'].every((char) => !DISCRIMINATOR_ALPHABET.includes(char)),
+  'the ambiguous characters I, L, O and U are excluded'
+)
+
+// ---------------------------------------------------------------------------
+
+section('collisions at scale — the whole point of the change')
+
+const SAMPLE = 100_000
+const seen = new Map()
+const collisions = []
+
+for (let i = 0; i < SAMPLE; i += 1) {
+  // Shaped like a real Clerk id rather than "user_1", "user_2": sequential
+  // inputs are the easy case for a hash, and would flatter the result.
+  const id = `user_${crypto.createHash('sha1').update(`seed-${i}`).digest('hex').slice(0, 24)}`
+  const name = generateAlias(id)
+  if (seen.has(name)) collisions.push([seen.get(name), id, name])
+  else seen.set(name, id)
+}
+
+check(seen.size, SAMPLE, `${SAMPLE.toLocaleString('en-US')} distinct ids produce that many distinct aliases`)
+check(collisions.length, 0, 'no two users share a name')
+
+if (collisions.length > 0) {
+  for (const [a, b, name] of collisions.slice(0, 5)) {
+    console.error(`       ${a} and ${b} are both "${name}"`)
+  }
+}
+
+// For contrast: the old scheme could not have passed the line above, because
+// it had only 1,600 names to hand out.
+const OLD_SPACE = 40 * 40
+checkTruthy(seen.size > OLD_SPACE, 'the number of distinct aliases exceeds the entire old alias space')
+
+// ---------------------------------------------------------------------------
+
+section('birthday odds')
+
+const space = describeAliasSpace()
+check(space.total, ALIAS_SPACE, 'describeAliasSpace reports the real total')
+check(space.collisionOdds(0), 0, 'no users, no collisions')
+check(space.collisionOdds(1), 0, 'one user cannot collide with anyone')
+checkTruthy(space.collisionOdds(100) < 1e-7, 'at 100 users the odds are under one in ten million')
+checkTruthy(space.collisionOdds(100_000) < 0.02, 'at 100,000 users the odds are under 2 %')
+checkTruthy(space.collisionOdds(2_000_000) > 0.5, 'the 50 % point is in the millions of users, not at 47')
+
+// The same figures under the old space, to show what was being fixed.
+const oldOdds = (k) => 1 - Math.exp((-k * (k - 1)) / (2 * OLD_SPACE))
+checkTruthy(oldOdds(47) > 0.49, 'the old scheme was a coin flip at 47 users')
+checkTruthy(oldOdds(100) > 0.95, 'the old scheme collided with 95 % probability at 100 users')
+checkTruthy(
+  space.collisionOdds(100) < oldOdds(100) / 1_000_000,
+  'the new odds at 100 users are more than a millionfold better'
+)
+
+// ---------------------------------------------------------------------------
+
+section('the secret — aliases must not be computable from a user id alone')
+
+const idUnderTest = 'user_2xyzABC987'
+const aliasA = aliasUnderSecret('secret-alpha', idUnderTest)
+const aliasB = aliasUnderSecret('secret-beta', idUnderTest)
+const aliasAAgain = aliasUnderSecret('secret-alpha', idUnderTest)
+
+checkTruthy(aliasA !== aliasB, 'the same id under a different secret gives a different alias')
+check(aliasAAgain, aliasA, 'the same id under the same secret is stable across calls')
+
+// A second pair, so the first is not passing on a lucky single draw.
+checkTruthy(
+  aliasUnderSecret('secret-gamma', 'user_other') !== aliasUnderSecret('secret-delta', 'user_other'),
+  'a second id also diverges under different secrets'
+)
+
+// A plain unsalted sha256 of the id — what the old implementation computed —
+// must no longer determine the answer.
+const legacyHash = crypto.createHash('sha256').update(idUnderTest).digest('hex')
+const legacyAdjective = ADJECTIVES.slice(0, 40)[parseInt(legacyHash.substring(0, 8), 16) % 40]
+const legacyNoun = NOUNS.slice(0, 40)[parseInt(legacyHash.substring(8, 16), 16) % 40]
+checkTruthy(
+  aliasA !== `${legacyAdjective} ${legacyNoun}`,
+  'the alias is no longer recoverable by hashing the user id'
+)
+
+process.env.FORUM_ALIAS_SECRET = 'test-secret-for-the-alias-suite'
+
+// ---------------------------------------------------------------------------
+
+section('distribution — rejection sampling must not skew the lists')
+
+const adjectiveCounts = new Map()
+const nounCounts = new Map()
+const symbolCounts = new Map()
+
+const DIST_SAMPLE = 60_000
+for (let i = 0; i < DIST_SAMPLE; i += 1) {
+  const id = `dist_${crypto.createHash('sha1').update(`d-${i}`).digest('hex').slice(0, 20)}`
+  const [adj, nn, suffix] = generateAlias(id).split(' ')
+  adjectiveCounts.set(adj, (adjectiveCounts.get(adj) || 0) + 1)
+  nounCounts.set(nn, (nounCounts.get(nn) || 0) + 1)
+  for (const char of suffix) symbolCounts.set(char, (symbolCounts.get(char) || 0) + 1)
+}
+
+check(adjectiveCounts.size, ADJECTIVES.length, 'every adjective is reachable')
+check(nounCounts.size, NOUNS.length, 'every noun is reachable')
+
+const expectedPerWord = DIST_SAMPLE / ADJECTIVES.length
+const worstAdjective = Math.max(...[...adjectiveCounts.values()].map((c) => Math.abs(c - expectedPerWord)))
+const worstNoun = Math.max(...[...nounCounts.values()].map((c) => Math.abs(c - expectedPerWord)))
+
+// Five standard deviations of a binomial(n, 1/96) is a bound random sampling
+// clears comfortably and a biased sampler does not.
+const tolerance = 5 * Math.sqrt(DIST_SAMPLE * (1 / 96) * (1 - 1 / 96))
+checkTruthy(worstAdjective < tolerance, `adjective frequencies are within tolerance (worst ${worstAdjective.toFixed(0)} < ${tolerance.toFixed(0)})`)
+checkTruthy(worstNoun < tolerance, `noun frequencies are within tolerance (worst ${worstNoun.toFixed(0)} < ${tolerance.toFixed(0)})`)
+
+// The old modulo-into-40 had its bias in the first 16 entries. Check that
+// range specifically rather than trusting the aggregate to reveal it.
+const firstSixteen = ADJECTIVES.slice(0, 16).reduce((sum, word) => sum + (adjectiveCounts.get(word) || 0), 0)
+const expectedFirstSixteen = (DIST_SAMPLE * 16) / 96
+checkTruthy(
+  Math.abs(firstSixteen - expectedFirstSixteen) < 4 * Math.sqrt(expectedFirstSixteen),
+  'the first sixteen adjectives are not over-represented'
+)
+
+check(symbolCounts.size, DISCRIMINATOR_ALPHABET.length, 'every discriminator character is reachable')
+
+const symbolDraws = DIST_SAMPLE * DISCRIMINATOR_LENGTH
+const expectedPerSymbol = symbolDraws / DISCRIMINATOR_ALPHABET.length
+const worstSymbol = Math.max(...[...symbolCounts.values()].map((c) => Math.abs(c - expectedPerSymbol)))
+const symbolTolerance = 5 * Math.sqrt(symbolDraws * (1 / 32) * (1 - 1 / 32))
+checkTruthy(
+  worstSymbol < symbolTolerance,
+  `discriminator characters are uniform (worst ${worstSymbol.toFixed(0)} < ${symbolTolerance.toFixed(0)})`
+)
+
+// ---------------------------------------------------------------------------
+
+section('invalid input is an error, not a plausible name')
+
+for (const bad of [null, undefined, '', '   ', 42, {}, []]) {
+  let threw = false
+  try {
+    generateAlias(bad)
+  } catch (error) {
+    threw = error instanceof TypeError
+  }
+  check(threw, true, `generateAlias(${JSON.stringify(bad)}) throws a TypeError`)
+}
+
+// ---------------------------------------------------------------------------
+
+section('rendering stored aliases — history must not move')
+
+check(renderStoredAlias('Brave Lotus'), 'Brave Lotus', 'a legacy two-word alias renders unchanged')
+check(renderStoredAlias('Gentle Willow 7K2QX'), 'Gentle Willow 7K2QX', 'a current alias renders unchanged')
+check(renderStoredAlias('  Quiet Fern 00007  '), 'Quiet Fern 00007', 'surrounding whitespace is trimmed')
+check(renderStoredAlias(''), MISSING_ALIAS_LABEL, 'an empty alias falls back to the missing-data label')
+check(renderStoredAlias(null), MISSING_ALIAS_LABEL, 'a null alias falls back')
+check(renderStoredAlias(undefined), MISSING_ALIAS_LABEL, 'an undefined alias falls back')
+check(renderStoredAlias(12345), MISSING_ALIAS_LABEL, 'a non-string alias falls back')
+
+// The fallback must not look like a real alias, which 'Anonymous User' did.
+checkTruthy(!isLegacyAlias(MISSING_ALIAS_LABEL), 'the missing-data label is not mistakable for a generated alias')
+checkTruthy(!hasDiscriminator(MISSING_ALIAS_LABEL), 'the missing-data label has no discriminator')
+
+check(isLegacyAlias('Brave Lotus'), true, 'a two-word alias is recognised as legacy')
+check(isLegacyAlias('Gentle Willow 7K2QX'), false, 'a current alias is not legacy')
+check(isLegacyAlias('Anonymous User'), true, 'the old fallback was indistinguishable from a real alias — this is why it went')
+check(isLegacyAlias(''), false, 'an empty string is not a legacy alias')
+check(isLegacyAlias(null), false, 'null is not a legacy alias')
+
+check(hasDiscriminator('Gentle Willow 7K2QX'), true, 'a current alias is recognised')
+check(hasDiscriminator('Gentle Willow 7K2Q'), false, 'a four-character suffix is not a discriminator')
+check(hasDiscriminator('Gentle Willow 7K2QXY'), false, 'a six-character suffix is not a discriminator')
+check(hasDiscriminator('Gentle Willow 7K2QI'), false, 'a suffix using an excluded character is rejected')
+check(hasDiscriminator('Gentle Willow'), false, 'a two-word alias has no discriminator')
+
+// ---------------------------------------------------------------------------
+
+console.log(`\n${failed === 0 ? '✅' : '❌'} ${passed} passed, ${failed} failed`)
+process.exit(failed === 0 ? 0 : 1)


### PR DESCRIPTION
## Linked Issue
Fixes #521

## Description

The forum's anonymous alias is its **only** identity — `forum_posts.author_alias` is what the UI renders, and `user_id` is never exposed. It was drawn from two 40-word lists:

```js
const adjIndex  = parseInt(hash.substring(0, 8), 16) % adjectives.length;
const nounIndex = parseInt(hash.substring(8, 16), 16) % nouns.length;
```

40 × 40 = **1,600 aliases for the entire user base.** By the birthday bound:

| Users | P(at least one collision) |
|------:|--------------------------:|
| 20 | 11 % |
| 47 | 50 % |
| 100 | 96 % |
| 200 | 99.996 % (≈12 colliding pairs) |

A collision presents two different people to every reader as the same person, in threads where they are describing their own diagnoses. Advice gets attributed to the wrong person, and neither user can tell them apart.

It also failed in the other direction: the alias was an unsalted `sha256(userId)`. Clerk ids appear in webhook payloads, in support tooling, and in the `user_id` column of every table an admin can read — so anyone holding one could compute that user's forum name offline and find everything she had ever written. The anonymity was one `sha256()` call deep.

### Approach

- **`lib/alias-words.js`** — 96 adjectives and 96 nouns, with the original 40 of each kept first and in their original order. Plus a five-character Crockford-base32 discriminator. The width is derived from the birthday bound rather than chosen by taste, and the working is in the file:

  | Discriminator | Space | 50 % collision at |
  |---|---:|---:|
  | none (old) | 1,600 | 47 users |
  | 4 decimal digits | 92.2 M | 11,300 |
  | **5 base32 chars** | **309 B** | **654,000** |

  Aliases read `Gentle Willow 7K2QX`.

- **Keyed derivation.** `HMAC-SHA512(secret, userId)` where the secret is `FORUM_ALIAS_SECRET`, falling back to `SUPABASE_SERVICE_ROLE_KEY` — already required on every server that runs this code, never sent to a browser, and stable across deploys, so an existing deployment gets non-reversible aliases without a new variable.

- **Rejection sampling** instead of `% 40`. The old modulo was biased toward the first 16 words of each list (`4294967296 % 40 === 16`) and used 64 of the 256 hash bits.

- **`generateAlias(null)` now throws** instead of returning `'Anonymous User'` — a string indistinguishable from a real generated alias, so a bug that lost the user id rendered as an ordinary-looking author.

### On rotation

This changes what `generateAlias()` returns for an existing user. That is deliberate and one-time: the old alias was not a durable identity because it was not unique. **Nothing in the database moves** — `author_alias` is stored per row, so every historical post and comment keeps the name it was written under and old threads stay internally consistent.

`lib/alias-display.js` is a separate, import-free module so `PostCard`, `CommentSection` and the post page can render a stored alias without pulling `crypto` — or the derivation itself — into the browser bundle. That split is a boundary, not a file-size preference: an alias derived in the browser is an alias whose secret is in the browser.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (clean code updates, no behavior modifications)
- [ ] Documentation update
- [ ] Performance optimization
- [x] Security patch

## Files Modified

| File | Change |
|------|--------|
| `lib/alias-words.js` | **new** — the vocabulary, the discriminator alphabet, and an editing policy (append only) |
| `lib/alias-display.js` | **new** — rendering stored aliases; no imports, safe in a Client Component |
| `lib/alias-generator.js` | HMAC derivation, uniform sampler, throws on invalid input |
| `components/community/PostCard.jsx` | renders through `renderStoredAlias` |
| `components/community/CommentSection.jsx` | same |
| `app/[locale]/community/post/[postId]/page.jsx` | same |
| `.env.example` | documents `FORUM_ALIAS_SECRET` and why it must stay stable |
| `scripts/test-alias-generator.js` | **new** — 75 assertions |

## Testing

```
$ node scripts/test-alias-generator.js
✅ 75 passed, 0 failed
```

The two assertions that matter most:

- **100,000 synthetic Clerk-shaped ids produce 100,000 distinct aliases**, zero collisions. The old scheme could not have passed this line at any sample size above 1,600.
- **The same id under two different secrets produces two unrelated aliases**, and the alias is no longer what `sha256(userId)` would have produced — so the mapping is not computable without the key.

Plus: distribution across 60,000 samples within 5σ of uniform for both word lists and every discriminator character (a subtly biased sampler still returns plausible-looking names, which is why this is measured rather than eyeballed), determinism, and that the legacy two-word format still renders unchanged.

## Screenshots (if UI changes are made)
N/A — the alias renders in the same place, in the same style. Existing posts are visually unchanged; new posts carry the discriminator suffix.

## Checklist
- [x] This PR is submitted under ECSOC.
- [x] Added the required **ECSoc26** label to this Pull Request.
- [x] Linked issue using `Fixes #521`.
- [x] Tested locally.
- [x] No breaking changes introduced — no migration, no schema change, history renders as-is.
- [x] Documentation updated if required (`.env.example`).
