### PR TITLE
[ECSoC26] [CODE QUALITY] Add JSDoc type definitions and prop validation for key dashboard components

### DIFF
--- a/components/dashboard/CycleCalendar.jsx
+++ b/components/dashboard/CycleCalendar.jsx
@@ -1,22 +1,34 @@
 import { useTranslations, useLocale } from 'next-intl'
 import { useRef, useState } from 'react'
 /**
- * CycleCalendar — renders a monthly grid with period/ovulation/predicted/today markers.
- *
- * Props (two modes, both supported):
- *  MODE A — pre-built array (current):
- *    calendarDays: Array<{ type: 'header'|'empty'|'normal'|'period'|'ovulation'|'predicted'|'today', label, isToday? }>
- *
- *  MODE B — explicit date Sets (new, as requested):
- *    periodDays:    Set<'YYYY-MM-DD'>
- *    ovulationDays: Set<'YYYY-MM-DD'>
- *    predictedDays: Set<'YYYY-MM-DD'>
- *    today:         'YYYY-MM-DD'
- *    viewYear:      number
- *    viewMonth:     number   (0-indexed)
- *
- *  Shared props:
- *    currentMonth, onPrevMonth, onNextMonth, averageCycleLength, daysUntilNext, activeLang
+ * @typedef {object} CalendarDayItem
+ * @property {'header'|'empty'|'normal'|'period'|'ovulation'|'predicted'|'today'} type
+ * @property {string|number} label
+ * @property {boolean} [isToday]
+ * @property {string} [iso]
+ */
+
+/**
+ * @typedef {object} CycleCalendarProps
+ * @property {CalendarDayItem[]} [calendarDays] Pre-built calendar day cells
+ * @property {Set<string>} [periodDays] Set of ISO dates for menstrual period days
+ * @property {Set<string>} [ovulationDays] Set of ISO dates for fertile window days
+ * @property {Set<string>} [predictedDays] Set of ISO dates for predicted future cycle days
+ * @property {string} [today] Current ISO date (YYYY-MM-DD)
+ * @property {number} [viewYear] Currently displayed calendar year
+ * @property {number} [viewMonth] Currently displayed calendar month index (0-11)
+ * @property {string} [currentMonth] Human-readable current month title
+ * @property {() => void} [onPrevMonth] Handler for previous month button
+ * @property {() => void} [onNextMonth] Handler for next month button
+ * @property {number} [averageCycleLength] Average cycle duration in days
+ * @property {number|null} [daysUntilNext] Days remaining until the next predicted cycle
+ * @property {(isoDate: string) => void} [onDayClick] Callback when clicking a date cell
+ * @property {string|null} [selectedDate] Currently active ISO date
+ */
+
+/**
+ * CycleCalendar renders a monthly grid with period, ovulation, predicted, and today markers.
+ * @param {CycleCalendarProps} props
  */
 export default function CycleCalendar({
   // Mode A
@@ -29,13 +41,13 @@ export default function CycleCalendar({
   viewYear,
   viewMonth,
   // Shared
-  currentMonth,
-  onPrevMonth,
-  onNextMonth,
-  averageCycleLength,
-  daysUntilNext,
-  onDayClick,
-  selectedDate
+  currentMonth = '',
+  onPrevMonth = () => {},
+  onNextMonth = () => {},
+  averageCycleLength = 28,
+  daysUntilNext = null,
+  onDayClick = () => {},
+  selectedDate = null
 }) {
   const t = useTranslations('cycle')
   const locale = useLocale()

--- a/components/dashboard/DailyLogPanel.jsx
+++ b/components/dashboard/DailyLogPanel.jsx
@@ -16,15 +16,31 @@ const symptomIcons = {
   Nausea: "🤢"
 }
 
+/**
+ * @typedef {object} DailyLogPanelProps
+ * @property {string[]} [selectedSymptoms] Array of selected symptom names
+ * @property {(symptom: string) => void} [toggleSymptom] Callback to toggle a symptom selection
+ * @property {string|null} [selectedMood] Currently selected mood emoji
+ * @property {(mood: string|null) => void} [setSelectedMood] Callback to update selected mood
+ * @property {string|null} [selectedFlow] Currently selected flow intensity
+ * @property {(flow: string|null) => void} [setSelectedFlow] Callback to update selected flow
+ * @property {() => void} [handleSaveLog] Callback to save the daily log
+ * @property {object} [cycleData] User's current cycle information
+ */
+
+/**
+ * DailyLogPanel renders interactive controls for tracking symptoms, mood, and flow.
+ * @param {DailyLogPanelProps} props
+ */
 export default function DailyLogPanel({
-  selectedSymptoms,
-  toggleSymptom,
-  selectedMood,
-  setSelectedMood,
-  selectedFlow,
-  setSelectedFlow,
-  handleSaveLog,
-  cycleData
+  selectedSymptoms = [],
+  toggleSymptom = () => {},
+  selectedMood = null,
+  setSelectedMood = () => {},
+  selectedFlow = null,
+  setSelectedFlow = () => {},
+  handleSaveLog = () => {},
+  cycleData = null
 }) {
   const t = useTranslations('log')
   const tSymp = useTranslations('symptoms')

--- a/components/dashboard/DayLogDrawer.jsx
+++ b/components/dashboard/DayLogDrawer.jsx
@@ -10,7 +10,26 @@ import { isEncryptionFailure } from '@/lib/encryption-policy'
 import { toISODate } from '@/lib/date-utils'
 import useModalA11y from '@/lib/a11y/useModalA11y'
 
-export default function DayLogDrawer({ isOpen, onClose, selectedDate, cycleData, onSaved }) {
+/**
+ * @typedef {object} DayLogDrawerProps
+ * @property {boolean} isOpen Whether the drawer is currently open
+ * @property {() => void} onClose Callback when closing the drawer
+ * @property {string|null} selectedDate Currently selected ISO date (YYYY-MM-DD)
+ * @property {object} [cycleData] User's current cycle information
+ * @property {() => void} [onSaved] Callback invoked after saving log changes
+ */
+
+/**
+ * DayLogDrawer slides out to view, edit, or delete a daily symptom log.
+ * @param {DayLogDrawerProps} props
+ */
+export default function DayLogDrawer({
+  isOpen = false,
+  onClose = () => {},
+  selectedDate = null,
+  cycleData = null,
+  onSaved = () => {}
+}) {
   const tTrack = useTranslations('pages.track')
   const locale = useLocale()
   const { offlineClient } = useOffline()


### PR DESCRIPTION
## Linked Issue
Fixes #613

## Description
Added comprehensive JSDoc `@typedef` type annotations and defensive prop defaults across key dashboard components:
- `CycleCalendar.jsx`
- `DailyLogPanel.jsx`
- `DayLogDrawer.jsx`

Enhances IDE IntelliSense, type safety, and prevents null-pointer exceptions.

## Type of Change
- [ ] Bug fix
- [x] Code quality
- [x] Refactoring

## Checklist
- [x] Linked issue using `Fixes #613`.
- [x] Added ECSoc26 label.