### PR TITLE
[ECSoC26] fix: Add ARIA labels to Insights page charts for screen reader accessibility

### DIFF
--- a/app/[locale]/insights/page.js
+++ b/app/[locale]/insights/page.js
@@ -496,11 +496,15 @@ export default function InsightsPage() {
                     {t('trendEmpty')}
                   </p>
                 ) : (
-                  <ResponsiveContainer width="100%" height={220}>
-                    <LineChart
-                      data={cycleLengthData}
-                      margin={{ top: 5, right: 20, left: -10, bottom: 5 }}
-                    >
+                  <div
+                    role="img"
+                    aria-label={`Line chart showing cycle length trend across your last ${cycleLengthData.length} tracked cycles, averaging ${avgCycle} days`}
+                  >
+                    <ResponsiveContainer width="100%" height={220} aria-hidden="true">
+                      <LineChart
+                        data={cycleLengthData}
+                        margin={{ top: 5, right: 20, left: -10, bottom: 5 }}
+                      >
                       <defs>
                         <filter
                           id="cycleGlow"
@@ -559,7 +563,8 @@ export default function InsightsPage() {
                         }}
                       />
                     </LineChart>
-                  </ResponsiveContainer>
+                    </ResponsiveContainer>
+                  </div>
                 )}
               </div>
             )}
@@ -588,8 +593,12 @@ export default function InsightsPage() {
                     {t('symptomEmpty')}
                   </p>
                 ) : (
-                  <ResponsiveContainer width="100%" height={200}>
-                    <BarChart data={symptomFreq} margin={{ top: 5, right: 20, left: -10, bottom: 5 }}>
+                <div
+                    role="img"
+                    aria-label={`Bar chart showing frequency of logged symptoms across ${totalLogs} entries`}
+                  >
+                    <ResponsiveContainer width="100%" height={200} aria-hidden="true">
+                      <BarChart data={symptomFreq} margin={{ top: 5, right: 20, left: -10, bottom: 5 }}>
                       <CartesianGrid {...gridProps} />
                       <XAxis dataKey="name" {...axisProps} />
                       <YAxis allowDecimals={false} {...axisProps} />
@@ -600,7 +609,8 @@ export default function InsightsPage() {
                         ))}
                       </Bar>
                     </BarChart>
-                  </ResponsiveContainer>
+                    </ResponsiveContainer>
+                  </div>
                 )}
               </div>
             )}


### PR DESCRIPTION
Fixes #251

Description
The Cycle Length Trend and Symptom Frequency charts on the Insights page 
had no ARIA labels, so screen readers couldn't announce what they showed. 
Added role="img" and a descriptive aria-label to both chart containers, 
and aria-hidden="true" on the chart internals so screen readers announce 
one clear description instead of reading out every individual bar/dot.

Type of Change
- Bug fix (non-breaking change which fixes an issue)

Testing
Ran npm run build — compiled successfully with no errors. Verified in 
Chrome DevTools' Accessibility panel that both charts show Role: image 
and the correct label text. Charts still render visually identical to 
before.