### PR TITLE
[ECSoC26] Frontend: Guard against NaN year keys in CycleHistoryCard group reducer

### DIFF
--- a/components/dashboard/CycleHistoryCard.jsx
+++ b/components/dashboard/CycleHistoryCard.jsx
@@ -9,16 +9,20 @@ export default function CycleHistoryCard({ cycleData }) {
   const t = useTranslations('CycleHistory');
   const [filter, setFilter] = useState('All');
   
-  const cycles = cycleData?.cycles || [];
+  const cycles = Array.isArray(cycleData?.cycles) ? cycleData.cycles : [];
   
-  // Sort cycles by start_date descending
-  const sortedCycles = [...cycles].sort((a, b) => new Date(b.start_date) - new Date(a.start_date));
+  // Sort valid cycles by start_date descending
+  const sortedCycles = [...cycles]
+    .filter(cycle => cycle && cycle.start_date && !Number.isNaN(new Date(cycle.start_date).getTime()))
+    .sort((a, b) => new Date(b.start_date) - new Date(a.start_date));
   
   // Group by year
   const groupedCycles = sortedCycles.reduce((acc, cycle) => {
     const year = new Date(cycle.start_date).getFullYear();
-    if (!acc[year]) acc[year] = [];
-    acc[year].push(cycle);
+    if (Number.isFinite(year)) {
+      if (!acc[year]) acc[year] = [];
+      acc[year].push(cycle);
+    }
     return acc;
   }, {});
 


### PR DESCRIPTION
## Linked Issue
Fixes #660

## Description
Guarded cycle year extraction against malformed dates and invalid year values in `CycleHistoryCard.jsx`.

- Filters cycles without valid `start_date` before sorting and grouping.
- Validates that `year` is a finite number before inserting into `groupedCycles`.

## Type of Change
- [x] Bug fix
- [x] Reliability

## Checklist
- [x] Linked issue using `Fixes #660`.
- [x] Added ECSoc26 label.