### PR TITLE
[ECSoC26] fix: Symptom Analysis Can Crash When symptoms Is Not an Array

### DIFF
--- a/app/[locale]/insights/page.js
+++ b/app/[locale]/insights/page.js
@@ -177,8 +177,13 @@ const [cycleData, setCycleData] = useState(null)
   SYMPTOM_LIST.forEach(s => { symptomCounts[s] = 0 })
   dailyLogs.forEach(log => {
     if (!log) return
-    const syms = Array.isArray(log.symptoms) ? log.symptoms : []
+    const syms = Array.isArray(log.symptoms)
+      ? log.symptoms
+      : typeof log.symptoms === 'string' && log.symptoms.trim()
+        ? [log.symptoms.trim()]
+        : []
     syms.forEach(s => {
+      if (typeof s !== 'string') return
       const key = SYMPTOM_LIST.find(k => k.toLowerCase() === s.toLowerCase())
       if (key) symptomCounts[key] = (symptomCounts[key] || 0) + 1
     })
@@ -253,8 +258,13 @@ const [cycleData, setCycleData] = useState(null)
     if (!log || !log.date) return
     const logDate = new Date(log.date)
     if (isNaN(logDate.getTime()) || logDate < thirtyDaysAgo) return
-    const syms = Array.isArray(log.symptoms) ? log.symptoms : []
+    const syms = Array.isArray(log.symptoms)
+      ? log.symptoms
+      : typeof log.symptoms === 'string' && log.symptoms.trim()
+        ? [log.symptoms.trim()]
+        : []
     syms.forEach(s => {
+      if (typeof s !== 'string') return
       const key = SYMPTOM_LIST.find(k => k.toLowerCase() === s.toLowerCase())
       if (key) recentSymptomNames.add(tSymp(key))
     })

--- a/app/[locale]/partner/page.js
+++ b/app/[locale]/partner/page.js
@@ -323,17 +323,24 @@ export default function PartnerPage() {
                   </div>
                   <h2 className="text-lg font-semibold text-white">Today&apos;s Symptoms</h2>
                 </div>
-                {insights.symptoms && insights.symptoms.length > 0 ? (
-                  <div className="flex flex-wrap gap-2">
-                    {insights.symptoms.map((sym, i) => (
-                      <span key={i} className="bg-white/10 px-3 py-1 rounded-full text-sm text-white">
-                        {sym}
-                      </span>
-                    ))}
-                  </div>
-                ) : (
-                  <p className="text-white/50 text-sm italic">No symptoms logged today</p>
-                )}
+                {(() => {
+                  const partnerSymptoms = Array.isArray(insights?.symptoms)
+                    ? insights.symptoms
+                    : typeof insights?.symptoms === 'string' && insights.symptoms.trim()
+                      ? [insights.symptoms.trim()]
+                      : []
+                  return partnerSymptoms.length > 0 ? (
+                    <div className="flex flex-wrap gap-2">
+                      {partnerSymptoms.map((sym, i) => (
+                        <span key={i} className="bg-white/10 px-3 py-1 rounded-full text-sm text-white">
+                          {sym}
+                        </span>
+                      ))}
+                    </div>
+                  ) : (
+                    <p className="text-white/50 text-sm italic">No symptoms logged today</p>
+                  )
+                })()}
               </div>
             )}
 

--- a/app/api/partner-coach/route.js
+++ b/app/api/partner-coach/route.js
@@ -9,8 +9,14 @@ const COACH_FALLBACKS = {
   Luteal: "Progesterone is high, which can cause fatigue, bloating, or emotional sensitivity. Be extra patient, offer soothing hugs, and avoid overwhelming plans."
 }
 
-async function callGeminiCoach(query, phase, cycleDay, symptoms, history = []) {
+async function callGeminiCoach(query, phase, cycleDay, rawSymptoms, history = []) {
   if (!process.env.GEMINI_API_KEY) return null
+
+  const safeSymptoms = Array.isArray(rawSymptoms)
+    ? rawSymptoms.filter((s) => typeof s === 'string' && s.trim())
+    : typeof rawSymptoms === 'string' && rawSymptoms.trim()
+      ? [rawSymptoms.trim()]
+      : []
 
   try {
     const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY)
@@ -20,7 +26,7 @@ async function callGeminiCoach(query, phase, cycleDay, symptoms, history = []) {
 Current Context:
 - Cycle Phase: ${phase}
 - Cycle Day: ${cycleDay}
-- Active Symptoms: ${symptoms.length > 0 ? symptoms.join(', ') : 'None reported'}
+- Active Symptoms: ${safeSymptoms.length > 0 ? safeSymptoms.join(', ') : 'None reported'}
 
 Guidelines:
 - Provide concise (2-4 sentences max), warm, actionable, and supportive advice tailored for a partner.
@@ -54,10 +60,16 @@ export async function POST(req) {
     }
     const { phase = 'Follicular', cycleDay = 1, symptoms = [], query = '' } = parsedBody
 
+    const safeSymptoms = Array.isArray(symptoms)
+      ? symptoms.filter((s) => typeof s === 'string' && s.trim())
+      : typeof symptoms === 'string' && symptoms.trim()
+        ? [symptoms.trim()]
+        : []
+
     // 1. Initial Briefing request (no query)
     if (!query || !query.trim()) {
       const defaultBriefing = COACH_FALLBACKS[phase] || COACH_FALLBACKS.Follicular
-      const extraSymptoms = symptoms.length > 0 ? ` Active symptoms logged today: ${symptoms.join(', ')}.` : ''
+      const extraSymptoms = safeSymptoms.length > 0 ? ` Active symptoms logged today: ${safeSymptoms.join(', ')}.` : ''
       return NextResponse.json({
         reply: `${defaultBriefing}${extraSymptoms}`,
         phase,
@@ -66,7 +78,7 @@ export async function POST(req) {
     }
 
     // 2. Chatbot Question: Attempt Gemini AI
-    const geminiReply = await callGeminiCoach(query, phase, cycleDay, symptoms)
+    const geminiReply = await callGeminiCoach(query, phase, cycleDay, safeSymptoms)
     if (geminiReply) {
       return NextResponse.json({ reply: geminiReply, phase, cycleDay })
     }

--- a/components/dashboard/DailyLogPanel.jsx
+++ b/components/dashboard/DailyLogPanel.jsx
@@ -55,9 +55,14 @@ export default function DailyLogPanel({
   // actually enforces it.
   const MAX_CUSTOM_SYMPTOM_LENGTH = 50
   const MAX_CUSTOM_SYMPTOMS = 20
+  const safeSelectedSymptoms = Array.isArray(selectedSymptoms)
+    ? selectedSymptoms
+    : typeof selectedSymptoms === 'string' && selectedSymptoms.trim()
+      ? [selectedSymptoms.trim()]
+      : []
 
   const baseSymptoms = ['Cramps', 'Headache', 'Bloating', 'Fatigue', 'Acne', 'Nausea']
-  const customSymptoms = selectedSymptoms.filter(s => !baseSymptoms.includes(s))
+  const customSymptoms = safeSelectedSymptoms.filter(s => !baseSymptoms.includes(s))
   const allDisplaySymptoms = [...baseSymptoms, ...customSymptoms]
 
   const handleAddCustom = (e) => {
@@ -65,7 +70,7 @@ export default function DailyLogPanel({
     const trimmed = customInput.trim().slice(0, MAX_CUSTOM_SYMPTOM_LENGTH)
     if (!trimmed) return
     if (customSymptoms.length >= MAX_CUSTOM_SYMPTOMS) return
-    if (!selectedSymptoms.includes(trimmed)) {
+    if (!safeSelectedSymptoms.includes(trimmed)) {
       toggleSymptom(trimmed)
     }
     setCustomInput('')
@@ -83,7 +88,7 @@ export default function DailyLogPanel({
 
         <div className="symp-grid symp-grid-scroll-wrapper">
           {allDisplaySymptoms.map(symptom => {
-            const active = selectedSymptoms.includes(symptom)
+            const active = safeSelectedSymptoms.includes(symptom)
             const isCustom = !baseSymptoms.includes(symptom)
             const icon = symptomIcons[symptom] || "📌"
 
@@ -150,9 +155,9 @@ export default function DailyLogPanel({
           <span>Selected Today</span>
 
           <strong>
-            {selectedSymptoms.length === 0
+            {safeSelectedSymptoms.length === 0
               ? 'None'
-              : `${selectedSymptoms.length} Selected`}
+              : `${safeSelectedSymptoms.length} Selected`}
           </strong>
         </div>
       </div>

--- a/lib/partner-insights.js
+++ b/lib/partner-insights.js
@@ -40,7 +40,11 @@ export function getBiologicalPhaseContext(phase) {
 
 export function getActionableCareTips(phase, symptoms = [], flow = null) {
   const tips = []
-  const safeSymptoms = Array.isArray(symptoms) ? symptoms.filter(s => typeof s === 'string') : []
+  const safeSymptoms = Array.isArray(symptoms)
+    ? symptoms.filter(s => typeof s === 'string')
+    : typeof symptoms === 'string' && symptoms.trim()
+      ? [symptoms.trim()]
+      : []
 
   // Severe symptom callout tip
   if (safeSymptoms.some(s => s.toLowerCase().includes('cramp'))) {
@@ -113,7 +117,11 @@ export function calculateEnergyBattery(phase, cycleDay, symptoms = []) {
   }
 
   // Symptom deductions
-  const safeSymptoms = Array.isArray(symptoms) ? symptoms.filter(s => typeof s === 'string') : []
+  const safeSymptoms = Array.isArray(symptoms)
+    ? symptoms.filter(s => typeof s === 'string')
+    : typeof symptoms === 'string' && symptoms.trim()
+      ? [symptoms.trim()]
+      : []
   if (safeSymptoms.some(s => s.toLowerCase().includes('fatigue'))) baseEnergy -= 20
   if (safeSymptoms.some(s => s.toLowerCase().includes('cramp'))) baseEnergy -= 15
   if (safeSymptoms.some(s => s.toLowerCase().includes('headache'))) baseEnergy -= 15

--- a/lib/symptom-correlation.js
+++ b/lib/symptom-correlation.js
@@ -101,6 +101,48 @@ export const CONFIDENCE = {
 }
 
 /**
+ * Safely normalises any symptoms input into an array of strings.
+ * Handles arrays, single strings, JSON stringified arrays, comma-separated strings,
+ * Postgres array string literals, and invalid non-array types (null, undefined, numbers, objects).
+ *
+ * @param {unknown} raw
+ * @returns {string[]}
+ */
+export function normalizeSymptomsList(raw) {
+  if (Array.isArray(raw)) {
+    return raw.filter((item) => typeof item === 'string' || typeof item === 'number')
+  }
+  if (typeof raw === 'string') {
+    const trimmed = raw.trim()
+    if (!trimmed) return []
+    if (trimmed.startsWith('[') && trimmed.endsWith(']')) {
+      try {
+        const parsed = JSON.parse(trimmed)
+        if (Array.isArray(parsed)) return parsed.filter((item) => typeof item === 'string' || typeof item === 'number')
+      } catch {}
+    }
+    if (trimmed.startsWith('{') && trimmed.endsWith('}')) {
+      return trimmed
+        .slice(1, -1)
+        .split(',')
+        .map((s) => s.trim().replace(/^"(.*)"$/, '$1'))
+        .filter(Boolean)
+    }
+    if (trimmed.includes(',')) {
+      return trimmed.split(',').map((s) => s.trim()).filter(Boolean)
+    }
+    return [trimmed]
+  }
+  if (raw && typeof raw === 'object') {
+    const values = Object.values(raw)
+    if (values.length > 0 && values.every((v) => typeof v === 'string' || typeof v === 'number')) {
+      return values
+    }
+  }
+  return []
+}
+
+/**
  * Normalises a symptom name for grouping.
  *
  * Symptoms arrive from three places — the fixed tracker list, the custom
@@ -195,12 +237,19 @@ export function attributeLogsToPhases(dailyLogs, cycles, fallbackCycleLength = 2
   const days = []
   let skipped = 0
 
-  const sortedCycles = (Array.isArray(cycles) ? cycles : [])
+  const safeCycles = Array.isArray(cycles)
+    ? cycles
+    : (cycles && typeof cycles === 'object' ? [cycles] : [])
+  const sortedCycles = safeCycles
     .filter((cycle) => cycle && toLocalDay(cycle.start_date))
     .sort((a, b) => toLocalDay(a.start_date) - toLocalDay(b.start_date))
 
+  const safeDailyLogs = Array.isArray(dailyLogs)
+    ? dailyLogs
+    : (dailyLogs && typeof dailyLogs === 'object' ? [dailyLogs] : [])
+
   if (sortedCycles.length === 0) {
-    return { days, exposure, totalDays: 0, skipped: Array.isArray(dailyLogs) ? dailyLogs.length : 0 }
+    return { days, exposure, totalDays: 0, skipped: safeDailyLogs.length }
   }
 
   // A day can be logged more than once in the data (a duplicate row, an
@@ -208,7 +257,7 @@ export function attributeLogsToPhases(dailyLogs, cycles, fallbackCycleLength = 2
   // exposure and the occurrence count for that phase, so days are de-duplicated
   // by calendar date, last write winning.
   const byDate = new Map()
-  for (const log of Array.isArray(dailyLogs) ? dailyLogs : []) {
+  for (const log of safeDailyLogs) {
     if (!log || !log.date) { skipped += 1; continue }
     const key = String(log.date).slice(0, 10)
     byDate.set(key, log)
@@ -233,9 +282,8 @@ export function attributeLogsToPhases(dailyLogs, cycles, fallbackCycleLength = 2
     // over-report.
     if (!hasData || !PHASES.includes(phaseKey)) { skipped += 1; continue }
 
-    const symptoms = Array.isArray(log.symptoms)
-      ? Array.from(new Set(log.symptoms.map(normaliseSymptomName).filter(Boolean)))
-      : []
+    const rawSymptoms = normalizeSymptomsList(log.symptoms)
+    const symptoms = Array.from(new Set(rawSymptoms.map(normaliseSymptomName).filter(Boolean)))
 
     exposure[phaseKey] += 1
     days.push({ phase: phaseKey, symptoms })
@@ -364,7 +412,8 @@ export function analyseSymptomPhases(dailyLogs, cycles, options = {}) {
   // Occurrences per symptom per phase.
   const counts = new Map()
   for (const day of days) {
-    for (const symptom of day.symptoms) {
+    const daySymptoms = Array.isArray(day?.symptoms) ? day.symptoms : []
+    for (const symptom of daySymptoms) {
       if (!counts.has(symptom)) {
         counts.set(symptom, Object.fromEntries(PHASES.map((phase) => [phase, 0])))
       }

--- a/scripts/test-symptom-correlation.js
+++ b/scripts/test-symptom-correlation.js
@@ -35,6 +35,7 @@ import {
   describePattern,
   gradeConfidence,
   normaliseSymptomName,
+  normalizeSymptomsList,
   toDisplayName,
 } from '../lib/symptom-correlation.js'
 
@@ -125,6 +126,16 @@ section('symptom name normalisation')
   check(toDisplayName('cramps'), 'Cramps', 'display form is title-cased')
   check(toDisplayName('back pain'), 'Back Pain', 'every word is title-cased')
   check(toDisplayName(''), '', 'an empty name has an empty display form')
+
+  // normalizeSymptomsList normalises non-array inputs into valid string arrays
+  checkDeep(normalizeSymptomsList(['Cramps', 'Headache']), ['Cramps', 'Headache'], 'arrays pass through')
+  checkDeep(normalizeSymptomsList('Cramps'), ['Cramps'], 'single string is wrapped in an array')
+  checkDeep(normalizeSymptomsList('Cramps, Headache'), ['Cramps', 'Headache'], 'comma-separated string is split')
+  checkDeep(normalizeSymptomsList('["Cramps", "Headache"]'), ['Cramps', 'Headache'], 'JSON array string is parsed')
+  checkDeep(normalizeSymptomsList('{Cramps,Headache}'), ['Cramps', 'Headache'], 'Postgres array string is parsed')
+  checkDeep(normalizeSymptomsList(null), [], 'null returns empty array')
+  checkDeep(normalizeSymptomsList(undefined), [], 'undefined returns empty array')
+  checkDeep(normalizeSymptomsList(123), [], 'number returns empty array')
 }
 
 /* ────────────────────────────────────────────────────────────────────────────
@@ -453,8 +464,15 @@ section('empty and degenerate inputs')
   const nulls = analyseSymptomPhases(null, null)
   check(nulls.totalDays, 0, 'null inputs are handled without throwing')
 
+  const singleString = analyseSymptomPhases(
+    [{ date: '2026-07-02', symptoms: 'Cramps' }],
+    CYCLES
+  )
+  check(singleString.totalDays, 1, 'single string symptoms field counts as exposure')
+  check(singleString.symptoms[0].symptom, 'cramps', 'a single string symptoms field is parsed into a valid symptom')
+
   const junkSymptoms = analyseSymptomPhases(
-    [{ date: '2026-07-02', symptoms: 'Cramps' }, { date: '2026-07-03', symptoms: [null, 7, ''] }],
+    [{ date: '2026-07-02', symptoms: 123 }, { date: '2026-07-03', symptoms: [null, 7, ''] }],
     CYCLES
   )
   check(


### PR DESCRIPTION
Key Changes
Added normalizeSymptomsList(raw) helper in symptom-correlation.js
:

Safely parses and normalizes non-array symptoms inputs (single strings, JSON arrays, Postgres array literals, comma-separated lists) into valid arrays of string symptom names.
Prevents null, numbers, booleans, and invalid objects from throwing during phase attribution and analysis.
Guarded day.symptoms in analyseSymptomPhases with Array.isArray(day?.symptoms) ? day.symptoms : [].
Updated API and Server Actions:


app/api/partner-coach/route.js: Coerced input symptoms to safeSymptoms array before calling .length and .join().


lib/partner-insights.js: Ensured getActionableCareTips and calculateEnergyBattery accept single string symptoms as well as array lists.
Updated UI Components & Pages:



app/[locale]/partner/page.js: Coerced insights.symptoms to partnerSymptoms array before calling .map().


app/[locale]/insights/page.js: Coerced log.symptoms safely before calculating frequency counts and recent symptoms text.


closes #164