### PR TITLE
[ECSoC26]  Fix: Prevent MISSING_MESSAGE crash in PCODRiskCard for unmatched factor text

### DIFF
--- a/components/dashboard/PCODRiskCard.jsx
+++ b/components/dashboard/PCODRiskCard.jsx
@@ -250,10 +250,10 @@ export default function PCODRiskCard({ pcodRisk, unavailableReason = null, loadi
 
       {/* Contributing factors from API */}
       <ul className="risk-factors">
-        {factors.length > 0
+                {factors.length > 0
           ? factors.map((f, i) => (
               <li key={i} style={{ '--dot-color': tokens.dotColor }}>
-                {tFactors(f)}
+                {tFactors.has(f) ? tFactors(f) : f}
               </li>
             ))
           : (
@@ -276,11 +276,11 @@ export default function PCODRiskCard({ pcodRisk, unavailableReason = null, loadi
           border:     '1px solid rgba(255,255,255,0.07)',
           lineHeight: 1.55,
         }}>
-          💡 {tRec(
-            recommendation.includes('consulting') ? 'consult' :
-            recommendation.includes('Keep tracking') ? 'keepTracking' :
+                   💡 {
+            recommendation.includes('consulting') ? tRec('consult') :
+            recommendation.includes('Keep tracking') ? tRec('keepTracking') :
             recommendation
-          )}
+          }
         </p>
       )}
 

--- a/messages/en.json
+++ b/messages/en.json
@@ -229,7 +229,10 @@
     "Multiple PCOD-related symptoms reported": "Multiple PCOD-related symptoms reported",
     "Some hormonal symptoms present": "Some hormonal symptoms present",
     "Regular cycle length maintained": "Regular cycle length maintained",
-    "No significant hormonal symptoms": "No significant hormonal symptoms"
+    "No significant hormonal symptoms": "No significant hormonal symptoms",
+    "Mild hormonal symptom noted": "Mild hormonal symptom noted",
+    "High symptom recurrence detected across 90-day window": "High symptom recurrence detected across 90-day window",
+    "Persistent recurrence of PCOD-related symptoms over 90 days": "Persistent recurrence of PCOD-related symptoms over 90 days"
   },
   "recommendations": {
     "consult": "Consider consulting with a healthcare provider for detailed assessment.",

--- a/messages/hi.json
+++ b/messages/hi.json
@@ -229,7 +229,10 @@
     "Multiple PCOD-related symptoms reported": "PCOD से संबंधित कई लक्षण बताए गए",
     "Some hormonal symptoms present": "कुछ हार्मोनल लक्षण मौजूद हैं",
     "Regular cycle length maintained": "नियमित चक्र अवधि बनी हुई है",
-    "No significant hormonal symptoms": "कोई महत्वपूर्ण हार्मोनल लक्षण नहीं"
+    "No significant hormonal symptoms": "कोई महत्वपूर्ण हार्मोनल लक्षण नहीं",
+    "Mild hormonal symptom noted": "हल्के हार्मोनल लक्षण देखे गए",
+"High symptom recurrence detected across 90-day window": "90 दिनों की अवधि में उच्च लक्षण पुनरावृत्ति का पता चला",
+"Persistent recurrence of PCOD-related symptoms over 90 days": "90 दिनों में PCOD-संबंधित लक्षणों की लगातार पुनरावृत्ति"
   },
   "recommendations": {
     "consult": "विस्तृत मूल्यांकन के लिए स्वास्थ्य सेवा प्रदाता से परामर्श करने पर विचार करें।",


### PR DESCRIPTION
Fixes #624

Description
PCODRiskCard.jsx was using next-intl's translation function directly on 
raw backend-generated strings (both risk "factors" and the "recommendation" 
text), treating them as if they were fixed, pre-registered translation 
keys. When the backend returned any string not already listed in 
messages/en.json's "factors" object — e.g. "Mild hormonal symptom noted" — 
next-intl threw MISSING_MESSAGE and crashed the component's render, taking 
down the Dashboard/Insights page with it.

What changed
1. factors list: now checks tFactors.has(f) before translating — if the 
   key exists, translate normally; if not, fall back to showing the raw 
   backend string instead of crashing. This makes the crash impossible 
   going forward, even for factor strings not yet anticipated.
2. recommendation text: found the same fragile pattern here too (an 
   if/else falling through to passing the raw string into tRec() as a 
   key) — same class of bug, just not yet triggered. Fixed the same way: 
   only call tRec() when a known pattern matches, otherwise show the 
   text as-is.
3. messages/en.json: filled in 3 factor strings that were missing from 
   the file entirely (found by cross-referencing every string 
   lib/api-helpers.js can actually generate), so known factors now 
   render as proper translated text rather than relying on the new 
   fallback.

Why this approach
Considered restructuring factors from string[] into {id, params}[] with 
stable short keys (the more "correct" long-term i18n pattern), but that 
would touch the risk-calculation logic, both translation files, the 
component, and two test files that assert on the current string format — 
a much larger change for the same underlying safety guarantee. The 
approach here fixes the crash permanently with a 2-file, low-risk change; 
the larger refactor could be a good follow-up if the team wants proper 
per-language interpolation for the two dynamic factor strings 
(recurring symptom list, consecutive-day list) — currently these will 
render in English regardless of locale if hit, since they contain 
interpolated data.

Type of Change
- Bug fix (non-breaking change which fixes an issue)

Testing
Confirmed on `main` (prior to my other PRs) that this crash is 
reproducible and unrelated to my other work. Applied the fix, reloaded 
the Dashboard, confirmed the PCOD risk card renders cleanly with no 
console error. npm run build completes successfully. npm run test:e2e — 
all 7 suites passing.

