### PR TITLE
[ECSoC26] Backend/Logic: Guard getLatestCycle against non-array inputs and invalid timestamps

### DIFF
--- a/lib/calculateCyclePhase.js
+++ b/lib/calculateCyclePhase.js
@@ -69,8 +69,18 @@ export function calculateCyclePhase({
 }
 
 export function getLatestCycle(cycles = []) {
+  if (!Array.isArray(cycles) || cycles.length === 0) {
+    return null
+  }
+
   return [...cycles]
-    .filter(cycle => cycle?.start_date || cycle?.period_start)
+    .filter(cycle => {
+      if (!cycle || typeof cycle !== 'object') return false
+      const rawDate = cycle.start_date || cycle.period_start
+      if (!rawDate) return false
+      const time = new Date(rawDate).getTime()
+      return !Number.isNaN(time)
+    })
     .sort((a, b) => {
       const aTime = new Date(a.start_date || a.period_start).getTime()
       const bTime = new Date(b.start_date || b.period_start).getTime()


### PR DESCRIPTION
## Linked Issue
Fixes #659

## Description
Added `Array.isArray(cycles)` validation and filtered out invalid date timestamps in `getLatestCycle` inside `lib/calculateCyclePhase.js`.

- Prevents `TypeError: cycles is not iterable` when `cycles` argument is null, undefined, or not an array.
- Ensures stable date sorting when cycle items contain missing or invalid date strings.

## Type of Change
- [x] Bug fix
- [x] Reliability

## Checklist
- [x] Linked issue using `Fixes #659`.
- [x] Added ECSoc26 label.