### PR TITLE
[ECSoC26] Feat/skeleton loading cards

### DIFF
--- a/app/[locale]/page.js
+++ b/app/[locale]/page.js
@@ -13,6 +13,7 @@ import Navbar from '@/components/layout/Navbar'
 import Footer from '@/components/layout/Footer'
 import HeroSection from '@/components/dashboard/HeroSection'
 import CycleCalendar from '@/components/dashboard/CycleCalendar'
+import CycleCalendarSkeleton from '@/components/dashboard/CycleCalendarSkeleton'
 import DayLogDrawer from '@/components/dashboard/DayLogDrawer'
 import PartnerLoveBanner from '@/components/dashboard/PartnerLoveBanner'
 import VibeCheckin from '@/components/dashboard/VibeCheckin'
@@ -496,17 +497,21 @@ const HerCycleApp = () => {
 
         <div className="hero">
           <HeroSection activeLang={activeLang} cycleDayInfo={cycleDayInfo} />
-          <CycleCalendar
-            calendarDays={calendarDays}
-            currentMonth={`${new Intl.DateTimeFormat(locale === 'hi' ? 'hi-IN' : 'en-US', { month: 'long' }).format(new Date(viewYear, viewMonth))} ${viewYear}`}
-            onPrevMonth={goToPrevMonth}
-            onNextMonth={goToNextMonth}
-            averageCycleLength={cycleData?.averageCycleLength || 28}
-            daysUntilNext={daysUntilNext}
-            activeLang={activeLang}
-            onDayClick={handleDayClick}
-            selectedDate={selectedDate}
-          />
+          {dataLoaded ? (
+            <CycleCalendar
+              calendarDays={calendarDays}
+              currentMonth={`${new Intl.DateTimeFormat(locale === 'hi' ? 'hi-IN' : 'en-US', { month: 'long' }).format(new Date(viewYear, viewMonth))} ${viewYear}`}
+              onPrevMonth={goToPrevMonth}
+              onNextMonth={goToNextMonth}
+              averageCycleLength={cycleData?.averageCycleLength || 28}
+              daysUntilNext={daysUntilNext}
+              activeLang={activeLang}
+              onDayClick={handleDayClick}
+              selectedDate={selectedDate}
+            />
+          ) : (
+            <CycleCalendarSkeleton />
+          )}
         </div>
 
         <DayLogDrawer

--- a/components/dashboard/CycleCalendarSkeleton.jsx
+++ b/components/dashboard/CycleCalendarSkeleton.jsx
@@ -1,0 +1,55 @@
+/**
+ * CycleCalendarSkeleton — pulse placeholder shown while `dataLoaded` is false.
+ *
+ * Reuses the exact same classes as CycleCalendar (`cycle-card`, `mini-cal`,
+ * `cal-d`, `cal-legend`, `stat-row`, `stat-tile`) so the skeleton takes up
+ * pixel-identical space to the real card. Swapping one for the other causes
+ * zero layout shift. The shimmer treatment reuses `.risk-skeleton-row`,
+ * already defined in globals.css for PCODRiskCard's skeleton.
+ */
+export default function CycleCalendarSkeleton() {
+    const headers = ['S', 'M', 'T', 'W', 'T', 'F', 'S']
+    const cells = Array.from({ length: 35 }) // 5 header-less rows, matches a typical month grid
+
+    return (
+        <div className="cycle-card glass" aria-hidden="true">
+            <div className="cycle-card-header">
+                <div className="risk-skeleton-row" style={{ width: 140, height: '1.25rem', borderRadius: 6 }} />
+                <div className="month-nav">
+                    <div className="risk-skeleton-row" style={{ width: 28, height: 28, borderRadius: '50%' }} />
+                    <div className="risk-skeleton-row" style={{ width: 28, height: 28, borderRadius: '50%' }} />
+                </div>
+            </div>
+
+            <div className="mini-cal">
+                {headers.map((_, i) => (
+                    <div key={`h-${i}`} className="cal-d header" />
+                ))}
+                {cells.map((_, i) => (
+                    <div
+                        key={i}
+                        className="risk-skeleton-row"
+                        style={{ aspectRatio: '1', borderRadius: '50%' }}
+                    />
+                ))}
+            </div>
+
+            <div className="cal-legend">
+                <div className="risk-skeleton-row" style={{ width: 70, height: 12, borderRadius: 50 }} />
+                <div className="risk-skeleton-row" style={{ width: 80, height: 12, borderRadius: 50 }} />
+                <div className="risk-skeleton-row" style={{ width: 75, height: 12, borderRadius: 50 }} />
+            </div>
+
+            <div className="stat-row">
+                <div className="stat-tile">
+                    <div className="risk-skeleton-row" style={{ width: '60%', height: '0.7rem', marginBottom: 8 }} />
+                    <div className="risk-skeleton-row" style={{ width: '40%', height: '1.5rem' }} />
+                </div>
+                <div className="stat-tile">
+                    <div className="risk-skeleton-row" style={{ width: '60%', height: '0.7rem', marginBottom: 8 }} />
+                    <div className="risk-skeleton-row" style={{ width: '40%', height: '1.5rem' }} />
+                </div>
+            </div>
+        </div>
+    )
+}


### PR DESCRIPTION
## Linked Issue
Fixes #605

## Description
Implemented an animated pulse skeleton placeholder for `CycleCalendar` to eliminate the layout shift (CLS) that occurred while cycle data was still loading on the dashboard.

- Added a new component `components/dashboard/CycleCalendarSkeleton.jsx` that reuses the exact same CSS classes as `CycleCalendar` (`cycle-card`, `mini-cal`, `cal-d`, `cal-legend`, `stat-row`, `stat-tile`), so the skeleton occupies pixel-identical space to the real card — swapping one for the other causes zero layout shift.
- The shimmer treatment reuses the existing `.risk-skeleton-row` class from `globals.css` (already used by `PCODRiskCard`'s loading state), so no new CSS/keyframes were introduced.
- Updated `app/[locale]/page.js` to conditionally render `<CycleCalendarSkeleton />` while `dataLoaded` is `false`, and the real `<CycleCalendar />` once cycle data has finished fetching. `dataLoaded` was already existing state (set in the `finally` block of `fetchCycleData`), so no new state was added.
- Confirmed `PCODRiskCard.jsx` already implements a pulse skeleton (via `loading={pcodRiskLoading}`) — no changes were needed there.
- Confirmed `PcosQuizCard.jsx` is a static call-to-action card with no async data dependency — no skeleton needed there.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (clean code updates, no behavior modifications)
- [ ] Documentation update
- [x] Performance optimization
- [ ] Security patch

## Testing
- Ran `npm run dev` and refreshed the dashboard (`/en`) with network throttled (Slow 3G, DevTools) to confirm the calendar-shaped shimmer skeleton renders immediately, then swaps to the populated `CycleCalendar` once `fetchCycleData` resolves.
- Verified via DevTools' Rendering → Layout Shift Regions (and the Performance panel's CLS metric) that no shift occurs when the skeleton is replaced by the real calendar — both render at identical dimensions.
- Confirmed the shimmer animation on the skeleton grid cells, header bar, legend, and stat tiles matches the existing shimmer used in `PCODRiskCard`'s loading state for visual consistency.
- Verified the calendar's day-click, month navigation, and selected-date behavior are unaffected once data loads.
- Checked mobile viewport widths to confirm the skeleton grid (7-column, aspect-ratio circles) scales the same way the real calendar grid does.

## Checklist
- [x] This PR is submitted under ECSOC.
- [x] Added the required **ECSoc26** label to this Pull Request.
- [x] Linked issue using `Fixes #605`.
- [x] Tested locally.
- [ ] `npm run build` completes successfully.
- [ ] GitHub Actions checks pass.
- [x] No breaking changes introduced.
- [ ] Documentation updated if required.

> ⚠️ **Important**
>
> PRs submitted for ECSOC **must include the `ECSoc26` label**.
> Pull Requests without this label **will not be processed by ECSOC Sentinel and will not receive a score.**