### PR TITLE
[ECSoC26] perf: chat history pruning

### DIFF
--- a/app/api/chat/route.js
+++ b/app/api/chat/route.js
@@ -7,45 +7,9 @@ import { logger } from '@/lib/logger'
 import { getSupabaseAdmin } from '@/lib/supabase-admin'
 import { z } from 'zod'
 
+import { pruneMessageHistory } from '@/lib/chat-utils';
+
 const TIMEOUT_MS = 8000; // 8 seconds timeout to prevent long hangs
-
-// Maximum number of conversation messages forwarded to the LLM. Sending a full
-// transcript costs tokens and risks context-length errors on long threads.
-const MAX_CONTEXT_MESSAGES = 15;
-
-const MAX_CONTEXT_CHARS = 12000; // Safe character limit for prompt optimization
-
-/**
- * Truncates a conversation history using a sliding window token estimator.
- * Keeps recent message payloads up to a safe character limit before calling AI models.
- *
- * @param {Array<{role: string, ...}>} messages
- * @param {number} [maxMessages=MAX_CONTEXT_MESSAGES]
- * @param {number} [maxChars=MAX_CONTEXT_CHARS]
- * @returns {Array<{role: string, ...}>}
- */
-function pruneMessageHistory(messages, maxMessages = MAX_CONTEXT_MESSAGES, maxChars = MAX_CONTEXT_CHARS) {
-  if (!Array.isArray(messages) || messages.length === 0) return messages;
-
-  const systemPrompt = messages[0];
-  let currentChars = JSON.stringify(systemPrompt).length;
-
-  const recentMessages = [];
-
-  // Iterate backwards to prioritize most recent conversation turns
-  for (let i = messages.length - 1; i > 0; i--) {
-    const msg = messages[i];
-    const msgChars = JSON.stringify(msg).length;
-
-    if (recentMessages.length >= maxMessages - 1) break;
-    if (currentChars + msgChars > maxChars) break;
-
-    recentMessages.unshift(msg);
-    currentChars += msgChars;
-  }
-
-  return [systemPrompt, ...recentMessages];
-}
 
 const chatPayloadSchema = z.object({
   language: z.string().max(10).optional(),

--- a/lib/chat-utils.js
+++ b/lib/chat-utils.js
@@ -1,0 +1,71 @@
+/**
+ * chat-utils.js — Utilities for LLM chat payload token estimation and sliding window pruning.
+ */
+
+export const MAX_CONTEXT_MESSAGES = 15
+export const MAX_CONTEXT_CHARS = 12000
+export const MAX_CONTEXT_TOKENS = 3000
+
+/**
+ * Estimates token count of a string or object (~4 characters per token).
+ * @param {any} payload
+ * @returns {number} estimated token count
+ */
+export function estimateTokens(payload) {
+  if (!payload) return 0
+  const text = typeof payload === 'string' ? payload : JSON.stringify(payload)
+  return Math.ceil(text.length / 4)
+}
+
+/**
+ * Truncates conversation history using a sliding window token estimator.
+ * Keeps system/header prompts and recent message turns within token, character,
+ * and message count limits before dispatching to AI models.
+ *
+ * @param {Array<{role: string, ...}>} messages
+ * @param {object} [options]
+ * @param {number} [options.maxMessages=MAX_CONTEXT_MESSAGES]
+ * @param {number} [options.maxChars=MAX_CONTEXT_CHARS]
+ * @param {number} [options.maxTokens=MAX_CONTEXT_TOKENS]
+ * @returns {Array<{role: string, ...}>}
+ */
+export function pruneMessageHistory(messages, options = {}) {
+  if (!Array.isArray(messages) || messages.length === 0) return messages || []
+
+  const maxMessages = options.maxMessages || MAX_CONTEXT_MESSAGES
+  const maxChars = options.maxChars || MAX_CONTEXT_CHARS
+  const maxTokens = options.maxTokens || MAX_CONTEXT_TOKENS
+
+  // Determine header message count (e.g. system prompt + initial model/assistant acknowledgment)
+  let headerCount = 1
+  if (
+    messages.length > 1 &&
+    (messages[1].role === 'model' || messages[1].role === 'assistant') &&
+    (messages[0].role === 'user' || messages[0].role === 'system')
+  ) {
+    headerCount = 2
+  }
+
+  const headerMessages = messages.slice(0, headerCount)
+  let currentChars = JSON.stringify(headerMessages).length
+  let currentTokens = estimateTokens(headerMessages)
+
+  const recentMessages = []
+
+  // Iterate backwards from the most recent conversation turn
+  for (let i = messages.length - 1; i >= headerCount; i--) {
+    const msg = messages[i]
+    const msgChars = JSON.stringify(msg).length
+    const msgTokens = estimateTokens(msg)
+
+    if (recentMessages.length + headerCount >= maxMessages) break
+    if (currentChars + msgChars > maxChars) break
+    if (currentTokens + msgTokens > maxTokens) break
+
+    recentMessages.unshift(msg)
+    currentChars += msgChars
+    currentTokens += msgTokens
+  }
+
+  return [...headerMessages, ...recentMessages]
+}

--- a/scripts/test-chat-pruning.js
+++ b/scripts/test-chat-pruning.js
@@ -1,0 +1,81 @@
+import assert from 'assert'
+import {
+  MAX_CONTEXT_CHARS,
+  MAX_CONTEXT_MESSAGES,
+  MAX_CONTEXT_TOKENS,
+  estimateTokens,
+  pruneMessageHistory,
+} from '../lib/chat-utils.js'
+
+async function runTests() {
+  console.log('Running Chat History Pruning & Token Optimization Tests...\n')
+
+  // 1. Token estimator tests (~4 chars per token)
+  const sampleText = 'Hello, how can I help you today?' // 32 chars => ~8 tokens
+  const estimated = estimateTokens(sampleText)
+  assert.strictEqual(estimated, 8, 'Text token estimation should be ceil(32 / 4) = 8')
+
+  const objectPayload = { role: 'user', content: 'What is ovulation?' }
+  const objTokens = estimateTokens(objectPayload)
+  assert(objTokens > 0, 'Object payload token estimation should be greater than 0')
+
+  // 2. Sliding window pruning tests - Message Count Limit (15 max)
+  const systemHeader = [{ role: 'system', content: 'You are a helpful assistant.' }]
+  const longTurnHistory = Array.from({ length: 30 }, (_, i) => ({
+    role: i % 2 === 0 ? 'user' : 'assistant',
+    content: `Turn message index ${i} with sample content.`,
+  }))
+
+  const prunedByCount = pruneMessageHistory([...systemHeader, ...longTurnHistory])
+  assert(
+    prunedByCount.length <= MAX_CONTEXT_MESSAGES,
+    `Pruned messages length (${prunedByCount.length}) should not exceed MAX_CONTEXT_MESSAGES (${MAX_CONTEXT_MESSAGES})`
+  )
+  assert.strictEqual(
+    prunedByCount[0].content,
+    systemHeader[0].content,
+    'System header prompt must be preserved at index 0'
+  )
+  assert.strictEqual(
+    prunedByCount[prunedByCount.length - 1].content,
+    longTurnHistory[longTurnHistory.length - 1].content,
+    'Most recent conversation turn must be preserved'
+  )
+
+  // 3. Sliding window pruning tests - Token / Character Limit
+  const largeTurnHistory = Array.from({ length: 10 }, (_, i) => ({
+    role: i % 2 === 0 ? 'user' : 'assistant',
+    content: 'X'.repeat(2500), // Large payload per message
+  }))
+
+  const prunedByTokenLimit = pruneMessageHistory([...systemHeader, ...largeTurnHistory], {
+    maxTokens: 1000,
+    maxChars: 4000,
+    maxMessages: 15,
+  })
+
+  const totalChars = JSON.stringify(prunedByTokenLimit).length
+  const totalTokens = estimateTokens(prunedByTokenLimit)
+
+  assert(totalChars <= 4000, `Total characters (${totalChars}) should be <= maxChars limit (4000)`)
+  assert(totalTokens <= 1000, `Total tokens (${totalTokens}) should be <= maxTokens limit (1000)`)
+  assert.strictEqual(
+    prunedByTokenLimit[0].content,
+    systemHeader[0].content,
+    'Header prompt preserved despite token limit'
+  )
+
+  // 4. Edge cases: empty history or single item
+  const emptyResult = pruneMessageHistory([])
+  assert.deepStrictEqual(emptyResult, [], 'Empty message list returns empty array')
+
+  const singleResult = pruneMessageHistory(systemHeader)
+  assert.deepStrictEqual(singleResult, systemHeader, 'Single message list returns identical array')
+
+  console.log('✅ All chat history pruning and token optimization tests passed successfully!')
+}
+
+runTests().catch(err => {
+  console.error('❌ Test failed:', err)
+  process.exit(1)
+})


### PR DESCRIPTION
Summary of Work
Token Estimation & Sliding Window Pruning:

Created 

lib/chat-utils.js
 containing estimateTokens (~4 chars/token) and pruneMessageHistory.
pruneMessageHistory preserves system instructions and acknowledgment headers while executing a backward sliding window over history turns.
Enforces configurable context limits: maxMessages = 15, maxChars = 12000, and maxTokens = 3000.
Integration into Chat Endpoint:

Updated 

app/api/chat/route.js
 to prune chat histories before calling Gemini and Groq AI providers.
Verification:

Unit Tests: node scripts/test-chat-pruning.js passed 100%.
Production Build: npm run build completed successfully.
E2E Tests: npm run test:e2e passed 7/7 test suites (100% success rate).


closes #516