### PR TITLE
[ECSoC26] [REFACTOR] Extract duplicate inline design tokens into centralized theme constants

### DIFF
--- a/app/[locale]/insights/page.js
+++ b/app/[locale]/insights/page.js
@@ -24,14 +24,16 @@ const WeightTrendChart = dynamic(() => import('@/components/dashboard/WeightTren
   loading: () => <div className="chart-skeleton-box" style={{ width: '100%', height: 260, borderRadius: 16 }} />,
   ssr: false,
 })
+import { THEME_COLORS, THEME_SURFACES, THEME_TEXT } from '@/lib/theme-constants'
+
 // ─── Design tokens ────────────────────────────────────────────────────────────
-const PINK = '#e8527e'
-const MAUVE = '#9d3f7a'
-const ACCENT = '#e91e8c'
-const TEXT_PRIMARY = '#ffffff'
-const TEXT_FAINT = 'rgba(255,255,255,0.65)'
-const CARD_BG = 'rgba(255,255,255,0.08)'
-const CARD_BORDER = '1px solid rgba(255,255,255,0.14)'
+const PINK = THEME_COLORS.pink
+const MAUVE = THEME_COLORS.mauve
+const ACCENT = THEME_COLORS.accent
+const TEXT_PRIMARY = THEME_TEXT.primary
+const TEXT_FAINT = THEME_TEXT.faint
+const CARD_BG = THEME_SURFACES.cardBg
+const CARD_BORDER = THEME_SURFACES.cardBorder
 
 const SYMPTOM_LIST = ['Cramps', 'Headache', 'Bloating', 'Fatigue', 'Acne', 'Nausea']
 const MOOD_EMOJIS = ['😊', '😐', '😢', '😡']

--- a/components/ui/SectionCard.jsx
+++ b/components/ui/SectionCard.jsx
@@ -12,10 +12,12 @@
  * shape (radius, padding, spacing, font sizes) stays identical.
  */
 
+import { THEME_SURFACES, THEME_TEXT } from '@/lib/theme-constants'
+
 const DEFAULT_TONE = {
-    background: 'rgba(255,255,255,0.08)',
-    border: '1px solid rgba(255,255,255,0.14)',
-    titleColor: '#ffffff',
+    background: THEME_SURFACES.cardBg,
+    border: THEME_SURFACES.cardBorder,
+    titleColor: THEME_TEXT.primary,
 }
 
 export function IconBadge({ children, size = 'lg' }) {
@@ -26,7 +28,7 @@ export function IconBadge({ children, size = 'lg' }) {
                 display: 'inline-flex',
                 alignItems: 'center',
                 justifyContent: 'center',
-                background: 'rgba(233,30,140,0.15)',
+                background: THEME_SURFACES.badgeBg,
                 borderRadius: '12px',
                 padding: pad,
                 marginBottom: size === 'lg' ? '0.6rem' : 0,

--- a/lib/theme-constants.js
+++ b/lib/theme-constants.js
@@ -1,0 +1,34 @@
+/**
+ * Centralized theme constants and design tokens.
+ *
+ * Consolidates inline colors, surface transparencies, glass borders, and text tokens
+ * across Dashboard, Insights, Self-Care, and shared UI components.
+ */
+
+export const THEME_COLORS = {
+  pink: '#e8527e',
+  mauve: '#9d3f7a',
+  accent: '#e91e8c',
+  roseBright: '#c25c8b',
+  roseDeep: '#c9375f',
+  emerald: '#6ee7b7',
+  lavender: '#a98bff',
+  noticeAmber: '#92400e',
+};
+
+export const THEME_SURFACES = {
+  cardBg: 'rgba(255, 255, 255, 0.08)',
+  cardBgSubtle: 'rgba(255, 255, 255, 0.06)',
+  cardBorder: '1px solid rgba(255, 255, 255, 0.14)',
+  cardBorderSubtle: '1px solid rgba(255, 255, 255, 0.10)',
+  cardRadius: 16,
+  badgeBg: 'rgba(233, 30, 140, 0.15)',
+  tooltipBg: 'rgba(30, 12, 40, 0.95)',
+};
+
+export const THEME_TEXT = {
+  primary: '#ffffff',
+  soft: '#d9c7d2',
+  faint: 'rgba(255, 255, 255, 0.65)',
+  muted: 'rgba(255, 255, 255, 0.72)',
+};


### PR DESCRIPTION
## Linked Issue
Fixes #610

## Description
Extracted hardcoded color values, surface transparencies, glass borders, and typography tokens into a centralized module `lib/theme-constants.js`.

- Standardizes `THEME_COLORS`, `THEME_SURFACES`, and `THEME_TEXT` tokens.
- Refactors `SectionCard.jsx` and `app/[locale]/insights/page.js` to eliminate token duplication.

## Type of Change
- [ ] Bug fix
- [x] Refactoring
- [ ] Code quality

## Checklist
- [x] Linked issue using `Fixes #610`.
- [x] Added ECSoc26 label.