### PR TITLE
[ECSoC26] [DB] Enforce database constraint checks for cycle start_date and cycle_length bounds

### DIFF
--- a/app/api/cycles/route.js
+++ b/app/api/cycles/route.js
@@ -44,6 +44,23 @@ const cyclePatchSchema = z
     { message: 'end_date must be on or after start_date', path: ['end_date'] }
   );
 
+  /**
+ * Maps a Postgres CHECK constraint violation (code 23514) to a clean,
+ * user-facing message. Falls back to the raw error for anything else.
+ */
+function toCleanCycleError(error) {
+  if (error?.code === '23514') {
+    if (error.message?.includes('check_end_date_after_start')) {
+      return { message: 'End date cannot be before the start date.', status: 400 }
+    }
+    if (error.message?.includes('check_cycle_length_bounds')) {
+      return { message: 'Cycle length must be between 10 and 120 days.', status: 400 }
+    }
+    return { message: 'Invalid cycle data submitted.', status: 400 }
+  }
+  return { message: error?.message || 'Unknown database error', status: 500 }
+}
+
 export async function GET(request) {
   // ============ RATE LIMITING ============
   try {
@@ -145,8 +162,9 @@ export async function POST(request) {
     const { error } = await supabaseAdmin.from('cycles').insert([insertObj])
 
     if (error) {
+      const clean = toCleanCycleError(error)
       logger.error(`Database error inserting cycle for user ${userId}:`, error.message);
-      return NextResponse.json({ success: false, error: error.message }, { status: 500 })
+      return NextResponse.json({ success: false, error: clean.message }, { status: clean.status })
     }
 
     logger.info(`Successfully added new period cycle for user ${userId}`);
@@ -216,11 +234,11 @@ export async function PATCH(request) {
       .eq('id', id)
       .eq('user_id', userId)
 
-    if (error) {
+   if (error) {
+      const clean = toCleanCycleError(error)
       logger.error(`Database error updating cycle ${id} for user ${userId}:`, error.message);
-      return NextResponse.json({ success: false, error: error.message }, { status: 500 })
+      return NextResponse.json({ success: false, error: clean.message }, { status: clean.status })
     }
-
     logger.info(`Successfully updated period cycle ${id} for user ${userId}`);
     
     // Automatic LRU cache invalidation for PCOD risk score

--- a/docs/database/COMPLETE_SETUP.sql
+++ b/docs/database/COMPLETE_SETUP.sql
@@ -12,12 +12,20 @@ CREATE TABLE IF NOT EXISTS public.users (
 );
 
 -- 3. Create public.cycles table (Period cycles tracker)
+-- CREATE TABLE IF NOT EXISTS public.cycles (
+--   id              UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+--   user_id         TEXT NOT NULL,
+--   start_date      DATE NOT NULL,
+--   end_date        DATE,
+-- --   cycle_length    INTEGER DEFAULT 28,
+--   created_at      TIMESTAMPTZ DEFAULT now()
+-- );
 CREATE TABLE IF NOT EXISTS public.cycles (
   id              UUID DEFAULT gen_random_uuid() PRIMARY KEY,
   user_id         TEXT NOT NULL,
   start_date      DATE NOT NULL,
-  end_date        DATE,
-  cycle_length    INTEGER DEFAULT 28,
+  end_date        DATE CHECK (end_date IS NULL OR end_date >= start_date),
+  cycle_length    INTEGER DEFAULT 28 CHECK (cycle_length IS NULL OR (cycle_length >= 10 AND cycle_length <= 120)),
   created_at      TIMESTAMPTZ DEFAULT now()
 );
 

--- a/supabase/03_cycle_date_constraints.sql
+++ b/supabase/03_cycle_date_constraints.sql
@@ -1,0 +1,7 @@
+ALTER TABLE public.cycles
+  ADD CONSTRAINT check_end_date_after_start
+  CHECK (end_date IS NULL OR end_date >= start_date);
+
+ALTER TABLE public.cycles
+  ADD CONSTRAINT check_cycle_length_bounds
+  CHECK (cycle_length IS NULL OR (cycle_length >= 10 AND cycle_length <= 120));


### PR DESCRIPTION
Fixes #599 


Description
Added SQL CHECK constraints directly on the cycles table so invalid data 
is rejected at the database level, not just in application code:
- end_date must be NULL or on/after start_date
- cycle_length must be NULL or between 10-120 days

NULL is intentionally allowed for both, since a user's most recent cycle 
is often still ongoing (end_date and cycle_length aren't known yet).

Also updated app/api/cycles/route.js so that if either constraint is ever 
violated, the API returns a clean 400 error with a readable message 
instead of leaking the raw Postgres error to the client.

One existing row in the live database already violated the new date 
constraint (end_date recorded before start_date — clearly bad/corrupted 
data). Its end_date was set to NULL before applying the constraint, since 
NULL is already a valid state in this schema.

Note: the app's existing Zod validation already rejects most bad cycle 
input before it reaches the database, so these constraints mainly act as 
a safety net for anything that bypasses that layer (direct API calls, 
future code changes, etc.), rather than the primary line of defense.

Type of Change
- Bug fix (non-breaking change which fixes an issue)

Testing
Ran npm run build — compiled successfully with no errors. Ran 
npm run test:e2e — all 7 suites passing. Confirmed both constraints are 
live on the database via a pg_constraint query. Manually verified in 
Supabase's SQL Editor that inserting a row with end_date before 
start_date, and a row with cycle_length outside 10-120, are both 
correctly rejected.

Files changed
- supabase/03_cycle_date_constraints.sql (new migration)
- docs/database/COMPLETE_SETUP.sql (inline constraints for fresh setups)
- app/api/cycles/route.js (clean error handling)

