### PR TITLE
[ECSoC26] Frontend: Replace dangerouslySetInnerHTML style tag with CSS class in HorizontalScroll

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -3728,3 +3728,12 @@ nav ul li a:focus-visible,
   scrollbar-gutter: stable;
   overflow-y: auto;
 }
+
+/* ──── HORIZONTAL SCROLLBAR HIDING CLASS (Fixes #661) ──── */
+.self-care-scroll::-webkit-scrollbar {
+  display: none;
+}
+.self-care-scroll {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}

--- a/components/self-care/HorizontalScroll.jsx
+++ b/components/self-care/HorizontalScroll.jsx
@@ -6,23 +6,12 @@ export default function HorizontalScroll({ children, className = '' }) {
   const scrollRef = useRef(null);
 
   return (
-    <>
-      <div 
-        ref={scrollRef}
-        className={`flex overflow-x-auto gap-4 py-4 -mt-4 snap-x snap-mandatory self-care-scroll ${className}`}
-        style={{ scrollBehavior: 'smooth', WebkitOverflowScrolling: 'touch' }}
-      >
-        {children}
-      </div>
-      <style dangerouslySetInnerHTML={{__html: `
-        .self-care-scroll::-webkit-scrollbar {
-          display: none;
-        }
-        .self-care-scroll {
-          -ms-overflow-style: none;
-          scrollbar-width: none;
-        }
-      `}} />
-    </>
+    <div 
+      ref={scrollRef}
+      className={`flex overflow-x-auto gap-4 py-4 -mt-4 snap-x snap-mandatory self-care-scroll ${className}`}
+      style={{ scrollBehavior: 'smooth', WebkitOverflowScrolling: 'touch' }}
+    >
+      {children}
+    </div>
   );
 }


### PR DESCRIPTION
## Linked Issue
Fixes #661

## Description
Replaced inline `<style dangerouslySetInnerHTML=...>` tag inside `HorizontalScroll.jsx` with centralized `.self-care-scroll` CSS definitions in `app/globals.css`.

- Eliminates duplicate DOM stylesheet elements on repeated component re-renders.
- Adheres strictly to Content Security Policy without requiring inline style exceptions.

## Type of Change
- [ ] Bug fix
- [x] Refactoring
- [x] Code quality

## Checklist
- [x] Linked issue using `Fixes #661`.
- [x] Added ECSoc26 label.