### PR TITLE
[ECSoC26] [UI/UX] Improve mobile touch targets to minimum 44x44px for calendar navigation and icon buttons

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -740,19 +740,22 @@ nav ul li a.active {
 }
 
 .month-nav button {
-  width: 28px;
-  height: 28px;
+  min-width: 44px;
+  min-height: 44px;
+  width: 44px;
+  height: 44px;
   border-radius: 50%;
   background: rgba(255, 255, 255, 0.12);
   border: 1px solid rgba(255, 255, 255, 0.22);
   color: rgba(255, 255, 255, 0.9);
-  font-size: 0.85rem;
+  font-size: 1.15rem;
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
   transition: all 0.18s;
   font-family: var(--sans);
+  touch-action: manipulation;
 }
 
 .month-nav button:hover {


### PR DESCRIPTION
## Linked Issue
Fixes #609

## Description
Improved mobile accessibility and touch target sizing to meet WCAG 2.1 AAA minimum 44x44px requirements for `.month-nav button` and calendar navigation controls in `app/globals.css`.

- Increases clickable/tappable area on mobile viewports.
- Adds `touch-action: manipulation` for responsive touch interactions.

## Type of Change
- [ ] Bug fix
- [x] UI/UX enhancement
- [ ] Code quality

## Checklist
- [x] Linked issue using `Fixes #609`.
- [x] Added ECSoc26 label.