### PR TITLE
[ECSoC26] fix(i18n): translate hardcoded Notification label in profile dropdown

### DIFF
--- a/components/layout/Navbar.jsx
+++ b/components/layout/Navbar.jsx
@@ -314,7 +314,7 @@ export default function Navbar() {
               />
             )}
             <UserButton.Action
-              label="Notification"
+              label={t('notification')}
               labelIcon={<BellIcon className="w-4 h-4 text-rose-400" />}
               open="notifications"
             />

--- a/e2e/suite3_self_care.test.mjs
+++ b/e2e/suite3_self_care.test.mjs
@@ -14,7 +14,7 @@ describe('Suite 3: Self-Care & Personalized Recommendations Flow', () => {
     const { exercises } = await import('../lib/selfCareData.js');
     for (const ex of exercises) {
       assert(typeof ex.id === 'string', `exercise id should be string: ${ex.id}`);
-      assert(typeof ex.title === 'string', `exercise title should be string: ${ex.title}`);
+      assert(typeof ex.title === 'string', `exercise title should be string: ${ex.id}`);
       assert(typeof ex.durationMin === 'number', `exercise durationMin should be number: ${ex.id}`);
       assert(Array.isArray(ex.poses), `exercise poses should be array: ${ex.id}`);
     }
@@ -25,7 +25,8 @@ describe('Suite 3: Self-Care & Personalized Recommendations Flow', () => {
     const phase = calculateCyclePhase({
       periodStart: '2026-07-15',
       cycleLength: 28,
-      periodLength: 5
+      periodLength: 5,
+      today: new Date('2026-07-20') // fixed reference date so the test doesn't drift as real time passes
     });
     assert(phase.hasData, 'calculateCyclePhase should have data for valid start date');
     assert(['menstrual', 'follicular', 'ovulation', 'luteal'].includes(phase.phaseKey), `Invalid phaseKey: ${phase.phaseKey}`);

--- a/messages/en.json
+++ b/messages/en.json
@@ -12,6 +12,12 @@
     "syncing": "Syncing",
     "logToday": "Log Today",
     "signOut": "Sign Out",
+    "notification": "Notification",
+    "language": "Language",
+    "partnerSharing": "Partner Sharing",
+    "dataPrivacy": "Data & Privacy",
+    "healthProfile": "Health Profile",
+    "helpSupport": "Help & Support",
     "syncFailed": "Not saved"
   },
   "SyncFailures": {

--- a/messages/hi.json
+++ b/messages/hi.json
@@ -12,6 +12,12 @@
     "syncing": "सिंक हो रहा है",
     "logToday": "आज लॉग करें",
     "signOut": "साइन आउट",
+    "notification": "सूचना",
+    "language": "भाषा",
+    "partnerSharing": "साथी साझाकरण",
+    "dataPrivacy": "डेटा और गोपनीयता",
+    "healthProfile": "स्वास्थ्य प्रोफाइल",
+    "helpSupport": "सहायता और समर्थन",
     "syncFailed": "सहेजा नहीं गया"
   },
   "SyncFailures": {


### PR DESCRIPTION
## Linked Issue
Fixes #273 

## Description
The "Notification" menu item label inside the profile dropdown was hardcoded in English (`label="Notification"` in Navbar.jsx), so it never respected the app's language toggle. This PR replaces it with the `t('notification')` translation function and adds the missing translation key to both `messages/en.json` and `messages/hi.json`. A few other related keys (`language`, `partnerSharing`, `dataPrivacy`, `healthProfile`, `helpSupport`) that were also missing from the translation files were added at the same time.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
Ran `npm run dev` locally and opened the profile dropdown menu. Verified the "Notification" label displays correctly in English, then switched the app language to Hindi and confirmed the label now shows the correct Hindi translation instead of falling back to English.

## Screenshots
*(add before/after screenshots of the dropdown in English and Hindi here)*

## Checklist
- [x] This PR is submitted under ECSOC.
- [ ] Added the required **ECSoc26** label to this Pull Request.
- [x] Linked issue using `Fixes #<issue_number>`.
- [x] Tested locally.
- [ ] `npm run build` completes successfully.
- [ ] GitHub Actions checks pass.
- [x] No breaking changes introduced.
- [ ] Documentation updated if required.

## Additional fix (found while getting CI green)
The Suite 3 E2E test used a hardcoded `periodStart` date ('2026-07-15') with no fixed `today` reference, so `calculateCyclePhase` defaulted to the real current date. Once real time passed the 28-day cycle window from that hardcoded start date, `cycleDay` exceeded `cycleLength` and the phase calculation fell through to `'irregular'`, which the test didn't expect, causing a "time bomb" failure unrelated to any actual bug in the app logic. Fixed by passing a fixed `today` value in the test so it stays deterministic.