### PR TITLE
[ECSoC26] fix: Health Profile not saving details

### DIFF
--- a/app/api/profile/route.js
+++ b/app/api/profile/route.js
@@ -15,9 +15,9 @@ export async function GET(request) {
       .from('user_profiles')
       .select('*')
       .eq('user_id', userId)
-      .single()
+      .maybeSingle()
 
-    if (error && error.code !== 'PGRST116') { // PGRST116 means no rows found (not an error if user hasn't created profile yet)
+    if (error) {
       logger.error('Error fetching user profile:', error)
       return NextResponse.json({ success: false, error: 'Database error' }, { status: 500 })
     }
@@ -36,39 +36,79 @@ export async function POST(request) {
       return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 })
     }
 
-    let body;
+    let body
     try {
-      body = await request.json();
+      body = await request.json()
     } catch (parseError) {
-      logger.warn(`Malformed JSON payload in profile POST: ${parseError.message}`);
-      return NextResponse.json({ success: false, error: 'Bad Request: Invalid JSON payload' }, { status: 400 });
+      logger.warn(`Malformed JSON payload in profile POST: ${parseError.message}`)
+      return NextResponse.json({ success: false, error: 'Bad Request: Invalid JSON payload' }, { status: 400 })
     }
-    const { age, weight_kg, height_cm, known_conditions, cycle_goal, allow_ai_analysis } = body
+
+    if (!body || typeof body !== 'object' || Array.isArray(body)) {
+      return NextResponse.json({ success: false, error: 'Invalid payload' }, { status: 400 })
+    }
+
+    const { age, weight_kg, height_cm, known_conditions, cycle_goal, allow_ai_analysis, cycleLength } = body
+
+    let parsedAge = null
+    if (age !== undefined && age !== null && age !== '') {
+      parsedAge = Number(age)
+      if (!Number.isFinite(parsedAge) || parsedAge < 1 || parsedAge > 120) {
+        return NextResponse.json({ success: false, error: 'Age must be a valid number between 1 and 120' }, { status: 400 })
+      }
+    }
+
+    let parsedWeight = null
+    if (weight_kg !== undefined && weight_kg !== null && weight_kg !== '') {
+      parsedWeight = Number(weight_kg)
+      if (!Number.isFinite(parsedWeight) || parsedWeight < 1 || parsedWeight > 500) {
+        return NextResponse.json({ success: false, error: 'Weight must be a valid number between 1 and 500 kg' }, { status: 400 })
+      }
+    }
+
+    let parsedHeight = null
+    if (height_cm !== undefined && height_cm !== null && height_cm !== '') {
+      parsedHeight = Number(height_cm)
+      if (!Number.isFinite(parsedHeight) || parsedHeight < 1 || parsedHeight > 300) {
+        return NextResponse.json({ success: false, error: 'Height must be a valid number between 1 and 300 cm' }, { status: 400 })
+      }
+    }
+
+    if (cycleLength !== undefined && cycleLength !== null && cycleLength !== '') {
+      const parsedCycleLength = Number(cycleLength)
+      if (!Number.isFinite(parsedCycleLength) || parsedCycleLength < 15 || parsedCycleLength > 60) {
+        return NextResponse.json({ success: false, error: 'Cycle length must be between 15 and 60 days' }, { status: 400 })
+      }
+    }
+
+    const profileRecord = {
+      user_id: userId,
+      age: parsedAge,
+      weight_kg: parsedWeight,
+      height_cm: parsedHeight,
+      known_conditions: Array.isArray(known_conditions) ? known_conditions : [],
+      cycle_goal: cycle_goal || null,
+      allow_ai_analysis: typeof allow_ai_analysis === 'boolean' ? allow_ai_analysis : true,
+      updated_at: new Date().toISOString()
+    }
 
     const supabase = getSupabaseAdmin()
     const { data, error } = await supabase
       .from('user_profiles')
-      .upsert({
-        user_id: userId,
-        age: age ? parseInt(age, 10) : null,
-        weight_kg: weight_kg ? parseFloat(weight_kg) : null,
-        height_cm: height_cm ? parseFloat(height_cm) : null,
-        known_conditions: Array.isArray(known_conditions) ? known_conditions : [],
-        cycle_goal: cycle_goal || null,
-        allow_ai_analysis: typeof allow_ai_analysis === 'boolean' ? allow_ai_analysis : true,
-        updated_at: new Date().toISOString()
-      }, { onConflict: 'user_id' })
+      .upsert(profileRecord, { onConflict: 'user_id' })
       .select()
-      .single()
 
     if (error) {
       logger.error('Error saving user profile:', error)
       return NextResponse.json({ success: false, error: 'Database error' }, { status: 500 })
     }
 
-    return NextResponse.json({ success: true, profile: data }, { status: 200 })
+    const savedProfile = Array.isArray(data) ? (data[0] || profileRecord) : (data || profileRecord)
+
+    return NextResponse.json({ success: true, profile: savedProfile }, { status: 200 })
   } catch (err) {
     logger.error('Profile POST error:', err)
     return NextResponse.json({ success: false, error: 'Internal Server Error' }, { status: 500 })
   }
 }
+

--- a/components/layout/HealthProfileSettings.jsx
+++ b/components/layout/HealthProfileSettings.jsx
@@ -35,9 +35,9 @@ export default function HealthProfileSettings() {
       const data = await res.json()
       if (data.success && data.profile) {
         setFormData({
-          age: data.profile.age || '',
-          weight_kg: data.profile.weight_kg || '',
-          height_cm: data.profile.height_cm || '',
+          age: data.profile.age !== null && data.profile.age !== undefined ? data.profile.age : '',
+          weight_kg: data.profile.weight_kg !== null && data.profile.weight_kg !== undefined ? data.profile.weight_kg : '',
+          height_cm: data.profile.height_cm !== null && data.profile.height_cm !== undefined ? data.profile.height_cm : '',
           known_conditions: data.profile.known_conditions || [],
           cycle_goal: data.profile.cycle_goal || ''
         })
@@ -77,7 +77,7 @@ export default function HealthProfileSettings() {
     setSaving(true)
     try {
       const payload = {
-        age: formData.age ? parseInt(formData.age) : null,
+        age: formData.age ? parseInt(formData.age, 10) : null,
         weight_kg: formData.weight_kg ? parseFloat(formData.weight_kg) : null,
         height_cm: formData.height_cm ? parseFloat(formData.height_cm) : null,
         known_conditions: formData.known_conditions,
@@ -93,6 +93,15 @@ export default function HealthProfileSettings() {
       const data = await res.json()
       if (data.success) {
         toast.success('Health profile saved successfully!')
+        if (data.profile) {
+          setFormData({
+            age: data.profile.age !== null && data.profile.age !== undefined ? data.profile.age : '',
+            weight_kg: data.profile.weight_kg !== null && data.profile.weight_kg !== undefined ? data.profile.weight_kg : '',
+            height_cm: data.profile.height_cm !== null && data.profile.height_cm !== undefined ? data.profile.height_cm : '',
+            known_conditions: data.profile.known_conditions || [],
+            cycle_goal: data.profile.cycle_goal || ''
+          })
+        }
       } else {
         toast.error(data.error || 'Failed to save profile')
       }


### PR DESCRIPTION
## Root Cause
In app/api/profile/route.js
:

Unsafe .single() Chaining: In POST /api/profile, .single() was chained directly onto .upsert(...).select(). When Supabase/PostgreSQL returned an array of upserted records (or empty result set depending on database state), .single() threw error code PGRST116, causing the handler to trigger a 500 Database Error response.
Missing Input Validation: POST /api/profile lacked numerical parsing & bounds checking for age, weight_kg, height_cm, and cycleLength. Non-numeric or out-of-range values resulted in NaN or SQL constraint check violations (age > 0 AND age < 120), crashing the query.
GET Error Handling: GET /api/profile used .single(), which emitted database error logs when a user fetched their profile for the first time before records existed.
UI State Persistence: In components/layout/HealthProfileSettings.jsx
, form state was not updated with the server's validated response payload upon successful submission.
## Solution
Safe Record Unpacking: Updated app/api/profile/route.js
 to execute .upsert(profileRecord, { onConflict: 'user_id' }).select(), safely extracting the updated record regardless of array or object return structure.
Strict Request Validation: Added validation logic in POST /api/profile:
age: 1 – 120
weight_kg: 1 – 500 kg
height_cm: 1 – 300 cm
cycleLength: 15 – 60 days Returns 400 Bad Request with descriptive error messages when invalid input is provided.
Safe Fetch with .maybeSingle(): Replaced .single() with .maybeSingle() in GET /api/profile, returning { success: true, profile: {} } smoothly when no profile record exists yet.
UI Response State Synchronisation: Updated handleSubmit in components/layout/HealthProfileSettings.jsx to sync formData state with the returned profile payload.
Verification
Ran node scripts/test-api-profile-cycles.js — all profile contract validation and integration tests passed.


closes #587