### PR TITLE
[ECSoC26] fix: guard symptoms and cycleHistory with Array.isArray (#164)

### DIFF
--- a/lib/api-helpers.js
+++ b/lib/api-helpers.js
@@ -318,11 +318,16 @@ function detectConsecutiveRecurrence(entries, highRiskSymptoms) {
 
 // Helper function to calculate PCOD risk (mock ML model)
 function calculatePCODRiskFallback(cycleHistory, symptoms) {
-  if (!cycleHistory || cycleHistory.length === 0) {
+  // Coerce to arrays so a truthy non-array value (string, object) never
+  // reaches .length or .filter() and causes a runtime TypeError.
+  const cycles = Array.isArray(cycleHistory) ? cycleHistory : []
+  const symptomList = Array.isArray(symptoms) ? symptoms : []
+
+  if (cycles.length === 0) {
     return { score: 0, tier: 'LOW RISK', factors: [] }
   }
 
-  const deduped = dedupeCycles(cycleHistory)
+  const deduped = dedupeCycles(cycles)
 
   let riskScore = 0
   let riskFactors = []
@@ -353,12 +358,12 @@ function calculatePCODRiskFallback(cycleHistory, symptoms) {
   }
 
   // Factor 2: Symptoms analysis & recurrence mapping over 90-day window
-  if (symptoms && Array.isArray(symptoms) && symptoms.length > 0) {
+  if (symptomList.length > 0) {
     const highRiskSymptoms = ['acne', 'fatigue', 'bloating', 'headache', 'hirsutism', 'weight gain', 'hair loss', 'irregular periods']
 
     // Normalize symptom entries with optional dates
     const entries = []
-    for (const item of symptoms) {
+    for (const item of symptomList) {
       if (!item) continue
       if (typeof item === 'string') {
         entries.push({ name: item.trim().toLowerCase(), date: null })
@@ -536,9 +541,14 @@ export async function predictNextPeriod(cycleHistory, today = new Date(), option
  * @returns {Promise<object>} the same shape as {@link calculatePCODRiskFallback}
  */
 export async function calculatePCODRisk(cycleHistory, symptoms, options = {}) {
+  // Normalise both args to arrays before any processing — a truthy non-array
+  // value (e.g. a string or plain object) must not reach .filter() / .length.
+  const safeHistory = Array.isArray(cycleHistory) ? cycleHistory : []
+  const safeSymptoms = Array.isArray(symptoms) ? symptoms : []
+
   const result = await callMlService(
     '/pcod-risk',
-    { cycle_history: cycleHistory || [], symptoms: symptoms || [] },
+    { cycle_history: safeHistory, symptoms: safeSymptoms },
     { ...options, parse: parseMlRisk }
   )
 
@@ -550,5 +560,5 @@ export async function calculatePCODRisk(cycleHistory, symptoms, options = {}) {
     )
   }
 
-  return calculatePCODRiskFallback(cycleHistory, symptoms)
+  return calculatePCODRiskFallback(safeHistory, safeSymptoms)
 }


### PR DESCRIPTION
## What
Fixes a runtime TypeError in `calculatePCODRisk()` when `symptoms` or 
`cycleHistory` is a truthy non-array value (e.g. a string or plain object).

## Why
The previous `symptoms || []` fallback only handles `null`/`undefined` — 
a truthy non-array like `"acne"` passes through unchanged and crashes at 
`.filter()` / `.length`.

## Changes
- `calculatePCODRisk()`: normalise both args with `Array.isArray()` before 
  passing to `callMlService` and the fallback
- `calculatePCODRiskFallback()`: coerce `cycleHistory` and `symptoms` to 
  arrays at the top of the function

## Testing
All 48 assertions in `scripts/test-pcod-risk-result.js` pass:
