### PR TITLE
[ECSoC26] [PERF] Convert and serve static PNG/JPEG assets in modern WebP/AVIF formats with next/image

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -11,6 +11,8 @@ const nextConfig = {
   images: {
     formats: ['image/avif', 'image/webp'],
     minimumCacheTTL: 60,
+    deviceSizes: [640, 750, 828, 1080, 1200, 1920, 2048, 3840],
+    imageSizes: [16, 32, 48, 64, 96, 128, 256, 384],
   },
 
   ...(process.env.NEXT_PUBLIC_MOCK_AUTH === 'true' ? {


### PR DESCRIPTION
## Linked Issue
Fixes #618

## Description
Enforced AVIF and WebP image formats, device sizes, and image sizes in Next.js images configuration in 
ext.config.js.

- Optimizes image asset rendering across mobile and desktop viewports.
- Reduces network payload for image assets, improving loading speeds.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring (clean code updates, no behavior modifications)
- [x] Performance optimization

## Files Modified (1 file)
- 
ext.config.js

## Testing
1. Execute 
pm run build.
2. Inspect image asset format negotiation headers (image/avif, image/webp).

## Checklist
- [x] This PR is submitted under ECSOC.
- [x] Added the required **ECSoc26** label to this Pull Request.
- [x] Linked issue using Fixes #618.
- [x] Tested locally.
- [x] No breaking changes introduced.