### PR TITLE
[ECSoC26] fix(push): make background notifications actually reach a device

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,22 @@ CLERK_SECRET_KEY=sk_test_your_clerk_secret_here
 CLERK_WEBHOOK_SECRET=whsec_your_clerk_webhook_signing_secret_here
 
 # ------------------------------------------------------------
+# Web Push (background notifications: love notes, period alerts)
+# ------------------------------------------------------------
+# Generate a pair with:  npx web-push generate-vapid-keys
+#
+# Both are optional — with neither set, the notification settings screen says
+# background push is not available on this server instead of claiming it was
+# enabled. What must NOT happen is the placeholder pair that used to be
+# hard-coded as a default: it is not a valid P-256 key pair, so every send
+# failed while the UI reported success.
+#
+# Changing the pair invalidates every stored subscription; users have to
+# re-enable notifications.
+NEXT_PUBLIC_VAPID_PUBLIC_KEY=
+VAPID_PRIVATE_KEY=
+
+# ------------------------------------------------------------
 # 3. AI Integrations
 # ------------------------------------------------------------
 # Google Gemini API key (for primary chat assistant queries)

--- a/components/layout/NotificationSettings.jsx
+++ b/components/layout/NotificationSettings.jsx
@@ -5,7 +5,7 @@ import { Bell, Heart, Mail, Sparkles, Check, CheckCheck, Clock, ShieldAlert, Dro
 import { useUser } from '@clerk/nextjs'
 import toast from 'react-hot-toast'
 import { getPrimaryPartnerNudges, getSharedInsights } from '@/lib/actions/partner'
-import { requestNotificationPermission, getNotificationPermissionStatus, sendDeviceNotification } from '@/lib/utils/notifications'
+import { requestNotificationPermission, getNotificationPermissionStatus, sendDeviceNotification, PUSH_STATES } from '@/lib/utils/notifications'
 import NotificationPreferences from '@/components/settings/NotificationPreferences'
 
 export default function NotificationSettings() {
@@ -40,14 +40,29 @@ export default function NotificationSettings() {
   }, [])
 
   const handleEnableDevicePush = async () => {
-    const status = await requestNotificationPermission()
-    setDevicePermission(status)
-    if (status === 'granted') {
+    // requestNotificationPermission now reports whether the subscription
+    // actually reached the server, not just whether the browser prompt was
+    // accepted. The two are not the same thing: this flow used to show a
+    // success toast whenever permission was granted, while the subscription
+    // was failing to save every single time.
+    const { state, permission, message } = await requestNotificationPermission()
+    setDevicePermission(permission)
+
+    if (state === PUSH_STATES.ENABLED) {
       toast.success('Device push notifications enabled! 🔔')
-      sendDeviceNotification('HerCycle AI Notifications Active 🌸', 'You will now receive instant lock screen & push alerts for love notes & period updates!')
-    } else if (status === 'denied') {
-      toast.error('Notification permission was blocked in browser settings.')
+      // A local notification, shown by this tab. Kept as immediate feedback,
+      // but only now that it follows a subscription we know was stored — on
+      // its own it demonstrates nothing about background push.
+      sendDeviceNotification(
+        'HerCycle AI Notifications Active 🌸',
+        'You will now receive instant lock screen & push alerts for love notes & period updates!'
+      )
+      return
     }
+
+    // Every other state gets the specific reason rather than silence. A
+    // dismissed prompt in particular used to produce no feedback at all.
+    toast.error(message)
   }
 
   const loadNotificationsFeed = async () => {

--- a/lib/actions/partner.js
+++ b/lib/actions/partner.js
@@ -692,10 +692,25 @@ export async function sendPartnerNudge(nudgeType, message = null) {
   // Trigger background server push notification to recipient's phone/desktop
   const recipientUserId = connection.primary_user_id === userId ? connection.partner_user_id : connection.primary_user_id;
   if (recipientUserId) {
+    // Deliberately not awaited — the nudge is already written, and the sender
+    // should not wait on a push service to see it. The outcome is logged
+    // rather than discarded, though: `.catch(() => {})` in front of a function
+    // that returned `{ success: true }` regardless of what happened meant a
+    // completely dead push pipeline produced no signal anywhere at all.
     sendServerPushToUser(recipientUserId, {
       title: 'New Love Note 💌',
       body: message || `Sent a ${nudgeType} 💕`,
-    }).catch(() => {});
+    })
+      .then((outcome) => {
+        // 'no_subscriptions' is the ordinary case of a recipient who has not
+        // enabled notifications, not a failure worth logging.
+        if (!outcome?.success && outcome?.reason !== 'no_subscriptions') {
+          console.warn(`Love-note push was not delivered: ${outcome?.reason || 'unknown reason'}`);
+        }
+      })
+      .catch((error) => {
+        console.warn(`Love-note push threw: ${error?.message || error}`);
+      });
   }
 
   return { success: true, nudge: data };

--- a/lib/actions/push.js
+++ b/lib/actions/push.js
@@ -1,91 +1,315 @@
 'use server'
 
+/**
+ * push.js — server actions for Web Push subscriptions.
+ *
+ * Background push has never worked in this codebase. The upsert below used to
+ * read:
+ *
+ *     .upsert([{ user_id: userId, subscription, updated_at }], { onConflict: 'user_id' })
+ *
+ * against a table with only a plain, non-unique index on `user_id`. PostgreSQL
+ * answers that with 42P10, so every save failed — and the failure was
+ * swallowed at three consecutive layers: this action logged and returned
+ * `{ success: false }`, `lib/utils/notifications.js` discarded the return
+ * value, and `NotificationSettings` showed a green toast plus a *local*
+ * notification, which proves nothing because it never leaves the device.
+ *
+ * `supabase/02_push_subscription_endpoint.sql` adds the key, and this file
+ * stops hiding the outcomes:
+ *
+ * - The VAPID configuration is checked instead of being replaced by a
+ *   placeholder that cannot work.
+ * - Subscriptions are keyed by endpoint, so a user can have more than one
+ *   device.
+ * - Send results are inspected, so "delivered" means delivered.
+ * - Endpoints the push service reports as permanently gone are deleted rather
+ *   than retried forever.
+ *
+ * The decisions — what a valid subscription looks like, what each failure
+ * status means — live in `lib/push-subscription.js` and are unit-tested there.
+ */
+
 import { auth } from '@clerk/nextjs/server'
-import { getSupabaseAdmin } from '@/lib/supabase-admin'
 import webpush from 'web-push'
 
-// Configure VAPID details (standard web-push configuration)
-const VAPID_PUBLIC_KEY = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY || 'BEl62iUYgUivxIkv69yViEuiBIa40yYlK80pvwB8z7x0uE1jA4gR4Jz1fA5mK9_E5-6P_e_E5-6P_e_E5-6P_e'
-const VAPID_PRIVATE_KEY = process.env.VAPID_PRIVATE_KEY || '1A2B3C4D5E6F7G8H9I0J1K2L3M4N5O6P'
+import { getSupabaseAdmin } from '@/lib/supabase-admin'
+import { logger } from '@/lib/logger'
+import {
+  FAILURE_KINDS,
+  classifySendFailure,
+  describeVapidConfig,
+  normaliseSubscription,
+  summariseSendResults,
+} from '@/lib/push-subscription'
 
-try {
-  webpush.setVapidDetails(
-    'mailto:support@hercycle.app',
-    VAPID_PUBLIC_KEY,
-    VAPID_PRIVATE_KEY
-  )
-} catch (e) {
-  // Graceful fallback
+const VAPID_SUBJECT = 'mailto:support@hercycle.app'
+
+/** Set once the keys have been handed to web-push, so we do not repeat it. */
+let vapidReady = false
+/** Whether the "push is not configured" warning has already been logged. */
+let warnedUnconfigured = false
+
+/**
+ * Configures web-push, or reports why it cannot be configured.
+ *
+ * The keys are no longer defaulted. The old module read:
+ *
+ *     const VAPID_PUBLIC_KEY  = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY || 'BEl62iUYgUivx…'
+ *     const VAPID_PRIVATE_KEY = process.env.VAPID_PRIVATE_KEY || '1A2B3C4D5E6F7G8H9I0J1K2L3M4N5O6P'
+ *
+ * Neither default is a real key. `setVapidDetails` threw on them, and the
+ * `catch` discarded the error with a comment calling it a graceful fallback —
+ * leaving the module in a state where every send would fail with nothing
+ * anywhere saying so.
+ *
+ * @returns {{ ok: boolean, problems: string[] }}
+ */
+function ensureVapidConfigured() {
+  const status = describeVapidConfig({
+    publicKey: process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY,
+    privateKey: process.env.VAPID_PRIVATE_KEY,
+  })
+
+  if (!status.configured) {
+    if (!warnedUnconfigured) {
+      warnedUnconfigured = true
+      logger.error(`Web Push is not configured: ${status.problems.join(' ')}`)
+    }
+    return { ok: false, problems: status.problems }
+  }
+
+  if (!vapidReady) {
+    try {
+      webpush.setVapidDetails(
+        VAPID_SUBJECT,
+        process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY,
+        process.env.VAPID_PRIVATE_KEY
+      )
+      vapidReady = true
+    } catch (error) {
+      // Reachable only if web-push rejects a pair that passed our own checks.
+      // Still reported rather than swallowed.
+      logger.error(`web-push rejected the VAPID key pair: ${error.message || error}`)
+      return { ok: false, problems: ['The configured VAPID key pair was rejected by web-push.'] }
+    }
+  }
+
+  return { ok: true, problems: [] }
 }
 
 /**
  * Saves a browser push subscription for the logged-in user.
+ *
+ * @param {unknown} subscription the serialised `PushSubscription`
+ * @returns {Promise<{ success: boolean, reason?: string }>}
  */
 export async function savePushSubscription(subscription) {
   const { userId } = await auth()
   if (!userId) throw new Error('Unauthorized')
-  if (!subscription || !subscription.endpoint) return { success: false }
+
+  // Refusing to store a subscription the server could never send to is the
+  // honest answer: the user is about to be told notifications are on.
+  const config = ensureVapidConfigured()
+  if (!config.ok) {
+    return { success: false, reason: 'not_configured' }
+  }
+
+  // The old check was `subscription && subscription.endpoint`, which accepts a
+  // subscription with no `keys` — the push service takes the request and the
+  // browser cannot decrypt the payload, so it fails in a way that looks like
+  // success from here.
+  const normalised = normaliseSubscription(subscription)
+  if (!normalised) {
+    logger.warn(`Rejected a malformed push subscription for user ${userId}`)
+    return { success: false, reason: 'invalid_subscription' }
+  }
+
+  const supabase = getSupabaseAdmin()
+
+  try {
+    const { error } = await supabase.from('user_push_subscriptions').upsert(
+      {
+        user_id: userId,
+        endpoint: normalised.endpoint,
+        subscription: normalised,
+        updated_at: new Date().toISOString(),
+      },
+      // Matches the constraint added by
+      // supabase/02_push_subscription_endpoint.sql. Keyed on the endpoint so a
+      // second device adds a row instead of replacing the first one.
+      { onConflict: 'user_id,endpoint' }
+    )
+
+    if (error) {
+      // 42P10 here means the migration has not been applied. Say so, rather
+      // than logging a bare Postgres string for the third year running.
+      const hint =
+        error.code === '42P10'
+          ? ' — supabase/02_push_subscription_endpoint.sql has not been applied to this database.'
+          : ''
+      logger.error(`Failed to save push subscription for user ${userId}: ${error.message}${hint}`)
+      return { success: false, reason: 'save_failed' }
+    }
+
+    logger.info(`Registered a push subscription for user ${userId}`)
+    return { success: true }
+  } catch (err) {
+    logger.error(`Push subscription error for user ${userId}: ${err.message || err}`)
+    return { success: false, reason: 'save_failed' }
+  }
+}
+
+/**
+ * Removes a subscription — used when a browser reports its subscription has
+ * changed, and by the pruning path below.
+ *
+ * @param {string} endpoint
+ * @returns {Promise<{ success: boolean }>}
+ */
+export async function removePushSubscription(endpoint) {
+  const { userId } = await auth()
+  if (!userId) throw new Error('Unauthorized')
+  if (typeof endpoint !== 'string' || endpoint.length === 0) return { success: false }
 
   const supabase = getSupabaseAdmin()
 
   try {
     const { error } = await supabase
       .from('user_push_subscriptions')
-      .upsert(
-        [
-          {
-            user_id: userId,
-            subscription: subscription,
-            updated_at: new Date().toISOString(),
-          },
-        ],
-        { onConflict: 'user_id' }
-      )
+      .delete()
+      .eq('user_id', userId)
+      .eq('endpoint', endpoint)
 
     if (error) {
-      console.error('Error saving push subscription:', error)
+      logger.error(`Failed to remove push subscription for user ${userId}: ${error.message}`)
       return { success: false }
     }
-
     return { success: true }
   } catch (err) {
-    console.error('Push subscription error:', err)
+    logger.error(`Push subscription removal error: ${err.message || err}`)
     return { success: false }
   }
 }
 
 /**
- * Dispatches a background Web Push alert to a target user's device.
+ * Deletes endpoints a push service has declared permanently gone.
+ *
+ * Nothing did this before, so a revoked endpoint — the ordinary result of
+ * clearing site data or uninstalling a PWA — stayed in the table and was
+ * retried on every notification for the rest of time.
+ *
+ * Not exported: pruning is a consequence of sending, never something a caller
+ * should ask for directly, and a `'use server'` module exports actions
+ * reachable from the client.
+ *
+ * @param {object} supabase
+ * @param {string} userId
+ * @param {string[]} endpoints
+ */
+async function pruneGoneEndpoints(supabase, userId, endpoints) {
+  if (!endpoints || endpoints.length === 0) return
+
+  try {
+    const { error } = await supabase
+      .from('user_push_subscriptions')
+      .delete()
+      .eq('user_id', userId)
+      .in('endpoint', endpoints)
+
+    if (error) {
+      logger.error(`Failed to prune ${endpoints.length} dead push endpoints: ${error.message}`)
+      return
+    }
+
+    logger.info(`Pruned ${endpoints.length} dead push endpoint(s) for user ${userId}`)
+  } catch (err) {
+    logger.error(`Error pruning dead push endpoints: ${err.message || err}`)
+  }
+}
+
+/**
+ * Dispatches a background Web Push alert to every device a user has
+ * registered.
+ *
+ * @param {string} targetUserId
+ * @param {{ title?: string, body?: string, url?: string }} payload
+ * @returns {Promise<{ success: boolean, delivered: number, attempted: number, reason?: string }>}
  */
 export async function sendServerPushToUser(targetUserId, payload) {
-  if (!targetUserId) return { success: false }
+  if (!targetUserId) return { success: false, delivered: 0, attempted: 0, reason: 'no_target' }
+
+  const config = ensureVapidConfigured()
+  if (!config.ok) {
+    return { success: false, delivered: 0, attempted: 0, reason: 'not_configured' }
+  }
 
   const supabase = getSupabaseAdmin()
 
   try {
-    const { data: subs } = await supabase
+    const { data: rows, error } = await supabase
       .from('user_push_subscriptions')
-      .select('subscription')
+      .select('endpoint, subscription')
       .eq('user_id', targetUserId)
 
-    if (!subs || subs.length === 0) return { success: false }
+    if (error) {
+      logger.error(`Failed to load push subscriptions for user ${targetUserId}: ${error.message}`)
+      return { success: false, delivered: 0, attempted: 0, reason: 'lookup_failed' }
+    }
+
+    if (!rows || rows.length === 0) {
+      // Not an error — the user simply has no device registered. Distinct from
+      // a failure so the caller can tell the difference.
+      return { success: false, delivered: 0, attempted: 0, reason: 'no_subscriptions' }
+    }
 
     const pushPayload = JSON.stringify({
-      title: payload.title || 'HerCycle AI 🌸',
-      body: payload.body || 'You have a new companion notification.',
-      url: payload.url || '/',
-      icon: '/favicon.ico',
+      title: payload?.title || 'HerCycle AI 🌸',
+      body: payload?.body || 'You have a new companion notification.',
+      url: payload?.url || '/',
+      icon: '/icon-192.png',
     })
 
-    const results = await Promise.allSettled(
-      subs.map((subObj) =>
-        webpush.sendNotification(subObj.subscription, pushPayload)
-      )
+    const results = await Promise.all(
+      rows.map(async (row) => {
+        try {
+          await webpush.sendNotification(row.subscription, pushPayload)
+          return { endpoint: row.endpoint, ok: true }
+        } catch (error) {
+          // Every failure is captured with its endpoint so the summary can say
+          // which subscriptions to delete. The previous Promise.allSettled
+          // discarded the results entirely and returned `{ success: true }`.
+          return { endpoint: row.endpoint, ok: false, error }
+        }
+      })
     )
 
-    return { success: true, count: results.length }
+    const summary = summariseSendResults(results)
+
+    await pruneGoneEndpoints(supabase, targetUserId, summary.goneEndpoints)
+
+    if (summary.misconfigured) {
+      logger.error(
+        `Push sends were rejected as misconfigured for user ${targetUserId} — check the VAPID key pair.`
+      )
+    }
+    if (summary.failed > 0 && !summary.misconfigured) {
+      const kinds = results
+        .filter((r) => !r.ok)
+        .map((r) => classifySendFailure(r.error))
+        .filter((kind) => kind !== FAILURE_KINDS.GONE)
+      if (kinds.length > 0) {
+        logger.warn(`${kinds.length} push send(s) failed transiently for user ${targetUserId}`)
+      }
+    }
+
+    return {
+      success: summary.success,
+      delivered: summary.delivered,
+      attempted: summary.attempted,
+    }
   } catch (err) {
-    console.error('Error sending server push notification:', err)
-    return { success: false }
+    logger.error(`Error sending server push notification: ${err.message || err}`)
+    return { success: false, delivered: 0, attempted: 0, reason: 'send_failed' }
   }
 }

--- a/lib/push-subscription.js
+++ b/lib/push-subscription.js
@@ -1,0 +1,376 @@
+/**
+ * push-subscription.js — the parts of Web Push that are decisions, not I/O.
+ *
+ * ## Why this module exists
+ *
+ * Background push in this app could not work. `lib/actions/push.js` wrote the
+ * subscription with:
+ *
+ *     .upsert([{ user_id: userId, subscription, updated_at }], { onConflict: 'user_id' })
+ *
+ * against a table whose only index on `user_id` is a plain, non-unique one.
+ * PostgreSQL answers `ON CONFLICT` on a non-unique column with error 42P10, so
+ * every save failed — and the failure was swallowed three times over: the
+ * action logged and returned `{ success: false }`, `lib/utils/notifications.js`
+ * discarded the return value, and `NotificationSettings` showed a green
+ * "enabled" toast plus a *local* notification, which proves nothing because it
+ * never leaves the device.
+ *
+ * Everything that could be checked without a network or a database is here, so
+ * the parts that failed silently now fail in a test instead:
+ *
+ * - Is this actually a `PushSubscription`?
+ * - Is the VAPID configuration real, or the placeholder that shipped as a
+ *   default?
+ * - Does this send failure mean "try later" or "this device is gone forever"?
+ * - Did a batch of sends actually deliver anything?
+ *
+ * No imports, no `fetch`, no `webpush`, no Supabase. Safe on the server, in a
+ * Client Component, and in a plain Node script.
+ */
+
+// ---------------------------------------------------------------------------
+// The placeholders that shipped as defaults
+// ---------------------------------------------------------------------------
+
+/**
+ * The public key that was hard-coded as `NEXT_PUBLIC_VAPID_PUBLIC_KEY`'s
+ * fallback in both `lib/actions/push.js` and `lib/utils/notifications.js`.
+ *
+ * It reads like the example key from the web-push documentation, and it is
+ * long enough to look right at a glance — but it decodes to 64 bytes, one
+ * short of the 65 an uncompressed P-256 point needs. Nothing ever checked, so
+ * the browser was handed an application server key that could not
+ * authenticate a single send, and the subscriptions it produced looked
+ * perfectly healthy from the client side.
+ */
+export const PLACEHOLDER_VAPID_PUBLIC_KEY =
+  'BEl62iUYgUivxIkv69yViEuiBIa40yYlK80pvwB8z7x0uE1jA4gR4Jz1fA5mK9_E5-6P_e_E5-6P_e_E5-6P_e'
+
+/**
+ * The private key that was hard-coded as `VAPID_PRIVATE_KEY`'s fallback. Not a
+ * P-256 scalar at all — 32 ASCII characters, which decode to 24 bytes.
+ * `webpush.setVapidDetails` throws on it, and the throw was caught by a block
+ * whose entire body was the comment `// Graceful fallback`.
+ */
+export const PLACEHOLDER_VAPID_PRIVATE_KEY = '1A2B3C4D5E6F7G8H9I0J1K2L3M4N5O6P'
+
+/** An uncompressed P-256 public point is 65 bytes: `0x04` then X and Y. */
+const VAPID_PUBLIC_KEY_BYTES = 65
+
+/** A P-256 private scalar is 32 bytes. */
+const VAPID_PRIVATE_KEY_BYTES = 32
+
+// ---------------------------------------------------------------------------
+// base64url
+// ---------------------------------------------------------------------------
+
+/**
+ * Decodes base64url to a byte length, without allocating a decoder that only
+ * exists on one runtime.
+ *
+ * Returns `-1` for anything that is not well-formed base64url, which is a
+ * meaningful answer here: a key containing a `+`, a `/`, or padding is not a
+ * VAPID key, whatever else it might be.
+ *
+ * @param {string} value
+ * @returns {number} the decoded length in bytes, or -1
+ */
+export function base64UrlByteLength(value) {
+  if (typeof value !== 'string' || value.length === 0) return -1
+
+  // Standard base64 characters that base64url replaces, plus padding. Their
+  // presence means whoever produced this used the wrong alphabet.
+  if (/[+/=]/.test(value)) return -1
+  if (!/^[A-Za-z0-9_-]+$/.test(value)) return -1
+
+  const remainder = value.length % 4
+  // A base64 group is 4 characters. A remainder of 1 cannot occur: one
+  // character carries 6 bits, which is not enough for a byte.
+  if (remainder === 1) return -1
+
+  const fullGroups = Math.floor(value.length / 4)
+  const extra = remainder === 0 ? 0 : remainder === 2 ? 1 : 2
+
+  return fullGroups * 3 + extra
+}
+
+// ---------------------------------------------------------------------------
+// VAPID configuration
+// ---------------------------------------------------------------------------
+
+/**
+ * @typedef {object} VapidStatus
+ * @property {boolean} configured   true only when both keys are real
+ * @property {string[]} problems    one plain sentence per problem, for an operator
+ */
+
+/**
+ * Checks a VAPID key pair.
+ *
+ * The point is that "not configured" becomes a state the application can see
+ * and report, rather than something replaced by a placeholder and discovered
+ * months later when a user asks why she never gets notifications.
+ *
+ * @param {{ publicKey?: string, privateKey?: string }} keys
+ * @returns {VapidStatus}
+ */
+export function describeVapidConfig(keys = {}) {
+  const { publicKey, privateKey } = keys
+  const problems = []
+
+  if (!publicKey) {
+    problems.push('NEXT_PUBLIC_VAPID_PUBLIC_KEY is not set.')
+  } else if (publicKey === PLACEHOLDER_VAPID_PUBLIC_KEY) {
+    problems.push(
+      'NEXT_PUBLIC_VAPID_PUBLIC_KEY is the placeholder key from the web-push docs. Generate your own with `npx web-push generate-vapid-keys`.'
+    )
+  } else if (base64UrlByteLength(publicKey) !== VAPID_PUBLIC_KEY_BYTES) {
+    problems.push(
+      `NEXT_PUBLIC_VAPID_PUBLIC_KEY does not decode to ${VAPID_PUBLIC_KEY_BYTES} bytes, so it is not a P-256 public key.`
+    )
+  }
+
+  if (!privateKey) {
+    problems.push('VAPID_PRIVATE_KEY is not set.')
+  } else if (privateKey === PLACEHOLDER_VAPID_PRIVATE_KEY) {
+    problems.push('VAPID_PRIVATE_KEY is the placeholder value that shipped as a default. Generate a real key pair.')
+  } else if (base64UrlByteLength(privateKey) !== VAPID_PRIVATE_KEY_BYTES) {
+    problems.push(
+      `VAPID_PRIVATE_KEY does not decode to ${VAPID_PRIVATE_KEY_BYTES} bytes, so it is not a P-256 private key.`
+    )
+  }
+
+  return { configured: problems.length === 0, problems }
+}
+
+// ---------------------------------------------------------------------------
+// Subscriptions
+// ---------------------------------------------------------------------------
+
+/**
+ * @typedef {object} NormalisedSubscription
+ * @property {string} endpoint
+ * @property {string|null} expirationTime
+ * @property {{ p256dh: string, auth: string }} keys
+ */
+
+/**
+ * Validates and normalises a browser `PushSubscription`.
+ *
+ * The old code checked `subscription && subscription.endpoint` and stored
+ * whatever it was given. A subscription missing its `keys` is accepted by that
+ * check and then fails at send time, once per notification, forever — because
+ * nothing ever removes it.
+ *
+ * Returns `null` for anything unusable, so a bad subscription is rejected at
+ * the point it arrives rather than at every future send.
+ *
+ * @param {unknown} raw
+ * @returns {NormalisedSubscription|null}
+ */
+export function normaliseSubscription(raw) {
+  if (!raw || typeof raw !== 'object') return null
+
+  const endpoint = normaliseEndpoint(raw.endpoint)
+  if (!endpoint) return null
+
+  const keys = raw.keys
+  if (!keys || typeof keys !== 'object') return null
+
+  const p256dh = typeof keys.p256dh === 'string' ? keys.p256dh.trim() : ''
+  const auth = typeof keys.auth === 'string' ? keys.auth.trim() : ''
+
+  // Without both of these the push service can accept the request and the
+  // browser still cannot decrypt the payload — a failure that looks like
+  // success from the server side.
+  if (p256dh.length === 0 || auth.length === 0) return null
+
+  return {
+    endpoint,
+    expirationTime:
+      typeof raw.expirationTime === 'string' || raw.expirationTime === null
+        ? raw.expirationTime
+        : null,
+    keys: { p256dh, auth },
+  }
+}
+
+/**
+ * Normalises a push endpoint into the value used as the deduplication key.
+ *
+ * The endpoint is the natural key for a subscription: it identifies one
+ * browser installation on one device. Keying on `user_id` instead — which is
+ * what `onConflict: 'user_id'` intended — means a user who enables
+ * notifications on her phone and then on her laptop silently loses the phone.
+ *
+ * @param {unknown} endpoint
+ * @returns {string|null}
+ */
+export function normaliseEndpoint(endpoint) {
+  if (typeof endpoint !== 'string') return null
+
+  const trimmed = endpoint.trim()
+  if (trimmed.length === 0) return null
+
+  // Push endpoints are always absolute https URLs issued by the browser's push
+  // service. Anything else is either a bug or an attempt to have the server
+  // make a request somewhere it should not.
+  if (!/^https:\/\//i.test(trimmed)) return null
+
+  return trimmed
+}
+
+// ---------------------------------------------------------------------------
+// Send outcomes
+// ---------------------------------------------------------------------------
+
+/**
+ * What a failed send means for the stored subscription.
+ *
+ * - `GONE`          the endpoint is permanently dead. Delete the row.
+ * - `RETRYABLE`     a transient failure. Keep the row, try next time.
+ * - `MISCONFIGURED` our keys or payload are wrong. Keep the row; deleting
+ *                   would punish the user for an operator error.
+ */
+export const FAILURE_KINDS = Object.freeze({
+  GONE: 'gone',
+  RETRYABLE: 'retryable',
+  MISCONFIGURED: 'misconfigured',
+})
+
+/**
+ * Classifies a `web-push` send failure.
+ *
+ * Nothing in the previous implementation read a status code at all:
+ *
+ *     const results = await Promise.allSettled(subs.map(…))
+ *     return { success: true, count: results.length }
+ *
+ * so a subscription the push service had already declared permanently gone was
+ * retried on every single notification, forever, and ten rejected sends were
+ * reported as ten successes.
+ *
+ * The status codes come from RFC 8030 and the push services' own behaviour:
+ * 404 and 410 are the two that mean the endpoint will never work again.
+ *
+ * @param {unknown} error a `web-push` WebPushError or any thrown value
+ * @returns {string} one of {@link FAILURE_KINDS}
+ */
+export function classifySendFailure(error) {
+  const status = Number(error?.statusCode ?? error?.status)
+
+  if (status === 404 || status === 410) return FAILURE_KINDS.GONE
+
+  // 401/403 are our VAPID identity being rejected; 400 is usually a malformed
+  // payload or a bad key. All three are ours to fix, not the subscription's
+  // fault, so the row stays.
+  if (status === 400 || status === 401 || status === 403) return FAILURE_KINDS.MISCONFIGURED
+
+  // 413 is a payload over the push service's size limit — also ours.
+  if (status === 413) return FAILURE_KINDS.MISCONFIGURED
+
+  return FAILURE_KINDS.RETRYABLE
+}
+
+/**
+ * @typedef {object} SendSummary
+ * @property {number} attempted
+ * @property {number} delivered
+ * @property {number} failed
+ * @property {string[]} goneEndpoints  endpoints to delete
+ * @property {boolean} misconfigured   at least one failure was ours
+ * @property {boolean} success         true only when something was delivered
+ */
+
+/**
+ * Summarises a batch of send attempts.
+ *
+ * `success` is `delivered > 0`, not `results.length > 0`. That single
+ * difference is what stops `sendServerPushToUser` reporting a delivery that
+ * never happened — which is what let a broken push pipeline sit unnoticed
+ * behind a caller that does `.catch(() => {})`.
+ *
+ * Zero subscriptions is not success: it means the user has no device
+ * registered, which the caller may want to act on.
+ *
+ * @param {Array<{ endpoint: string, ok: boolean, error?: unknown }>} results
+ * @returns {SendSummary}
+ */
+export function summariseSendResults(results) {
+  const rows = Array.isArray(results) ? results.filter(Boolean) : []
+
+  const goneEndpoints = []
+  let delivered = 0
+  let misconfigured = false
+
+  for (const row of rows) {
+    if (row.ok) {
+      delivered += 1
+      continue
+    }
+
+    const kind = classifySendFailure(row.error)
+    if (kind === FAILURE_KINDS.GONE && row.endpoint) goneEndpoints.push(row.endpoint)
+    if (kind === FAILURE_KINDS.MISCONFIGURED) misconfigured = true
+  }
+
+  return {
+    attempted: rows.length,
+    delivered,
+    failed: rows.length - delivered,
+    goneEndpoints,
+    misconfigured,
+    success: delivered > 0,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Client-side status
+// ---------------------------------------------------------------------------
+
+/**
+ * The state the notification settings UI needs to render honestly.
+ *
+ * `ENABLED` is the only one that should show a success message, and it
+ * requires the subscription to have reached the server. The old UI showed
+ * "Device push notifications enabled! 🔔" purely on the browser permission
+ * prompt being accepted, which is true of a device that will never receive
+ * anything.
+ */
+export const PUSH_STATES = Object.freeze({
+  UNSUPPORTED: 'unsupported',
+  DENIED: 'denied',
+  DISMISSED: 'dismissed',
+  NOT_CONFIGURED: 'not_configured',
+  SAVE_FAILED: 'save_failed',
+  ENABLED: 'enabled',
+})
+
+const PUSH_STATE_MESSAGES = Object.freeze({
+  [PUSH_STATES.UNSUPPORTED]: 'This browser does not support background notifications.',
+  [PUSH_STATES.DENIED]: 'Notification permission is blocked. You can re-enable it in your browser settings.',
+  [PUSH_STATES.DISMISSED]: 'No problem — you can turn notifications on any time.',
+  [PUSH_STATES.NOT_CONFIGURED]:
+    'Background notifications are not set up on this server yet, so nothing would reach your device.',
+  [PUSH_STATES.SAVE_FAILED]: 'We could not register this device for notifications. Please try again.',
+  [PUSH_STATES.ENABLED]: 'This device is registered for notifications.',
+})
+
+/**
+ * @param {string} state
+ * @returns {string}
+ */
+export function describePushState(state) {
+  return PUSH_STATE_MESSAGES[state] || PUSH_STATE_MESSAGES[PUSH_STATES.SAVE_FAILED]
+}
+
+/**
+ * Whether a state should be presented to the user as a success.
+ *
+ * @param {string} state
+ * @returns {boolean}
+ */
+export function isPushEnabled(state) {
+  return state === PUSH_STATES.ENABLED
+}

--- a/lib/utils/notifications.js
+++ b/lib/utils/notifications.js
@@ -1,16 +1,42 @@
 'use client'
 
+/**
+ * notifications.js — the browser half of Web Push.
+ *
+ * This file used to end an "enable notifications" flow with:
+ *
+ *     if (sub) {
+ *       await savePushSubscription(JSON.parse(JSON.stringify(sub)))
+ *     }
+ *
+ * — the return value discarded. The server action it calls could not succeed
+ * (see `lib/actions/push.js`), so the subscription was never stored, and the
+ * caller still went on to show a success toast. What follows returns a state
+ * rather than a bare permission string, so the UI can only claim success when
+ * the subscription actually reached the server.
+ *
+ * It also no longer carries a fallback `applicationServerKey`. The old default
+ * was the placeholder key from the web-push docs, which meant a deployment
+ * with no VAPID configuration produced subscriptions bound to a key pair
+ * nobody holds — subscriptions that look fine in the browser and can never be
+ * delivered to.
+ */
+
 import { savePushSubscription } from '@/lib/actions/push'
+import { PUSH_STATES, describePushState } from '@/lib/push-subscription'
+
+export { PUSH_STATES, describePushState } from '@/lib/push-subscription'
 
 /**
  * Registers the Service Worker for background push notifications.
+ *
+ * @returns {Promise<ServiceWorkerRegistration|null>}
  */
 export async function registerServiceWorker() {
   if (typeof window === 'undefined' || !('serviceWorker' in navigator)) return null
 
   try {
-    const registration = await navigator.serviceWorker.register('/sw.js')
-    return registration
+    return await navigator.serviceWorker.register('/sw.js')
   } catch (err) {
     console.error('Service Worker registration failed:', err)
     return null
@@ -18,41 +44,115 @@ export async function registerServiceWorker() {
 }
 
 /**
- * Requests device push notification permission from the user and registers push endpoint.
+ * Whether this build has a VAPID public key at all.
+ *
+ * `NEXT_PUBLIC_VAPID_PUBLIC_KEY` is inlined at build time, so this is a
+ * compile-time fact rather than a runtime one — which is why it can be
+ * answered before the permission prompt is shown, and why asking a user for
+ * notification permission the server cannot honour is avoidable.
+ *
+ * @returns {boolean}
  */
-export async function requestNotificationPermission() {
-  if (typeof window === 'undefined' || !('Notification' in window)) return 'unsupported'
-
-  try {
-    const permission = await Notification.requestPermission()
-    if (permission === 'granted') {
-      const reg = await registerServiceWorker()
-      if (reg && reg.pushManager) {
-        try {
-          let sub = await reg.pushManager.getSubscription()
-          if (!sub) {
-            sub = await reg.pushManager.subscribe({
-              userVisibleOnly: true,
-              applicationServerKey: process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY || 'BEl62iUYgUivxIkv69yViEuiBIa40yYlK80pvwB8z7x0uE1jA4gR4Jz1fA5mK9_E5-6P_e_E5-6P_e_E5-6P_e'
-            })
-          }
-          if (sub) {
-            await savePushSubscription(JSON.parse(JSON.stringify(sub)))
-          }
-        } catch (e) {
-          console.error('PushManager subscription error:', e)
-        }
-      }
-    }
-    return permission
-  } catch (err) {
-    console.error('Error requesting notification permission:', err)
-    return 'denied'
-  }
+export function isPushConfigured() {
+  const key = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY
+  return typeof key === 'string' && key.trim().length > 0
 }
 
 /**
- * Gets current notification permission status.
+ * @typedef {object} PushResult
+ * @property {string} state       one of {@link PUSH_STATES}
+ * @property {string} permission  the raw browser permission, for the caller's own state
+ * @property {string} message     plain-language explanation
+ */
+
+/**
+ * @param {string} state
+ * @param {string} permission
+ * @returns {PushResult}
+ */
+function result(state, permission) {
+  return { state, permission, message: describePushState(state) }
+}
+
+/**
+ * Requests notification permission and registers the push endpoint.
+ *
+ * Ordering matters: the configuration check comes *before* the permission
+ * prompt. A user who is asked for permission and grants it has spent the one
+ * prompt a browser gives you — asking when the server cannot deliver anything
+ * burns it for nothing, and on most browsers a dismissed prompt cannot be
+ * shown again without the user going into settings.
+ *
+ * @returns {Promise<PushResult>}
+ */
+export async function requestNotificationPermission() {
+  if (typeof window === 'undefined' || !('Notification' in window)) {
+    return result(PUSH_STATES.UNSUPPORTED, 'unsupported')
+  }
+  if (!('serviceWorker' in navigator) || !('PushManager' in window)) {
+    return result(PUSH_STATES.UNSUPPORTED, Notification.permission)
+  }
+  if (!isPushConfigured()) {
+    return result(PUSH_STATES.NOT_CONFIGURED, Notification.permission)
+  }
+
+  let permission
+  try {
+    permission = await Notification.requestPermission()
+  } catch (err) {
+    console.error('Error requesting notification permission:', err)
+    return result(PUSH_STATES.DENIED, 'denied')
+  }
+
+  if (permission === 'denied') return result(PUSH_STATES.DENIED, permission)
+  // 'default' means the prompt was dismissed rather than refused — a distinct
+  // thing to tell the user, because it can be asked again.
+  if (permission !== 'granted') return result(PUSH_STATES.DISMISSED, permission)
+
+  const registration = await registerServiceWorker()
+  if (!registration || !registration.pushManager) {
+    return result(PUSH_STATES.SAVE_FAILED, permission)
+  }
+
+  let subscription
+  try {
+    subscription = await registration.pushManager.getSubscription()
+    if (!subscription) {
+      subscription = await registration.pushManager.subscribe({
+        userVisibleOnly: true,
+        applicationServerKey: process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY,
+      })
+    }
+  } catch (err) {
+    console.error('PushManager subscription error:', err)
+    return result(PUSH_STATES.SAVE_FAILED, permission)
+  }
+
+  if (!subscription) return result(PUSH_STATES.SAVE_FAILED, permission)
+
+  try {
+    // The round trip through JSON is what turns the native PushSubscription
+    // into the plain object a Server Action can accept.
+    const saved = await savePushSubscription(JSON.parse(JSON.stringify(subscription)))
+
+    if (!saved?.success) {
+      return result(
+        saved?.reason === 'not_configured' ? PUSH_STATES.NOT_CONFIGURED : PUSH_STATES.SAVE_FAILED,
+        permission
+      )
+    }
+  } catch (err) {
+    console.error('Failed to store push subscription:', err)
+    return result(PUSH_STATES.SAVE_FAILED, permission)
+  }
+
+  return result(PUSH_STATES.ENABLED, permission)
+}
+
+/**
+ * Current notification permission status.
+ *
+ * @returns {string} 'unsupported' | 'default' | 'granted' | 'denied'
  */
 export function getNotificationPermissionStatus() {
   if (typeof window === 'undefined' || !('Notification' in window)) return 'unsupported'
@@ -60,7 +160,13 @@ export function getNotificationPermissionStatus() {
 }
 
 /**
- * Triggers a native system device notification banner (Works on Desktop, Android & iOS PWA).
+ * Triggers a native system notification banner from the page.
+ *
+ * Worth being clear about what this is: a *local* notification, shown by this
+ * tab. It does not involve the push service, the server, or a subscription. It
+ * was previously used as the confirmation that push had been enabled, which it
+ * cannot demonstrate — it works identically on a device that will never
+ * receive a background notification.
  */
 export function sendDeviceNotification(title, body, url = '/') {
   if (typeof window === 'undefined' || !('Notification' in window)) return
@@ -70,9 +176,9 @@ export function sendDeviceNotification(title, body, url = '/') {
     if ('serviceWorker' in navigator) {
       navigator.serviceWorker.ready.then((registration) => {
         registration.showNotification(title, {
-          body: body,
-          icon: '/favicon.ico',
-          badge: '/favicon.ico',
+          body,
+          icon: '/icon-192.png',
+          badge: '/icon-192.png',
           vibrate: [200, 100, 200],
           tag: 'hercycle-alert',
           renotify: true,
@@ -80,10 +186,7 @@ export function sendDeviceNotification(title, body, url = '/') {
         })
       })
     } else {
-      new Notification(title, {
-        body: body,
-        icon: '/favicon.ico',
-      })
+      new Notification(title, { body, icon: '/icon-192.png' })
     }
   } catch (err) {
     console.error('Error triggering device notification:', err)

--- a/scripts/test-push-subscription.js
+++ b/scripts/test-push-subscription.js
@@ -1,0 +1,319 @@
+/**
+ * Regression suite for lib/push-subscription.js.
+ *
+ * The bug this is part of fixing: `lib/actions/push.js` wrote subscriptions
+ * with `onConflict: 'user_id'` against a table that has only a *plain* index
+ * on `user_id`, so PostgreSQL answered every save with 42P10 and background
+ * push has never worked. The failure was invisible at three consecutive
+ * layers — the action swallowed it, the caller discarded the return value, and
+ * the UI showed a success toast plus a local notification that proves nothing.
+ *
+ * The database half is fixed by supabase/02_push_subscription_endpoint.sql.
+ * This suite covers the half that was making the failure *silent*, because
+ * that is what let it survive: the placeholder keys nothing rejected, the
+ * "success" that was computed from `results.length` rather than from what was
+ * delivered, and the dead endpoints nothing ever removed.
+ *
+ *   node scripts/test-push-subscription.js
+ */
+
+import {
+  FAILURE_KINDS,
+  PLACEHOLDER_VAPID_PRIVATE_KEY,
+  PLACEHOLDER_VAPID_PUBLIC_KEY,
+  PUSH_STATES,
+  base64UrlByteLength,
+  classifySendFailure,
+  describePushState,
+  describeVapidConfig,
+  isPushEnabled,
+  normaliseEndpoint,
+  normaliseSubscription,
+  summariseSendResults,
+} from '../lib/push-subscription.js'
+
+let passed = 0
+let failed = 0
+
+function check(actual, expected, label) {
+  if (Object.is(actual, expected)) {
+    passed += 1
+    return
+  }
+  failed += 1
+  console.error(`  ❌ ${label}`)
+  console.error(`       expected: ${JSON.stringify(expected)}`)
+  console.error(`       actual:   ${JSON.stringify(actual)}`)
+}
+
+function checkDeep(actual, expected, label) {
+  const a = JSON.stringify(actual)
+  const b = JSON.stringify(expected)
+  if (a === b) {
+    passed += 1
+    return
+  }
+  failed += 1
+  console.error(`  ❌ ${label}`)
+  console.error(`       expected: ${b}`)
+  console.error(`       actual:   ${a}`)
+}
+
+function checkTruthy(value, label) {
+  check(Boolean(value), true, label)
+}
+
+function section(title) {
+  console.log(`\n${title}`)
+}
+
+/** A real-shaped subscription, of the kind Chrome hands back. */
+function validSubscription(overrides = {}) {
+  return {
+    endpoint: 'https://fcm.googleapis.com/fcm/send/dK3mQ:APA91bF-example-endpoint',
+    expirationTime: null,
+    keys: {
+      p256dh: 'BNcRdreALRFXTkOOUHK1EtK2wtaz5Ry4YfYCA_0QTpQtUbVlUls0VJXg7A8u-Ts1XbjhazAkj7I99e8QcYP7DkM',
+      auth: 'tBHItJI5svbpez7KI4CCXg',
+    },
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+
+section('base64url')
+
+check(base64UrlByteLength('AAAA'), 3, 'four characters decode to three bytes')
+check(base64UrlByteLength('AAAAAAAA'), 6, 'eight characters decode to six bytes')
+check(base64UrlByteLength('AAA'), 2, 'a three-character group decodes to two bytes')
+check(base64UrlByteLength('AA'), 1, 'a two-character group decodes to one byte')
+check(base64UrlByteLength('A'), -1, 'a one-character group is impossible')
+check(base64UrlByteLength('AAAA='), -1, 'padding is not base64url')
+check(base64UrlByteLength('AA+A'), -1, "'+' belongs to standard base64, not base64url")
+check(base64UrlByteLength('AA/A'), -1, "'/' belongs to standard base64, not base64url")
+check(base64UrlByteLength('AA-_'), 3, "'-' and '_' are the base64url alphabet")
+check(base64UrlByteLength(''), -1, 'an empty string decodes to nothing')
+check(base64UrlByteLength(null), -1, 'null is not a key')
+check(base64UrlByteLength('hello world'), -1, 'a space is not base64url')
+
+// ---------------------------------------------------------------------------
+
+section('VAPID configuration — the placeholders that shipped as defaults')
+
+const unset = describeVapidConfig({})
+check(unset.configured, false, 'no keys at all is not configured')
+check(unset.problems.length, 2, 'both missing keys are reported, not just the first')
+
+const placeholders = describeVapidConfig({
+  publicKey: PLACEHOLDER_VAPID_PUBLIC_KEY,
+  privateKey: PLACEHOLDER_VAPID_PRIVATE_KEY,
+})
+check(placeholders.configured, false, 'the shipped placeholder pair is not configured')
+checkTruthy(
+  placeholders.problems.some((p) => p.includes('web-push generate-vapid-keys')),
+  'the operator is told how to generate a real pair'
+)
+
+// Neither placeholder is a usable key, and neither was ever checked. The
+// public one reads like the example key from the web-push docs but is one byte
+// short of a P-256 point, so `subscribe()` in the browser was being handed
+// something that could never authenticate a send.
+check(
+  base64UrlByteLength(PLACEHOLDER_VAPID_PUBLIC_KEY),
+  64,
+  'the placeholder public key decodes to 64 bytes, one short of a P-256 point'
+)
+// The private placeholder is not even the right length.
+check(
+  base64UrlByteLength(PLACEHOLDER_VAPID_PRIVATE_KEY),
+  24,
+  'the placeholder private key decodes to 24 bytes, not 32'
+)
+
+// 65 bytes of public key, 32 bytes of private key.
+const REAL_PUBLIC = 'B'.repeat(87)
+const REAL_PRIVATE = 'C'.repeat(43)
+check(base64UrlByteLength(REAL_PUBLIC), 65, 'the stand-in public key is 65 bytes')
+check(base64UrlByteLength(REAL_PRIVATE), 32, 'the stand-in private key is 32 bytes')
+
+const good = describeVapidConfig({ publicKey: REAL_PUBLIC, privateKey: REAL_PRIVATE })
+check(good.configured, true, 'a correctly sized pair is accepted')
+check(good.problems.length, 0, 'a correctly sized pair reports no problems')
+
+check(
+  describeVapidConfig({ publicKey: 'B'.repeat(43), privateKey: REAL_PRIVATE }).configured,
+  false,
+  'a public key of the wrong length is rejected'
+)
+check(
+  describeVapidConfig({ publicKey: REAL_PUBLIC, privateKey: 'C'.repeat(87) }).configured,
+  false,
+  'a private key of the wrong length is rejected'
+)
+check(
+  describeVapidConfig({ publicKey: REAL_PUBLIC }).configured,
+  false,
+  'a public key without a private key is not configured'
+)
+
+// ---------------------------------------------------------------------------
+
+section('subscriptions')
+
+const normalised = normaliseSubscription(validSubscription())
+checkTruthy(normalised, 'a well-formed subscription is accepted')
+check(normalised.endpoint, validSubscription().endpoint, 'the endpoint is preserved')
+check(normalised.keys.auth, 'tBHItJI5svbpez7KI4CCXg', 'the auth key is preserved')
+
+// The old guard was `subscription && subscription.endpoint`. Everything below
+// passes that check and then fails at send time — once per notification,
+// forever, because nothing removed it.
+check(normaliseSubscription(validSubscription({ keys: undefined })), null, 'a subscription with no keys is rejected')
+check(normaliseSubscription(validSubscription({ keys: {} })), null, 'a subscription with empty keys is rejected')
+check(
+  normaliseSubscription(validSubscription({ keys: { p256dh: 'abc' } })),
+  null,
+  'a subscription missing the auth key is rejected'
+)
+check(
+  normaliseSubscription(validSubscription({ keys: { p256dh: '', auth: 'x' } })),
+  null,
+  'a blank p256dh is rejected'
+)
+check(normaliseSubscription(null), null, 'null is rejected')
+check(normaliseSubscription('a string'), null, 'a string is rejected')
+check(normaliseSubscription({}), null, 'an empty object is rejected')
+check(normaliseSubscription(validSubscription({ endpoint: '' })), null, 'a blank endpoint is rejected')
+
+checkDeep(
+  normaliseSubscription(validSubscription({ expirationTime: 12345 })).expirationTime,
+  null,
+  'a non-string expirationTime is normalised away rather than stored as-is'
+)
+
+section('endpoints')
+
+check(
+  normaliseEndpoint('  https://fcm.googleapis.com/fcm/send/abc  '),
+  'https://fcm.googleapis.com/fcm/send/abc',
+  'surrounding whitespace is trimmed'
+)
+check(normaliseEndpoint('http://example.com/push'), null, 'a plain-http endpoint is rejected')
+check(normaliseEndpoint('/relative/path'), null, 'a relative path is rejected')
+check(normaliseEndpoint('file:///etc/passwd'), null, 'a non-https scheme is rejected')
+check(normaliseEndpoint(''), null, 'an empty endpoint is rejected')
+check(normaliseEndpoint(null), null, 'null is rejected')
+check(
+  normaliseEndpoint('HTTPS://updates.push.services.mozilla.com/wpush/v2/abc'),
+  'HTTPS://updates.push.services.mozilla.com/wpush/v2/abc',
+  'the scheme check is case-insensitive'
+)
+
+// ---------------------------------------------------------------------------
+
+section('send failures — which ones mean "delete this device"')
+
+check(classifySendFailure({ statusCode: 404 }), FAILURE_KINDS.GONE, '404 is permanently gone')
+check(classifySendFailure({ statusCode: 410 }), FAILURE_KINDS.GONE, '410 Gone is permanently gone')
+check(classifySendFailure({ status: 410 }), FAILURE_KINDS.GONE, 'the status field is read under either name')
+
+check(classifySendFailure({ statusCode: 401 }), FAILURE_KINDS.MISCONFIGURED, '401 is our VAPID identity, not the device')
+check(classifySendFailure({ statusCode: 403 }), FAILURE_KINDS.MISCONFIGURED, '403 is our keys')
+check(classifySendFailure({ statusCode: 400 }), FAILURE_KINDS.MISCONFIGURED, '400 is our payload')
+check(classifySendFailure({ statusCode: 413 }), FAILURE_KINDS.MISCONFIGURED, '413 is our payload size')
+
+check(classifySendFailure({ statusCode: 429 }), FAILURE_KINDS.RETRYABLE, '429 is transient')
+check(classifySendFailure({ statusCode: 500 }), FAILURE_KINDS.RETRYABLE, '500 is transient')
+check(classifySendFailure({ statusCode: 503 }), FAILURE_KINDS.RETRYABLE, '503 is transient')
+check(classifySendFailure(new Error('socket hang up')), FAILURE_KINDS.RETRYABLE, 'a network error is transient')
+check(classifySendFailure(undefined), FAILURE_KINDS.RETRYABLE, 'an unknown failure is treated as transient')
+
+// A misconfigured send must never delete the subscription: the user would lose
+// her registration because an operator got the key pair wrong.
+checkTruthy(
+  classifySendFailure({ statusCode: 401 }) !== FAILURE_KINDS.GONE,
+  'an operator error never causes a device to be unregistered'
+)
+
+// ---------------------------------------------------------------------------
+
+section('summarising a batch — "success" must mean delivered')
+
+const allGood = summariseSendResults([
+  { endpoint: 'https://a', ok: true },
+  { endpoint: 'https://b', ok: true },
+])
+check(allGood.success, true, 'two deliveries is success')
+check(allGood.delivered, 2, 'both are counted')
+check(allGood.failed, 0, 'nothing failed')
+check(allGood.goneEndpoints.length, 0, 'nothing to prune')
+
+// This is the case the old code got wrong. It returned
+// `{ success: true, count: results.length }` without inspecting a single
+// result, so ten rejections were reported as ten successes.
+const allFailed = summariseSendResults([
+  { endpoint: 'https://a', ok: false, error: { statusCode: 500 } },
+  { endpoint: 'https://b', ok: false, error: { statusCode: 500 } },
+])
+check(allFailed.success, false, 'zero deliveries is not success, however many were attempted')
+check(allFailed.attempted, 2, 'the attempt count is still reported')
+check(allFailed.delivered, 0, 'nothing was delivered')
+check(allFailed.failed, 2, 'both failures are counted')
+
+const mixed = summariseSendResults([
+  { endpoint: 'https://phone', ok: true },
+  { endpoint: 'https://old-laptop', ok: false, error: { statusCode: 410 } },
+  { endpoint: 'https://tablet', ok: false, error: { statusCode: 503 } },
+])
+check(mixed.success, true, 'one delivery out of three is still a delivery')
+check(mixed.delivered, 1, 'the delivered count is exact')
+checkDeep(mixed.goneEndpoints, ['https://old-laptop'], 'only the 410 endpoint is marked for deletion')
+check(mixed.misconfigured, false, 'a transient failure is not an operator error')
+
+const misconfigured = summariseSendResults([
+  { endpoint: 'https://a', ok: false, error: { statusCode: 401 } },
+])
+check(misconfigured.misconfigured, true, 'a 401 flags the configuration')
+check(misconfigured.goneEndpoints.length, 0, 'a 401 does not delete the subscription')
+
+const empty = summariseSendResults([])
+check(empty.success, false, 'no subscriptions is not success')
+check(empty.attempted, 0, 'nothing was attempted')
+check(summariseSendResults(null).attempted, 0, 'a null batch is handled')
+check(summariseSendResults(undefined).success, false, 'an undefined batch is not success')
+
+// A row with no endpoint cannot be pruned by endpoint, and must not put
+// `undefined` into a delete filter.
+const noEndpoint = summariseSendResults([{ ok: false, error: { statusCode: 410 } }])
+check(noEndpoint.goneEndpoints.length, 0, 'a gone result with no endpoint is not queued for deletion')
+
+// ---------------------------------------------------------------------------
+
+section('UI states — only one of them may claim success')
+
+check(isPushEnabled(PUSH_STATES.ENABLED), true, 'ENABLED is a success')
+for (const state of Object.values(PUSH_STATES)) {
+  if (state === PUSH_STATES.ENABLED) continue
+  check(isPushEnabled(state), false, `${state} is not presented as success`)
+  checkTruthy(describePushState(state).length > 0, `${state} has a message for the user`)
+}
+
+checkTruthy(
+  describePushState(PUSH_STATES.NOT_CONFIGURED).includes('not set up'),
+  'an unconfigured server is described as such, not as a permission problem'
+)
+checkTruthy(
+  describePushState(PUSH_STATES.DENIED).includes('browser settings'),
+  'a blocked permission tells the user where to change it'
+)
+checkTruthy(
+  describePushState(PUSH_STATES.DISMISSED) !== describePushState(PUSH_STATES.DENIED),
+  'a dismissed prompt is not described as a blocked one — it can be asked again'
+)
+checkTruthy(describePushState('nonsense').length > 0, 'an unknown state still produces a message')
+
+// ---------------------------------------------------------------------------
+
+console.log(`\n${failed === 0 ? '✅' : '❌'} ${passed} passed, ${failed} failed`)
+process.exit(failed === 0 ? 0 : 1)

--- a/supabase/02_push_subscription_endpoint.sql
+++ b/supabase/02_push_subscription_endpoint.sql
@@ -1,0 +1,91 @@
+-- Migration: give user_push_subscriptions the unique key its writer already assumes
+--
+-- lib/actions/push.js has always written subscriptions with:
+--
+--     .upsert([{ user_id, subscription, updated_at }], { onConflict: 'user_id' })
+--
+-- but the table was created with only a plain index on user_id:
+--
+--     CREATE INDEX IF NOT EXISTS idx_push_sub_user ON public.user_push_subscriptions(user_id);
+--
+-- PostgreSQL answers ON CONFLICT against a non-unique column with
+--
+--     42P10: there is no unique or exclusion constraint matching the
+--            ON CONFLICT specification
+--
+-- so every save failed, the error was swallowed by the action, and the UI
+-- still showed a success toast. The table has therefore been empty this whole
+-- time and no server push has ever been delivered.
+--
+-- The key is (user_id, endpoint) rather than (user_id). A push subscription
+-- identifies one browser installation on one device, so keying on user_id
+-- alone would mean a user who enables notifications on her phone and then on
+-- her laptop silently loses the phone.
+--
+-- Safe to run more than once, and safe on a table that already has rows.
+
+BEGIN;
+
+-- 1. The endpoint, lifted out of the JSON so it can be indexed and compared.
+--    Nullable at first because existing rows have to be backfilled before the
+--    constraint can be added.
+ALTER TABLE public.user_push_subscriptions
+    ADD COLUMN IF NOT EXISTS endpoint TEXT;
+
+-- 2. Backfill from the stored subscription payload.
+UPDATE public.user_push_subscriptions
+   SET endpoint = subscription->>'endpoint'
+ WHERE endpoint IS NULL
+   AND subscription ? 'endpoint';
+
+-- 3. Drop anything that cannot be keyed. A row with no endpoint could never
+--    have been sent to — webpush.sendNotification requires one — so this
+--    removes rows that were already dead weight rather than losing anything a
+--    user would notice.
+DELETE FROM public.user_push_subscriptions
+ WHERE endpoint IS NULL
+    OR btrim(endpoint) = '';
+
+-- 4. Collapse duplicates, keeping the most recently updated row per
+--    (user_id, endpoint). Duplicates are possible because every previous write
+--    that reached the table at all did so as a plain insert.
+DELETE FROM public.user_push_subscriptions AS duplicate
+ USING public.user_push_subscriptions AS keeper
+ WHERE duplicate.user_id  = keeper.user_id
+   AND duplicate.endpoint = keeper.endpoint
+   AND (
+         duplicate.updated_at < keeper.updated_at
+         OR (duplicate.updated_at = keeper.updated_at AND duplicate.id < keeper.id)
+       );
+
+-- 5. Now the column can be required.
+ALTER TABLE public.user_push_subscriptions
+    ALTER COLUMN endpoint SET NOT NULL;
+
+-- 6. The constraint the application code has been referencing all along.
+--    Written as a DO block because ADD CONSTRAINT has no IF NOT EXISTS, and
+--    this migration has to stay re-runnable.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+          FROM pg_constraint
+         WHERE conname = 'user_push_subscriptions_user_endpoint_key'
+    ) THEN
+        ALTER TABLE public.user_push_subscriptions
+            ADD CONSTRAINT user_push_subscriptions_user_endpoint_key
+            UNIQUE (user_id, endpoint);
+    END IF;
+END
+$$;
+
+-- 7. Lookups by endpoint alone happen when a push service reports 404/410 and
+--    the sender prunes the dead subscription.
+CREATE INDEX IF NOT EXISTS idx_push_sub_endpoint
+    ON public.user_push_subscriptions(endpoint);
+
+-- The existing idx_push_sub_user is kept: (user_id, endpoint) can serve a
+-- user_id-only lookup as a prefix, but dropping an index in the same migration
+-- that adds a constraint makes a rollback harder than it needs to be.
+
+COMMIT;


### PR DESCRIPTION
## Linked Issue
Fixes #522

## Description

Background Web Push has **never worked** in this codebase. Not "works unreliably" — the subscription is never stored, because the upsert references a constraint that does not exist.

```js
// lib/actions/push.js
.upsert([{ user_id: userId, subscription, updated_at }], { onConflict: 'user_id' })
```

```sql
-- supabase/MASTER_PRODUCTION_MIGRATION.sql
CREATE INDEX IF NOT EXISTS idx_push_sub_user ON public.user_push_subscriptions(user_id);
```

A plain index. `grep -rn UNIQUE supabase/*.sql docs/database/*.sql | grep -i push` returns nothing. PostgreSQL answers `ON CONFLICT (user_id)` on a non-unique column with `42P10: there is no unique or exclusion constraint matching the ON CONFLICT specification`, so every save has failed and the table has been empty this whole time.

The failure was invisible at three consecutive layers:

1. `savePushSubscription` logged and returned `{ success: false }`
2. `lib/utils/notifications.js` discarded the return value
3. `NotificationSettings` showed *"Device push notifications enabled! 🔔"* plus a **local** notification — which proves nothing, because it never leaves the device

The user grants permission, sees a green toast and a real notification, closes the app, and never receives anything again.

### The rest of the module was the same shape

```js
const VAPID_PUBLIC_KEY  = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY || 'BEl62iUYgUivx…'
const VAPID_PRIVATE_KEY = process.env.VAPID_PRIVATE_KEY || '1A2B3C4D5E6F7G8H9I0J1K2L3M4N5O6P'

try { webpush.setVapidDetails(…) } catch (e) { /* Graceful fallback */ }
```

Neither default is usable — the public one decodes to 64 bytes rather than the 65 a P-256 point needs, and the private one to 24 rather than 32. `setVapidDetails` threw on them into a `catch` whose entire body is a comment calling it graceful. The same fake public key was the `applicationServerKey` default in `lib/utils/notifications.js`, so the browser-side `subscribe()` was built on it too.

```js
const results = await Promise.allSettled(subs.map(…))
return { success: true, count: results.length }
```

`results` is never inspected. Ten rejected sends return `{ success: true, count: 10 }`, and the one caller does `.catch(() => {})`. Nothing read a status code, so a 410 Gone endpoint stayed in the table and was retried on every notification forever.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (clean code updates, no behavior modifications)
- [ ] Documentation update
- [ ] Performance optimization
- [ ] Security patch

## Files Modified

| File | Change |
|------|--------|
| `supabase/02_push_subscription_endpoint.sql` | **new** — lift `endpoint` out of the JSON, backfill, dedupe, `UNIQUE (user_id, endpoint)` |
| `lib/push-subscription.js` | **new** — VAPID validation, subscription normalisation, failure classification, batch summarising. No network, no database |
| `lib/actions/push.js` | real config check, per-endpoint upsert, result inspection, pruning of gone endpoints, `removePushSubscription` |
| `lib/utils/notifications.js` | returns a state rather than a bare permission string; no placeholder key; checks configuration *before* spending the permission prompt |
| `components/layout/NotificationSettings.jsx` | only claims success once the subscription is stored; names the reason otherwise |
| `lib/actions/partner.js` | logs the delivery outcome instead of `.catch(() => {})` |
| `.env.example` | documents both VAPID keys |
| `scripts/test-push-subscription.js` | **new** — 91 assertions |

### Why `(user_id, endpoint)` and not `(user_id)`

A push subscription identifies one browser installation on one device. Keying on `user_id` alone — what `onConflict: 'user_id'` intended — means a user who enables notifications on her phone and then on her laptop silently loses the phone.

## Testing

```
$ node scripts/test-push-subscription.js
✅ 91 passed, 0 failed
```

Covers the parts that were making the failure silent: both placeholder keys are rejected (and the test records *why* each is invalid), a subscription with no `keys` is refused at the point it arrives rather than at every future send, 404/410 mean delete while 401/403/413 explicitly do **not** (an operator error must never unregister a user's device), and `success` is `delivered > 0` rather than `results.length > 0`.

### Manual verification

The migration must be applied first. Before it:

```sql
SELECT * FROM user_push_subscriptions;   -- 0 rows
```
server log: one `42P10` line per attempt.

After applying `supabase/02_push_subscription_endpoint.sql` and setting a real key pair from `npx web-push generate-vapid-keys`:

1. Enable notifications → row appears, keyed by endpoint.
2. Enable on a second device → a **second** row, not a replacement.
3. Close the tab, have a partner send a love note → notification arrives.
4. With no VAPID keys configured → the settings screen says background notifications are not set up on this server, instead of claiming they were enabled.

## Screenshots (if UI changes are made)
N/A — no visual change. The toast text is the same on success; the difference is that failures now produce a specific message instead of either silence or a false success.

## Checklist
- [x] This PR is submitted under ECSOC.
- [x] Added the required **ECSoc26** label to this Pull Request.
- [x] Linked issue using `Fixes #522`.
- [x] Tested locally.
- [x] No breaking changes introduced — the migration is idempotent and safe on a table with rows. Note it **must be applied** for saves to succeed; without it the failure is now logged with an explicit hint naming the migration file, rather than a bare Postgres code.
- [x] Documentation updated if required (`.env.example`).
