### PR TITLE
[ECSoC26]  [FEAT] Add copy-to-clipboard feedback toast and error boundary for HealthReport generation

### DIFF
--- a/app/[locale]/insights/page.js
+++ b/app/[locale]/insights/page.js
@@ -118,12 +118,14 @@ export default function InsightsPage() {
   const { user } = useUser()
   const { offlineClient } = useOffline()
 
-  const [cycleData, setCycleData] = useState(null)
+const [cycleData, setCycleData] = useState(null)
   const [pcodRisk, setPcodRisk] = useState(null)
   const [dailyLogs, setDailyLogs] = useState([])
   const [copied, setCopied] = useState(false)
   const [loading, setLoading] = useState(true)
   const [mounted, setMounted] = useState(false)
+  const [showCopyFallback, setShowCopyFallback] = useState(false)
+  const [fallbackText, setFallbackText] = useState('')
 
   useEffect(() => {
     setMounted(true)
@@ -279,7 +281,7 @@ export default function InsightsPage() {
         document.body.appendChild(textArea)
         textArea.focus()
         textArea.select()
-        const successful = document.execCommand('copy')
+       const successful = document.execCommand('copy')
         document.body.removeChild(textArea)
         if (successful) {
           setCopied(true)
@@ -288,8 +290,11 @@ export default function InsightsPage() {
           throw new Error('Fallback copy failed')
         }
       }
-    } catch (err) {
+   } catch (err) {
       console.error('Could not copy summary', err)
+      toast.error('Could not copy automatically. Please copy the text manually below.')
+      setFallbackText(summaryText)
+      setShowCopyFallback(true)
     }
   }
 
@@ -417,6 +422,45 @@ export default function InsightsPage() {
               <span>{t('exportCsv')}</span>
             </button>
           </div>
+
+          {/* ── Visible copy fallback, shown only when automatic clipboard copy fails ── */}
+          {showCopyFallback && (
+            <div style={{
+              background: CARD_BG,
+              border: CARD_BORDER,
+              borderRadius: 16,
+              padding: '1rem 1.25rem',
+              marginBottom: '1.5rem',
+            }}>
+              <p style={{ color: TEXT_PRIMARY, fontSize: '0.85rem', marginBottom: 8 }}>
+                Automatic copy didn't work. Select the text below and copy it manually:
+              </p>
+              <textarea
+                readOnly
+                value={fallbackText}
+                onClick={(e) => e.target.select()}
+                style={{
+                  width: '100%',
+                  minHeight: 100,
+                  padding: '10px',
+                  borderRadius: 10,
+                  border: CARD_BORDER,
+                  background: 'rgba(255,255,255,0.05)',
+                  color: TEXT_PRIMARY,
+                  fontSize: '0.82rem',
+                  fontFamily: 'monospace',
+                  resize: 'vertical',
+                }}
+              />
+              <button
+                onClick={() => setShowCopyFallback(false)}
+                className="export-btn"
+                style={{ width: 'auto', padding: '6px 14px', marginTop: 8, fontSize: '0.8rem' }}
+              >
+                Dismiss
+              </button>
+            </div>
+          )}
 
           {/* ── Cycle Length Trend ── */}
           <SectionCard

--- a/app/[locale]/page.js
+++ b/app/[locale]/page.js
@@ -18,6 +18,7 @@ import DayLogDrawer from '@/components/dashboard/DayLogDrawer'
 import PartnerLoveBanner from '@/components/dashboard/PartnerLoveBanner'
 import VibeCheckin from '@/components/dashboard/VibeCheckin'
 import PCODRiskCard from '@/components/dashboard/PCODRiskCard'
+import ReportErrorBoundary from '@/components/dashboard/ReportErrorBoundary'
 import ChatAssistant from '@/components/dashboard/ChatAssistant'
 import DailyLogPanel from '@/components/dashboard/DailyLogPanel'
 import OnboardingModal from '@/components/dashboard/OnboardingModal'
@@ -545,15 +546,17 @@ const HerCycleApp = () => {
 
         <h2 className="sec-head" id="pcod-risk-section">{tHeadings('insights')}</h2>
         <div className="dual-row">
-          <PCODRiskCard
-            pcodRisk={pcodRisk}
-            unavailableReason={pcodRiskReason}
-            loading={pcodRiskLoading}
-            cycleCount={cycleData?.cycles?.length ?? 0}
-            cycles={cycleData?.cycles ?? []}
-            recentSymptoms={selectedSymptoms}
-            activeLang={activeLang}
-          />
+        <ReportErrorBoundary>
+            <PCODRiskCard
+              pcodRisk={pcodRisk}
+              unavailableReason={pcodRiskReason}
+              loading={pcodRiskLoading}
+              cycleCount={cycleData?.cycles?.length ?? 0}
+              cycles={cycleData?.cycles ?? []}
+              recentSymptoms={selectedSymptoms}
+              activeLang={activeLang}
+            />
+          </ReportErrorBoundary>
           <ChatAssistant
             chatMessages={chatMessages}
             isTyping={isTyping}

--- a/components/dashboard/PCODRiskCard.jsx
+++ b/components/dashboard/PCODRiskCard.jsx
@@ -1,10 +1,10 @@
 'use client'
-
 import { useEffect, useState } from 'react'
 import { useUser } from '@clerk/nextjs'
 import generateReport from '@/lib/generateReport'
 import { useTranslations, useLocale } from 'next-intl'
 import { RISK_UNAVAILABLE_REASONS, normaliseRiskResult } from '@/lib/pcod-risk-result'
+import toast from 'react-hot-toast'
 
 // ── Tier → visual tokens ──────────────────────────────────────────────────────
 const TIER_TOKENS = {
@@ -93,6 +93,7 @@ export default function PCODRiskCard({ pcodRisk, unavailableReason = null, loadi
       })
     } catch (error) {
       console.error('Failed to generate the doctor report', error)
+      toast.error('Could not generate the report. Please try again.')
     } finally {
       setExporting(false)
     }

--- a/components/dashboard/ReportErrorBoundary.jsx
+++ b/components/dashboard/ReportErrorBoundary.jsx
@@ -1,0 +1,42 @@
+'use client'
+
+import { Component } from 'react'
+
+/**
+ * Catches rendering-phase errors inside the Health Report export area
+ * (PCODRiskCard and its children) and shows a fallback UI instead of
+ * letting the crash take down the whole page.
+ *
+ * This is separate from the try/catch inside handleExport, which only
+ * catches errors from the async generateReport() call itself. This
+ * boundary catches anything that goes wrong while React is actually
+ * rendering the card — e.g. bad data causing a child component to throw.
+ */
+export default class ReportErrorBoundary extends Component {
+  constructor(props) {
+    super(props)
+    this.state = { hasError: false }
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true }
+  }
+
+  componentDidCatch(error, errorInfo) {
+    console.error('ReportErrorBoundary caught an error:', error, errorInfo)
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="risk-card glass" style={{ textAlign: 'center', padding: '2rem' }}>
+          <p style={{ color: 'var(--text-faint)' }}>
+            Something went wrong showing your health report. Please refresh the page.
+          </p>
+        </div>
+      )
+    }
+
+    return this.props.children
+  }
+}


### PR DESCRIPTION
Fixes #608

Description
Added error handling and visual feedback for the Health Report export flow:
- Added a descriptive toast.error() when PDF report generation fails 
  (PCODRiskCard.jsx), instead of failing silently with only a console log
- Added a new ReportErrorBoundary component wrapping PCODRiskCard on the 
  Dashboard, so any rendering-phase crash inside the card shows a fallback 
  message instead of taking down the whole page
- Added a visible fallback textarea in the Insights page's "Copy Summary" 
  flow, shown only when both the Clipboard API and the execCommand fallback 
  fail — previously this failure was completely silent, with an invisible 
  off-screen textarea the user had no way to interact with

Type of Change
- Bug fix (non-breaking change which fixes an issue)

Testing
Ran npm run build — compiled successfully. Ran npm run test:e2e — all 7 
suites passing. Manually verified the clipboard fallback by triggering a 
real execCommand failure in dev — confirmed the toast and visible textarea 
box both appear correctly, and the summary text can be manually selected 
and copied from it.

