### PR TITLE
[ECSoC26] perf: skeleton loader in Insights

### DIFF
--- a/app/[locale]/insights/page.js
+++ b/app/[locale]/insights/page.js
@@ -49,7 +49,7 @@ function IconBadge({ children, size = 'lg' }) {
 }
 
 // ─── Stat Card ────────────────────────────────────────────────────────────────
-function StatCard({ icon, label, value, sub }) {
+function StatCard({ icon, label, value, sub, loading }) {
   return (
     <div className="insight-card interactive-card" style={{
       textAlign: 'center',
@@ -62,13 +62,17 @@ function StatCard({ icon, label, value, sub }) {
       <div style={{ marginBottom: '0.5rem' }}>
         <IconBadge size="lg">{icon}</IconBadge>
       </div>
-      <div style={{
-        fontSize: '2rem', fontWeight: 700,
-        background: `linear-gradient(135deg, ${PINK}, ${MAUVE})`,
-        WebkitBackgroundClip: 'text', WebkitTextFillColor: 'transparent',
-      }}>
-        {value}
-      </div>
+      {loading ? (
+        <div className="chart-skeleton-box" style={{ width: '60%', height: '2rem', margin: '4px auto 4px auto' }} />
+      ) : (
+        <div style={{
+          fontSize: '2rem', fontWeight: 700,
+          background: `linear-gradient(135deg, ${PINK}, ${MAUVE})`,
+          WebkitBackgroundClip: 'text', WebkitTextFillColor: 'transparent',
+        }}>
+          {value}
+        </div>
+      )}
       <div style={{ fontSize: '0.88rem', fontWeight: 600, color: TEXT_PRIMARY, marginTop: 4 }}>
         {label}
       </div>
@@ -367,29 +371,33 @@ export default function InsightsPage() {
               label={t('avgCycle')}
               value={`${avgCycle}d`}
               sub="days"
+              loading={loading}
             />
             <StatCard
               icon={<Calendar size={28} color={ACCENT} strokeWidth={1.5} />}
               label={recordedLabel}
-              value={loading ? '…' : recordedValue}
+              value={recordedValue}
               sub={recordedSub}
+              loading={loading}
             />
             <StatCard
               icon={<span style={{ fontSize: '1.75rem', lineHeight: 1 }}>🌸</span>}
               label={t('nextPeriod')}
-              value={loading ? '…' : nextDate}
+              value={nextDate}
               sub={t('predicted')}
+              loading={loading}
             />
             <StatCard
               icon={<span style={{ fontSize: '1.75rem', lineHeight: 1 }}>🩺</span>}
               label={t('pcodRisk')}
-              value={loading ? '…' : riskResult ? `${riskResult.score}/100` : '—'}
+              value={riskResult ? `${riskResult.score}/100` : '—'}
               sub={
                 riskTier === 'HIGH RISK' ? tRisk('high')
                   : riskTier === 'MEDIUM RISK' ? tRisk('med')
                     : riskTier === 'LOW RISK' ? tRisk('low')
                       : tRisk('unavailableBadge')
               }
+              loading={loading}
             />
           </div>
 
@@ -418,75 +426,90 @@ export default function InsightsPage() {
             icon={<TrendingUp size={18} color={ACCENT} strokeWidth={1.5} />}
             title={t('trendTitle')}
           >
-            {cycleLengthData.length < 1 ? (
-              <p style={{ color: TEXT_FAINT, textAlign: 'center', padding: '2rem 0' }}>
-                {t('trendEmpty')}
-              </p>
+            {loading ? (
+              <div style={{ width: '100%', height: 220, display: 'flex', flexDirection: 'column', gap: '1rem', justifyContent: 'center' }}>
+                <div className="chart-skeleton-box" style={{ width: '100%', height: 160, borderRadius: 12 }} />
+                <div style={{ display: 'flex', justifyContent: 'space-between', padding: '0 10px' }}>
+                  <div className="chart-skeleton-box" style={{ width: 40, height: 12 }} />
+                  <div className="chart-skeleton-box" style={{ width: 40, height: 12 }} />
+                  <div className="chart-skeleton-box" style={{ width: 40, height: 12 }} />
+                  <div className="chart-skeleton-box" style={{ width: 40, height: 12 }} />
+                  <div className="chart-skeleton-box" style={{ width: 40, height: 12 }} />
+                </div>
+              </div>
             ) : (
-              <ResponsiveContainer width="100%" height={220}>
-                <LineChart
-                  data={cycleLengthData}
-                  margin={{ top: 5, right: 20, left: -10, bottom: 5 }}
-                >
-                  <defs>
-                    <filter
-                      id="cycleGlow"
-                      x="-50%"
-                      y="-50%"
-                      width="200%"
-                      height="200%"
+              <div className="insights-fade-in">
+                {cycleLengthData.length < 1 ? (
+                  <p style={{ color: TEXT_FAINT, textAlign: 'center', padding: '2rem 0' }}>
+                    {t('trendEmpty')}
+                  </p>
+                ) : (
+                  <ResponsiveContainer width="100%" height={220}>
+                    <LineChart
+                      data={cycleLengthData}
+                      margin={{ top: 5, right: 20, left: -10, bottom: 5 }}
                     >
-                      <feGaussianBlur
-                        in="SourceGraphic"
-                        stdDeviation="4"
-                        result="blur"
+                      <defs>
+                        <filter
+                          id="cycleGlow"
+                          x="-50%"
+                          y="-50%"
+                          width="200%"
+                          height="200%"
+                        >
+                          <feGaussianBlur
+                            in="SourceGraphic"
+                            stdDeviation="4"
+                            result="blur"
+                          />
+                          <feMerge>
+                            <feMergeNode in="blur" />
+                            <feMergeNode in="SourceGraphic" />
+                          </feMerge>
+                        </filter>
+                      </defs>
+
+                      <CartesianGrid
+                        vertical={false}
+                        stroke="rgba(255,255,255,0.05)"
                       />
-                      <feMerge>
-                        <feMergeNode in="blur" />
-                        <feMergeNode in="SourceGraphic" />
-                      </feMerge>
-                    </filter>
-                  </defs>
 
-                  <CartesianGrid
-                    vertical={false}
-                    stroke="rgba(255,255,255,0.05)"
-                  />
+                      <XAxis
+                        dataKey="name"
+                        {...axisProps}
+                      />
 
-                  <XAxis
-                    dataKey="name"
-                    {...axisProps}
-                  />
+                      <YAxis
+                        domain={[20, 40]}
+                        {...axisProps}
+                      />
 
-                  <YAxis
-                    domain={[20, 40]}
-                    {...axisProps}
-                  />
+                      <Tooltip content={<CustomTooltip />} />
 
-                  <Tooltip content={<CustomTooltip />} />
-
-                  <Line
-                    type="monotone"
-                    dataKey="days"
-                    name="days"
-                    stroke={PINK}
-                    strokeWidth={2.5}
-                    filter="url(#cycleGlow)"
-                    dot={{
-                      fill: PINK,
-                      stroke: PINK,
-                      strokeWidth: 2,
-                      r: 5,
-                    }}
-                    activeDot={{
-                      r: 8,
-                      fill: MAUVE,
-                      stroke: PINK,
-                      strokeWidth: 3,
-                    }}
-                  />
-                </LineChart>
-              </ResponsiveContainer>
+                      <Line
+                        type="monotone"
+                        dataKey="days"
+                        name="days"
+                        stroke={PINK}
+                        strokeWidth={2.5}
+                        filter="url(#cycleGlow)"
+                        dot={{
+                          fill: PINK,
+                          stroke: PINK,
+                          strokeWidth: 2,
+                          r: 5,
+                        }}
+                        activeDot={{
+                          r: 8,
+                          fill: MAUVE,
+                          stroke: PINK,
+                          strokeWidth: 3,
+                        }}
+                      />
+                    </LineChart>
+                  </ResponsiveContainer>
+                )}
+              </div>
             )}
           </SectionCard>
 
@@ -497,24 +520,37 @@ export default function InsightsPage() {
             icon={<Activity size={18} color={ACCENT} strokeWidth={1.5} />}
             title={t('symptomTitle')}
           >
-            {totalLogs === 0 ? (
-              <p style={{ color: TEXT_FAINT, textAlign: 'center', padding: '2rem 0' }}>
-                {t('symptomEmpty')}
-              </p>
+            {loading ? (
+              <div style={{ width: '100%', height: 200, display: 'flex', alignItems: 'flex-end', justifyContent: 'space-around', padding: '10px 20px 20px 20px' }}>
+                <div className="chart-skeleton-box" style={{ width: '12%', height: '40%', borderRadius: '6px 6px 0 0' }} />
+                <div className="chart-skeleton-box" style={{ width: '12%', height: '75%', borderRadius: '6px 6px 0 0' }} />
+                <div className="chart-skeleton-box" style={{ width: '12%', height: '30%', borderRadius: '6px 6px 0 0' }} />
+                <div className="chart-skeleton-box" style={{ width: '12%', height: '60%', borderRadius: '6px 6px 0 0' }} />
+                <div className="chart-skeleton-box" style={{ width: '12%', height: '85%', borderRadius: '6px 6px 0 0' }} />
+                <div className="chart-skeleton-box" style={{ width: '12%', height: '50%', borderRadius: '6px 6px 0 0' }} />
+              </div>
             ) : (
-              <ResponsiveContainer width="100%" height={200}>
-                <BarChart data={symptomFreq} margin={{ top: 5, right: 20, left: -10, bottom: 5 }}>
-                  <CartesianGrid {...gridProps} />
-                  <XAxis dataKey="name" {...axisProps} />
-                  <YAxis allowDecimals={false} {...axisProps} />
-                  <Tooltip content={<CustomTooltip />} />
-                  <Bar dataKey="count" name="occurrences" radius={[6, 6, 0, 0]}>
-                    {symptomFreq.map((_, i) => (
-                      <Cell key={i} fill={i % 2 === 0 ? PINK : MAUVE} />
-                    ))}
-                  </Bar>
-                </BarChart>
-              </ResponsiveContainer>
+              <div className="insights-fade-in">
+                {totalLogs === 0 ? (
+                  <p style={{ color: TEXT_FAINT, textAlign: 'center', padding: '2rem 0' }}>
+                    {t('symptomEmpty')}
+                  </p>
+                ) : (
+                  <ResponsiveContainer width="100%" height={200}>
+                    <BarChart data={symptomFreq} margin={{ top: 5, right: 20, left: -10, bottom: 5 }}>
+                      <CartesianGrid {...gridProps} />
+                      <XAxis dataKey="name" {...axisProps} />
+                      <YAxis allowDecimals={false} {...axisProps} />
+                      <Tooltip content={<CustomTooltip />} />
+                      <Bar dataKey="count" name="occurrences" radius={[6, 6, 0, 0]}>
+                        {symptomFreq.map((_, i) => (
+                          <Cell key={i} fill={i % 2 === 0 ? PINK : MAUVE} />
+                        ))}
+                      </Bar>
+                    </BarChart>
+                  </ResponsiveContainer>
+                )}
+              </div>
             )}
           </SectionCard>
 
@@ -534,39 +570,59 @@ export default function InsightsPage() {
             icon={null}
             title={t('moodTitle')}
           >
-            {totalLogs === 0 ? (
-              <p style={{ color: TEXT_FAINT, textAlign: 'center', padding: '1rem 0' }}>
-                {t('moodEmpty')}
-              </p>
+            {loading ? (
+              <div className="mood-distribution-grid">
+                {[1, 2, 3, 4].map(i => (
+                  <div key={i} style={{
+                    textAlign: 'center', padding: '1rem 0.5rem',
+                    background: 'rgba(255,255,255,0.06)',
+                    borderRadius: 12,
+                    border: '1px solid rgba(255,255,255,0.1)',
+                    display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 6
+                  }}>
+                    <div className="chart-skeleton-box" style={{ width: 32, height: 32, borderRadius: '50%' }} />
+                    <div className="chart-skeleton-box" style={{ width: 48, height: 24 }} />
+                    <div className="chart-skeleton-box" style={{ width: 40, height: 12 }} />
+                  </div>
+                ))}
+              </div>
             ) : (
-              <>
-                <div className="mood-distribution-grid">
-                  {moodData.map(({ emoji, label, pct }) => (
-                    <div key={label} className="mood-summary-card interactive-card" style={{
-                      textAlign: 'center', padding: '1rem 0.5rem',
-                      background: 'rgba(255,255,255,0.06)',
-                      borderRadius: 12,
-                      border: '1px solid rgba(255,255,255,0.1)',
-                    }}>
-                      <div style={{ fontSize: '1.8rem' }}>{emoji}</div>
-                      <div style={{
-                        fontSize: '1.2rem', fontWeight: 700,
-                        background: `linear-gradient(135deg, ${PINK}, ${MAUVE})`,
-                        WebkitBackgroundClip: 'text', WebkitTextFillColor: 'transparent',
-                        marginTop: 4,
-                      }}>
-                        {pct}%
-                      </div>
-                      <div style={{ fontSize: '0.78rem', color: TEXT_PRIMARY, marginTop: 2 }}>
-                        {label}
-                      </div>
+              <div className="insights-fade-in">
+                {totalLogs === 0 ? (
+                  <p style={{ color: TEXT_FAINT, textAlign: 'center', padding: '1rem 0' }}>
+                    {t('moodEmpty')}
+                  </p>
+                ) : (
+                  <>
+                    <div className="mood-distribution-grid">
+                      {moodData.map(({ emoji, label, pct }) => (
+                        <div key={label} className="mood-summary-card interactive-card" style={{
+                          textAlign: 'center', padding: '1rem 0.5rem',
+                          background: 'rgba(255,255,255,0.06)',
+                          borderRadius: 12,
+                          border: '1px solid rgba(255,255,255,0.1)',
+                        }}>
+                          <div style={{ fontSize: '1.8rem' }}>{emoji}</div>
+                          <div style={{
+                            fontSize: '1.2rem', fontWeight: 700,
+                            background: `linear-gradient(135deg, ${PINK}, ${MAUVE})`,
+                            WebkitBackgroundClip: 'text', WebkitTextFillColor: 'transparent',
+                            marginTop: 4,
+                          }}>
+                            {pct}%
+                          </div>
+                          <div style={{ fontSize: '0.78rem', color: TEXT_PRIMARY, marginTop: 2 }}>
+                            {label}
+                          </div>
+                        </div>
+                      ))}
                     </div>
-                  ))}
-                </div>
-                <p style={{ fontSize: '0.72rem', color: TEXT_FAINT, marginTop: '0.75rem' }}>
-                  {t('moodBasedOn', { count: totalLogs, entryLabel: totalLogs === 1 ? t('entry') : t('entries') })}
-                </p>
-              </>
+                    <p style={{ fontSize: '0.72rem', color: TEXT_FAINT, marginTop: '0.75rem' }}>
+                      {t('moodBasedOn', { count: totalLogs, entryLabel: totalLogs === 1 ? t('entry') : t('entries') })}
+                    </p>
+                  </>
+                )}
+              </div>
             )}
           </SectionCard>
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -1126,6 +1126,32 @@ nav ul li a.active {
   }
 }
 
+/* ── Insights & Chart Skeleton Loaders & Fade In ── */
+.chart-skeleton-box {
+  border-radius: 8px;
+  background: linear-gradient(90deg,
+      rgba(255, 255, 255, 0.06) 0%,
+      rgba(255, 255, 255, 0.14) 40%,
+      rgba(255, 255, 255, 0.06) 80%);
+  background-size: 200% 100%;
+  animation: skeletonShimmer 1.5s ease-in-out infinite;
+}
+
+.insights-fade-in {
+  animation: chartFadeIn 0.4s ease-out forwards;
+}
+
+@keyframes chartFadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
 /* ── Risk card: factor dot color from CSS var ── */
 .risk-factors li::before {
   color: var(--dot-color, #6ee7b7);

--- a/components/dashboard/SymptomPhaseInsights.jsx
+++ b/components/dashboard/SymptomPhaseInsights.jsx
@@ -126,7 +126,17 @@ export default function SymptomPhaseInsights({
     return (
       <div className="insight-card" style={card}>
         {header}
-        <p style={{ color: TEXT_FAINT, textAlign: 'center', padding: '2rem 0' }}>{t('loading')}</p>
+        <div className="chart-skeleton-box" style={{ width: '50%', height: 14, marginBottom: '1.25rem' }} />
+        <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '1.25rem' }}>
+          <div className="chart-skeleton-box" style={{ width: 90, height: 24, borderRadius: 999 }} />
+          <div className="chart-skeleton-box" style={{ width: 90, height: 24, borderRadius: 999 }} />
+          <div className="chart-skeleton-box" style={{ width: 90, height: 24, borderRadius: 999 }} />
+          <div className="chart-skeleton-box" style={{ width: 90, height: 24, borderRadius: 999 }} />
+        </div>
+        <div style={{ display: 'grid', gap: '1rem' }}>
+          <div className="chart-skeleton-box" style={{ width: '100%', height: 75, borderRadius: 12 }} />
+          <div className="chart-skeleton-box" style={{ width: '100%', height: 75, borderRadius: 12 }} />
+        </div>
       </div>
     )
   }
@@ -135,7 +145,7 @@ export default function SymptomPhaseInsights({
   // showing an empty chart — a number the user can act on beats "no data".
   if (!analysis.hasEnoughData) {
     return (
-      <div className="insight-card" style={card}>
+      <div className="insight-card insights-fade-in" style={card}>
         {header}
         <p style={{ color: TEXT_FAINT, fontSize: '0.85rem', marginBottom: '1rem' }}>{t('subtitle')}</p>
         <div style={{
@@ -157,7 +167,7 @@ export default function SymptomPhaseInsights({
   }
 
   return (
-    <div className="insight-card" style={card}>
+    <div className="insight-card insights-fade-in" style={card}>
       {header}
       <p style={{ color: TEXT_FAINT, fontSize: '0.85rem', marginBottom: '1.25rem' }}>
         {t('subtitle')}

--- a/components/dashboard/WeightTrendChart.jsx
+++ b/components/dashboard/WeightTrendChart.jsx
@@ -119,71 +119,84 @@ export default function WeightTrendChart({ refreshKey = 0 }) {
       </div>
 
       {loading ? (
-        <p style={{ color: 'rgba(255,255,255,0.65)' }}>{t('loading')}</p>
-      ) : chartData.length === 0 ? (
-        <div style={{
-          minHeight: 180,
-          display: 'grid',
-          placeItems: 'center',
-          textAlign: 'center',
-          color: 'rgba(255,255,255,0.62)',
-        }}>
-          <div>
-            <Activity size={30} style={{ marginBottom: 8 }} />
-            <p style={{ margin: 0 }}>
-              {t('noMeasurements')}
-            </p>
+        <div style={{ width: '100%', height: 260, display: 'flex', flexDirection: 'column', gap: '1rem', justifyContent: 'center' }}>
+          <div className="chart-skeleton-box" style={{ width: '100%', height: 180, borderRadius: 12 }} />
+          <div style={{ display: 'flex', justifyContent: 'space-between', padding: '0 10px' }}>
+            <div className="chart-skeleton-box" style={{ width: 45, height: 12 }} />
+            <div className="chart-skeleton-box" style={{ width: 45, height: 12 }} />
+            <div className="chart-skeleton-box" style={{ width: 45, height: 12 }} />
+            <div className="chart-skeleton-box" style={{ width: 45, height: 12 }} />
+            <div className="chart-skeleton-box" style={{ width: 45, height: 12 }} />
           </div>
         </div>
       ) : (
-        <div style={{ width: '100%', height: 300 }}>
-          <ResponsiveContainer>
-            <LineChart data={chartData} margin={{ top: 8, right: 12, left: -8, bottom: 4 }}>
-              <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.1)" />
-              <XAxis
-                dataKey="label"
-                tick={{ fill: 'rgba(255,255,255,0.72)', fontSize: 12 }}
-              />
-              <YAxis
-                yAxisId="weight"
-                tick={{ fill: 'rgba(255,255,255,0.72)', fontSize: 12 }}
-                domain={['dataMin - 3', 'dataMax + 3']}
-              />
-              <YAxis
-                yAxisId="waist"
-                orientation="right"
-                tick={{ fill: 'rgba(255,255,255,0.72)', fontSize: 12 }}
-                domain={['dataMin - 5', 'dataMax + 5']}
-              />
-              <Tooltip
-                contentStyle={{
-                  background: 'rgba(30,12,40,0.96)',
-                  border: '1px solid rgba(232,82,126,0.5)',
-                  borderRadius: 10,
-                }}
-                labelStyle={{ color: '#fff' }}
-              />
-              <Legend />
-              <Line
-                yAxisId="weight"
-                type="monotone"
-                dataKey="weight"
-                name={t('weight')}
-                stroke="#e8527e"
-                strokeWidth={3}
-                activeDot={{ r: 6 }}
-              />
-              <Line
-                yAxisId="waist"
-                type="monotone"
-                dataKey="waist"
-                name={t('waist')}
-                stroke="#a98bff"
-                strokeWidth={2}
-                connectNulls
-              />
-            </LineChart>
-          </ResponsiveContainer>
+        <div className="insights-fade-in">
+          {chartData.length === 0 ? (
+            <div style={{
+              minHeight: 180,
+              display: 'grid',
+              placeItems: 'center',
+              textAlign: 'center',
+              color: 'rgba(255,255,255,0.62)',
+            }}>
+              <div>
+                <Activity size={30} style={{ marginBottom: 8 }} />
+                <p style={{ margin: 0 }}>
+                  {t('noMeasurements')}
+                </p>
+              </div>
+            </div>
+          ) : (
+            <div style={{ width: '100%', height: 300 }}>
+              <ResponsiveContainer>
+                <LineChart data={chartData} margin={{ top: 8, right: 12, left: -8, bottom: 4 }}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.1)" />
+                  <XAxis
+                    dataKey="label"
+                    tick={{ fill: 'rgba(255,255,255,0.72)', fontSize: 12 }}
+                  />
+                  <YAxis
+                    yAxisId="weight"
+                    tick={{ fill: 'rgba(255,255,255,0.72)', fontSize: 12 }}
+                    domain={['dataMin - 3', 'dataMax + 3']}
+                  />
+                  <YAxis
+                    yAxisId="waist"
+                    orientation="right"
+                    tick={{ fill: 'rgba(255,255,255,0.72)', fontSize: 12 }}
+                    domain={['dataMin - 5', 'dataMax + 5']}
+                  />
+                  <Tooltip
+                    contentStyle={{
+                      background: 'rgba(30,12,40,0.96)',
+                      border: '1px solid rgba(232,82,126,0.5)',
+                      borderRadius: 10,
+                    }}
+                    labelStyle={{ color: '#fff' }}
+                  />
+                  <Legend />
+                  <Line
+                    yAxisId="weight"
+                    type="monotone"
+                    dataKey="weight"
+                    name={t('weight')}
+                    stroke="#e8527e"
+                    strokeWidth={3}
+                    activeDot={{ r: 6 }}
+                  />
+                  <Line
+                    yAxisId="waist"
+                    type="monotone"
+                    dataKey="waist"
+                    name={t('waist')}
+                    stroke="#a98bff"
+                    strokeWidth={2}
+                    connectNulls
+                  />
+                </LineChart>
+              </ResponsiveContainer>
+            </div>
+          )}
         </div>
       )}
     </section>


### PR DESCRIPTION
Summary of Work
Skeleton Loaders Implemented:

Stat Cards: Render shimmering skeleton boxes for values while data fetches.
Cycle Length Trend Chart: Added line chart shimmer skeleton during loading state instead of rendering empty state text.
Weight Trend Chart: Updated 

WeightTrendChart.jsx
 to render visual chart skeleton during fetch.
Symptom Frequency Chart: Added bar chart height skeleton shimmer bars during loading.
Symptom Phase Insights: Updated 

SymptomPhaseInsights.jsx
 to render a structured skeleton layout with phase pills and list placeholders.
Mood Distribution: Render visual 4-card skeleton grid during loading.
Smooth Fade-In Transition:

Defined .insights-fade-in CSS animation in globals.css
.
Applied smooth fade-in wrappers across chart sections when switching from loading to loaded state.


closes #514