### PR TITLE
[ECSoC26] fix:  '+ Add' button overflows out of Daily Checklist card on mobile …

### DIFF
--- a/components/self-care/HydrationTracker.jsx
+++ b/components/self-care/HydrationTracker.jsx
@@ -263,7 +263,7 @@ function SettingsModal({ settings, onSave, onClose, t }) {
               step={100}
               value={draft.dailyGoal}
               onChange={(e) => setDraft((d) => ({ ...d, dailyGoal: e.target.value }))}
-              className="flex-1 bg-white/10 border border-white/15 rounded-xl px-3 py-2 text-white text-sm focus:outline-none focus:ring-2 focus:ring-pink-400/50"
+              className="flex-1 min-w-0 bg-white/10 border border-white/15 rounded-xl px-3 py-2 text-white text-sm focus:outline-none focus:ring-2 focus:ring-pink-400/50"
               style={{ WebkitUserSelect: 'text', userSelect: 'text' }}
             />
             <span className="text-white/50 text-sm shrink-0">ml</span>
@@ -284,7 +284,7 @@ function SettingsModal({ settings, onSave, onClose, t }) {
               step={50}
               value={draft.cupCapacity}
               onChange={(e) => setDraft((d) => ({ ...d, cupCapacity: e.target.value }))}
-              className="flex-1 bg-white/10 border border-white/15 rounded-xl px-3 py-2 text-white text-sm focus:outline-none focus:ring-2 focus:ring-pink-400/50"
+              className="flex-1 min-w-0 bg-white/10 border border-white/15 rounded-xl px-3 py-2 text-white text-sm focus:outline-none focus:ring-2 focus:ring-pink-400/50"
               style={{ WebkitUserSelect: 'text', userSelect: 'text' }}
             />
             <span className="text-white/50 text-sm shrink-0">ml</span>

--- a/components/self-care/SelfCareChecklist.jsx
+++ b/components/self-care/SelfCareChecklist.jsx
@@ -149,7 +149,7 @@ export default function SelfCareChecklist() {
   // ── Render ─────────────────────────────────────────────────────────────────
 
   return (
-    <section className="bg-white/5 border border-white/10 rounded-3xl p-6 sm:p-8 space-y-6">
+    <section className="bg-white/5 border border-white/10 rounded-3xl p-4 sm:p-8 space-y-6">
       {/* Header */}
       <div className="flex items-center justify-between gap-2">
         <div className="flex items-center gap-2">
@@ -325,7 +325,7 @@ export default function SelfCareChecklist() {
           onKeyDown={(e) => { if (e.key === 'Enter') addTask(); }}
           placeholder={t('checklistAddPlaceholder')}
           maxLength={80}
-          className="flex-1 bg-white/10 border border-white/15 rounded-xl px-4 py-2.5 text-white placeholder-white/40 text-sm focus:outline-none focus:ring-2 focus:ring-pink-400/50"
+          className="flex-1 min-w-0 bg-white/10 border border-white/15 rounded-xl px-3 sm:px-4 py-2.5 text-white placeholder-white/40 text-sm focus:outline-none focus:ring-2 focus:ring-pink-400/50"
           style={{ WebkitUserSelect: 'text', userSelect: 'text' }}
         />
         <button
@@ -333,10 +333,10 @@ export default function SelfCareChecklist() {
           onClick={addTask}
           disabled={!newTaskLabel.trim()}
           aria-label={t('checklistAdd')}
-          className="btn-pill px-4 py-2.5 text-sm disabled:opacity-40 disabled:cursor-not-allowed shrink-0 flex items-center gap-1.5"
+          className="btn-pill px-3 sm:px-4 py-2.5 text-sm disabled:opacity-40 disabled:cursor-not-allowed shrink-0 flex items-center gap-1.5"
         >
-          <Plus className="w-4 h-4" aria-hidden="true" />
-          {t('checklistAdd')}
+          <Plus className="w-4 h-4 shrink-0" aria-hidden="true" />
+          <span>{t('checklistAdd')}</span>
         </button>
       </div>
     </section>


### PR DESCRIPTION
## Root Cause
In components/self-care/SelfCareChecklist.jsx
, the custom task input row placed the <input> element and + Add button side-by-side in a flex container (flex items-center gap-2).

The <input> element was given flex-1 but lacked min-w-0. HTML <input> elements have a browser-default intrinsic minimum width (min-width: auto). On narrow mobile screens (< 400px width), this prevented the input field from shrinking below its intrinsic size, causing the flex row to exceed the container width and push the + Add button outside the card border. Additionally, fixed p-6 padding on the parent card container consumed 48px of width on small screens.

## Solution
Flex Shrinkage (min-w-0): Added min-w-0 to the custom task <input> element in components/self-care/SelfCareChecklist.jsx
. This allows flexbox to contract the input field below its default intrinsic width when screen width is constrained.
Responsive Card Padding: Adjusted card padding to p-4 sm:p-8, saving 16px of horizontal space on narrow mobile screens.
Responsive Button Padding: Updated input and button padding to px-3 sm:px-4, preventing label overflow across all localized button text strings.
Preventative Fix in Hydration Tracker: Added min-w-0 to the numeric goal input fields in components/self-care/HydrationTracker.jsx
.
Verification
Executed node --test e2e/suite3_self_care.test.mjs — passed all unit and integration assertions without regressions.


closes #586