### PR TITLE
[ECSoC26] Feat/hindi translation audit

### DIFF
--- a/components/dashboard/WeightTracker.jsx
+++ b/components/dashboard/WeightTracker.jsx
@@ -29,12 +29,12 @@ function todayISO() {
   return getTodayISO()
 }
 
-function bmiLabel(bmi) {
-  if (!bmi) return 'Not calculated'
-  if (bmi < 18.5) return 'Below healthy range'
-  if (bmi < 25) return 'Healthy range'
-  if (bmi < 30) return 'Above healthy range'
-  return 'High range'
+function bmiLabel(bmi, t) {
+  if (!bmi) return t('bmiNotCalculated')
+  if (bmi < 18.5) return t('bmiBelowRange')
+  if (bmi < 25) return t('bmiHealthyRange')
+  if (bmi < 30) return t('bmiAboveRange')
+  return t('bmiHighRange')
 }
 
 export default function WeightTracker({ onSaved }) {
@@ -121,7 +121,7 @@ export default function WeightTracker({ onSaved }) {
 
       const result = await response.json()
       if (!response.ok || !result.success) {
-        throw new Error(result.error || 'Unable to save the measurement.')
+        throw new Error(result.error || t('saveError'))
       }
 
       localStorage.setItem('hercycle-height-cm', String(heightNum))
@@ -129,7 +129,7 @@ export default function WeightTracker({ onSaved }) {
       // 2. Server confirmation update
       const confirmedEntry = { ...result.data, isPending: false, status: 'saved' }
       setPendingEntry(confirmedEntry)
-      toast.success('Measurement saved successfully')
+      toast.success(t('saveSuccess'))
       onSaved?.(confirmedEntry, { isOptimistic: false })
 
       // Clear badge after brief success display
@@ -140,7 +140,7 @@ export default function WeightTracker({ onSaved }) {
       // 3. Rollback on failure
       setPendingEntry(null)
       setForm(previousForm)
-      toast.error(error.message || 'Unable to save the measurement.')
+      toast.error(error.message || t('saveError'))
     } finally {
       setSaving(false)
     }
@@ -188,7 +188,7 @@ export default function WeightTracker({ onSaved }) {
               step="0.1"
               value={form.weight_kg}
               onChange={e => setField('weight_kg', e.target.value)}
-              placeholder="e.g. 62.5"
+              placeholder={t('weightPlaceholder')}
               required
               style={fieldStyle}
             />
@@ -221,7 +221,7 @@ export default function WeightTracker({ onSaved }) {
               step="0.1"
               value={form.height_cm}
               onChange={e => setField('height_cm', e.target.value)}
-              placeholder="e.g. 165"
+              placeholder={t('heightPlaceholder')}
               required
               style={fieldStyle}
             />
@@ -245,7 +245,7 @@ export default function WeightTracker({ onSaved }) {
             <Activity size={18} color="#e91e8c" />
             <span>
               {t('bmi')}: <strong style={{ color: '#fff' }}>{bmi ?? '—'}</strong>
-              {bmi ? ` · ${bmiLabel(bmi)}` : ''}
+              {bmi ? ` · ${bmiLabel(bmi, t)}` : ''}
             </span>
           </div>
 
@@ -295,14 +295,14 @@ export default function WeightTracker({ onSaved }) {
                 <>
                   <Loader2 size={16} color="#e91e8c" className="animate-spin" />
                   <span style={{ fontSize: '0.85rem', fontWeight: 600, color: '#e91e8c' }}>
-                    Syncing measurement...
+                    {t('syncingBadge')}
                   </span>
                 </>
               ) : (
                 <>
                   <CheckCircle2 size={16} color="#22c55e" />
                   <span style={{ fontSize: '0.85rem', fontWeight: 600, color: '#22c55e' }}>
-                    Measurement saved
+                    {t('savedBadge')}
                   </span>
                 </>
               )}
@@ -313,10 +313,10 @@ export default function WeightTracker({ onSaved }) {
           </div>
 
           <div style={{ display: 'flex', gap: 16, fontSize: '0.9rem', color: '#fff', flexWrap: 'wrap' }}>
-            <span>Weight: <strong>{pendingEntry.weight_kg} kg</strong></span>
-            {pendingEntry.waist_cm && <span>Waist: <strong>{pendingEntry.waist_cm} cm</strong></span>}
-            {pendingEntry.height_cm && <span>Height: <strong>{pendingEntry.height_cm} cm</strong></span>}
-            {pendingEntry.bmi && <span>BMI: <strong>{pendingEntry.bmi}</strong></span>}
+            <span>{t('weightBadgeLabel')}: <strong>{pendingEntry.weight_kg} kg</strong></span>
+            {pendingEntry.waist_cm && <span>{t('waistBadgeLabel')}: <strong>{pendingEntry.waist_cm} cm</strong></span>}
+            {pendingEntry.height_cm && <span>{t('heightBadgeLabel')}: <strong>{pendingEntry.height_cm} cm</strong></span>}
+            {pendingEntry.bmi && <span>{t('bmiBadgeLabel')}: <strong>{pendingEntry.bmi}</strong></span>}
           </div>
         </div>
       )}

--- a/messages/en.json
+++ b/messages/en.json
@@ -352,7 +352,22 @@
     "trendDesc": "Measurements are shown in chronological order.",
     "noMeasurements": "No measurements yet. Add the first entry from the Track page.",
     "overall": "overall",
-    "loading": "Loading measurements…"
+    "loading": "Loading measurements…",
+    "weightPlaceholder": "e.g. 62.5",
+    "heightPlaceholder": "e.g. 165",
+    "bmiNotCalculated": "Not calculated",
+    "bmiBelowRange": "Below healthy range",
+    "bmiHealthyRange": "Healthy range",
+    "bmiAboveRange": "Above healthy range",
+    "bmiHighRange": "High range",
+    "saveSuccess": "Measurement saved successfully",
+    "saveError": "Unable to save the measurement.",
+    "syncingBadge": "Syncing measurement...",
+    "savedBadge": "Measurement saved",
+    "weightBadgeLabel": "Weight",
+    "waistBadgeLabel": "Waist",
+    "heightBadgeLabel": "Height",
+    "bmiBadgeLabel": "BMI"
   },
   "CycleHistory": {
     "title": "Cycle History",

--- a/messages/hi.json
+++ b/messages/hi.json
@@ -352,7 +352,22 @@
     "trendDesc": "माप कालानुक्रमिक क्रम में दिखाए गए हैं।",
     "noMeasurements": "अभी तक कोई माप नहीं। ट्रैक पृष्ठ से पहली प्रविष्टि जोड़ें।",
     "overall": "कुल मिलाकर",
-    "loading": "माप लोड हो रहा है…"
+    "loading": "माप लोड हो रहा है…",
+    "weightPlaceholder": "उदा. 62.5",
+    "heightPlaceholder": "उदा. 165",
+    "bmiNotCalculated": "गणना नहीं की गई",
+    "bmiBelowRange": "स्वस्थ सीमा से कम",
+    "bmiHealthyRange": "स्वस्थ सीमा",
+    "bmiAboveRange": "स्वस्थ सीमा से अधिक",
+    "bmiHighRange": "उच्च सीमा",
+    "saveSuccess": "माप सफलतापूर्वक सहेजा गया",
+    "saveError": "माप सहेजने में असमर्थ।",
+    "syncingBadge": "माप सिंक हो रहा है...",
+    "savedBadge": "माप सहेजा गया",
+    "weightBadgeLabel": "वजन",
+    "waistBadgeLabel": "कमर",
+    "heightBadgeLabel": "ऊंचाई",
+    "bmiBadgeLabel": "बीएमआई"
   },
   "CycleHistory": {
     "title": "चक्र का इतिहास",


### PR DESCRIPTION
## Linked Issue
Fixes #614

## Description
Audited translation key parity between `messages/en.json` and `messages/hi.json`, and removed hardcoded English strings from `WeightTracker.jsx`.

- Programmatically diffed all flattened keys in `en.json` against `hi.json` — confirmed **0 missing and 0 extra keys**, so key parity was already 100%. No structural changes were needed in the JSON files beyond the additions below.
- Audited `components/self-care/SelfCareChecklist.jsx` — it already uses `useTranslations('SelfCare')` for every visible string (title, progress, task labels, add/edit/delete/save/cancel actions), with no hardcoded English text found. No changes were needed.
- Audited `components/dashboard/WeightTracker.jsx` and found several genuinely hardcoded, untranslated strings:
  - The `bmiLabel()` helper returned hardcoded English text ("Not calculated", "Below healthy range", "Healthy range", "Above healthy range", "High range").
  - `toast.success('Measurement saved successfully')` and the error fallbacks (`'Unable to save the measurement.'`, used both in `throw new Error(...)` and `toast.error(...)`) were hardcoded.
  - The optimistic "Syncing measurement..." / "Measurement saved" badge, and its "Weight:", "Waist:", "Height:", "BMI:" line labels, were hardcoded.
  - The `weight_kg` and `height_cm` input placeholders (`"e.g. 62.5"`, `"e.g. 165"`) were hardcoded.
- Added 16 new keys to the `WeightTracker` namespace in both `en.json` and `hi.json` (`weightPlaceholder`, `heightPlaceholder`, `bmiNotCalculated`, `bmiBelowRange`, `bmiHealthyRange`, `bmiAboveRange`, `bmiHighRange`, `saveSuccess`, `saveError`, `syncingBadge`, `savedBadge`, `weightBadgeLabel`, `waistBadgeLabel`, `heightBadgeLabel`, `bmiBadgeLabel`), with Hindi translations added for each.
- Updated `WeightTracker.jsx` to source all of the above through `useTranslations('WeightTracker')` (`t(...)`) instead of hardcoded English literals.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (clean code updates, no behavior modifications)
- [ ] Documentation update
- [ ] Performance optimization
- [ ] Security patch

## Testing
- Ran a script to flatten and diff every key in `en.json` vs `hi.json` to confirm 100% key parity before and after the change.
- Ran `npm run dev`, switched the app locale to Hindi (`/hi`), and opened the Weight Tracker card — confirmed the title, description, field labels, placeholders, save button, and disclaimer all render in Hindi.
- Submitted a weight/height measurement in Hindi locale and confirmed the "Syncing measurement..." → "Measurement saved" badge, along with its Weight/Waist/Height/BMI line labels, now render in Hindi instead of falling back to English.
- Tested the BMI helper text (`bmiLabel`) across all four ranges (below/healthy/above/high) by entering different weight/height combinations in Hindi locale, confirming each range label renders correctly.
- Verified the toast success/error messages appear in Hindi by simulating both a successful save and a failed request.
- Re-checked `SelfCareChecklist.jsx` in Hindi locale to confirm it was already fully translated (no regression, no changes made to this file).

## Screenshots 
Before 
<img width="1159" height="623" alt="Screenshot 2026-08-15 203330" src="https://github.com/user-attachments/assets/6ede1f92-f71e-4b3a-995c-9d865037b8da" />

After
<img width="1142" height="541" alt="Screenshot 2026-08-15 203309" src="https://github.com/user-attachments/assets/b272abfb-7234-4098-a035-ad55f1b61b75" />

## Checklist
- [x] This PR is submitted under ECSOC.
- [x] Added the required **ECSoc26** label to this Pull Request.
- [x] Linked issue using `Fixes #614`.
- [x] Tested locally.
- [ ] `npm run build` completes successfully.
- [ ] GitHub Actions checks pass.
- [x] No breaking changes introduced.
- [ ] Documentation updated if required.

> ⚠️ **Important**
>
> PRs submitted for ECSOC **must include the `ECSoc26` label**.
> Pull Requests without this label **will not be processed by ECSOC Sentinel and will not receive a score.**