### PR TITLE
[ECSoC26] fix:  Insights page header text and Avg Cycle Length badge overlap on mobile

### DIFF
--- a/app/[locale]/insights/page.js
+++ b/app/[locale]/insights/page.js
@@ -313,21 +313,25 @@ export default function InsightsPage() {
         <div className="max-w-[1000px] mx-auto px-4 sm:px-6 py-8">
 
           {/* ── Page header ── */}
-          <div style={{ display: 'flex', alignItems: 'center', gap: '12px', marginBottom: '8px', flexWrap: 'wrap', rowGap: '12px' }}>
-            <div style={{
-              background: 'rgba(255,255,255,0.2)',
-              borderRadius: '12px',
-              padding: '8px',
-              display: 'flex',
-              alignItems: 'center',
-              flexShrink: 0,
-            }}>
-              <BarChart2 size={28} color="white" strokeWidth={1.5} />
+          <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 sm:gap-4 mb-2">
+            <div className="flex items-center gap-3 min-w-0">
+              <div style={{
+                background: 'rgba(255,255,255,0.2)',
+                borderRadius: '12px',
+                padding: '8px',
+                display: 'flex',
+                alignItems: 'center',
+                flexShrink: 0,
+              }}>
+                <BarChart2 size={28} color="white" strokeWidth={1.5} />
+              </div>
+              <h1 style={{ margin: 0, fontSize: '2rem' }} className="font-bold text-white tracking-tight leading-tight min-w-0 break-words">
+                {t('title')}
+              </h1>
             </div>
-            <h1 style={{ margin: 0, fontSize: '2rem', flex: 1, minWidth: 0 }}>{t('title')}</h1>
 
             {!loading && (
-              <div style={{
+              <div className="self-start sm:self-auto shrink-0" style={{
                 background: 'rgba(233,30,140,0.15)',
                 border: `1px solid ${PINK}55`,
                 padding: '6px 14px',
@@ -336,7 +340,6 @@ export default function InsightsPage() {
                 alignItems: 'center',
                 gap: '8px',
                 whiteSpace: 'nowrap',
-                flexShrink: 0,
               }}>
                 <CalendarRange size={16} color={PINK} />
                 <span style={{ fontSize: '0.9rem', fontWeight: 600, color: '#ffb3d9' }}>
@@ -346,7 +349,7 @@ export default function InsightsPage() {
             )}
           </div>
           <p style={{ color: TEXT_FAINT, marginBottom: '2rem' }}>
-            {t('subtitle')} {!loading && <span style={{ opacity: 0.9, marginLeft: '0.5rem', color: PINK, fontWeight: 500 }}>({t('avgCycle')}: {avgCycle} days)</span>}
+            {t('subtitle')}
           </p>
 
           {/* ── Stat Cards ── */}


### PR DESCRIPTION
In app/[locale]/insights/page.js
:

Responsive Flex Stacking: Changed the header wrapper to use responsive flex direction (flex flex-col sm:flex-row sm:items-center justify-between gap-3 sm:gap-4 mb-2).
Title Grouping: Grouped the icon box and h1 heading together into a dedicated left-aligned flex row container (flex items-center gap-3 min-w-0), preventing the h1 heading from being horizontally compressed by the badge pill.
Responsive Badge Positioning: Positioned the Avg Cycle Length badge pill with self-start on mobile viewports so it wraps cleanly onto a new row below the header title without colliding or overlapping, and sm:self-auto on desktop viewports so it aligns to the right side of the header row.
Cleaner Subtitle: Removed redundant (Avg Cycle Length: X days) text from the subtitle since the header badge pill displays this cleanly.
Verification
Ran node --test e2e/suite4_insights_analytics.test.mjs — passed all tests without regressions.


closes #585