### PR TITLE
[ECSoC26] [BACKEND] Gracefully handle database connection timeouts and pooling errors in getSupabaseAdmin

### DIFF
--- a/lib/supabase-admin.js
+++ b/lib/supabase-admin.js
@@ -1,5 +1,6 @@
 import { createClient } from '@supabase/supabase-js'
 import { validateEnv } from './env.js'
+import { logger } from './logger.js'
 
 /**
  * Returns a Supabase client initialized with the service role key (or anon key).
@@ -125,9 +126,170 @@ export function getSupabaseAdmin() {
     auth: {
       persistSession: false,
       autoRefreshToken: false,
-    }
+    },
+    db: {
+      schema: 'public',
+    },
   })
 
   return supabaseAdminClient;
+}
+
+/**
+ * Classifies a Supabase/Postgres error into a category, so callers and logs
+ * can distinguish "the network is having a bad day, retry" from "the
+ * credentials are wrong" from "the schema doesn't match what we expect" —
+ * three very different problems that all used to surface as an identical
+ * unhandled exception and a generic 500.
+ *
+ * @param {any} error
+ * @returns {'timeout'|'auth'|'schema'|'unknown'}
+ */
+function classifySupabaseError(error) {
+  if (!error) return 'unknown'
+  const message = String(error?.message || error).toLowerCase()
+  const code = error?.code
+
+  if (
+    message.includes('timeout') ||
+    message.includes('econnreset') ||
+    message.includes('etimedout') ||
+    message.includes('fetch failed') ||
+    message.includes('network')
+  ) {
+    return 'timeout'
+  }
+
+  if (
+    code === '28P01' || // invalid_password
+    code === '28000' || // invalid_authorization_specification
+    message.includes('jwt') ||
+    message.includes('unauthorized') ||
+    message.includes('invalid api key') ||
+    message.includes('permission denied')
+  ) {
+    return 'auth'
+  }
+
+  if (
+    code === '42P01' || // undefined_table
+    code === '42703' || // undefined_column
+    message.includes('relation') && message.includes('does not exist') ||
+    message.includes('column') && message.includes('does not exist')
+  ) {
+    return 'schema'
+  }
+
+  return 'unknown'
+}
+
+/**
+ * Whether a classified error is worth retrying. Timeouts are transient and
+ * often succeed on a second attempt; auth and schema problems will not
+ * change no matter how many times they're retried, so retrying them only
+ * delays a response the caller could have had immediately.
+ *
+ * @param {'timeout'|'auth'|'schema'|'unknown'} kind
+ * @returns {boolean}
+ */
+function isRetryable(kind) {
+  return kind === 'timeout' || kind === 'unknown'
+}
+
+/**
+ * Runs a Supabase query with a timeout and a small number of retries for
+ * transient failures, logging a structured, classified error via `logger`
+ * either way.
+ *
+ * This does not change what a successful call returns — it wraps the same
+ * `{ data, error }` shape Supabase always returns, so existing call sites
+ * (`const { data, error } = await supabaseAdmin.from(...)...`) keep working
+ * unchanged. It's meant for call sites that want the added timeout/retry
+ * protection; using it is opt-in, not required.
+ *
+ * @param {() => PromiseLike<{ data: any, error: any }>} queryFn a function
+ *   that returns the Supabase query builder call, e.g.
+ *   `() => supabaseAdmin.from('cycles').select('*')`
+ * @param {{ timeoutMs?: number, retries?: number, label?: string }} [options]
+ * @returns {Promise<{ data: any, error: any, friendlyError: string|null }>}
+ */
+export async function runSupabaseQuery(queryFn, options = {}) {
+  const timeoutMs = options.timeoutMs ?? 8000
+  const retries = options.retries ?? 2
+  const label = options.label || 'supabase_query'
+
+  let lastError = null
+
+  for (let attempt = 1; attempt <= retries + 1; attempt += 1) {
+    try {
+      const timeoutPromise = new Promise((_, reject) => {
+        setTimeout(() => reject(new Error(`Supabase query timed out after ${timeoutMs}ms`)), timeoutMs)
+      })
+
+      const result = await Promise.race([queryFn(), timeoutPromise])
+
+      if (result?.error) {
+        const kind = classifySupabaseError(result.error)
+        logger.error(`[${label}] Supabase query returned an error`, {
+          kind,
+          attempt,
+          message: result.error.message,
+          code: result.error.code,
+        })
+
+        if (isRetryable(kind) && attempt <= retries) {
+          lastError = result.error
+          await new Promise((r) => setTimeout(r, 200 * attempt))
+          continue
+        }
+
+        return {
+          data: result.data ?? null,
+          error: result.error,
+          friendlyError: toFriendlyMessage(kind),
+        }
+      }
+
+      return { data: result.data, error: null, friendlyError: null }
+    } catch (err) {
+      const kind = classifySupabaseError(err)
+      lastError = err
+      logger.error(`[${label}] Supabase query threw`, {
+        kind,
+        attempt,
+        message: err?.message,
+      })
+
+      if (isRetryable(kind) && attempt <= retries) {
+        await new Promise((r) => setTimeout(r, 200 * attempt))
+        continue
+      }
+
+      return { data: null, error: err, friendlyError: toFriendlyMessage(kind) }
+    }
+  }
+
+  return { data: null, error: lastError, friendlyError: toFriendlyMessage('timeout') }
+}
+
+/**
+ * Maps an error classification to a message safe to show a user — never the
+ * raw error stack or Postgres message, which can leak internal schema
+ * details.
+ *
+ * @param {'timeout'|'auth'|'schema'|'unknown'} kind
+ * @returns {string}
+ */
+function toFriendlyMessage(kind) {
+  switch (kind) {
+    case 'timeout':
+      return 'The database is taking longer than expected to respond. Please try again in a moment.'
+    case 'auth':
+      return 'A server configuration issue is preventing this request. Please contact support if this persists.'
+    case 'schema':
+      return 'A server configuration issue is preventing this request. Please contact support if this persists.'
+    default:
+      return 'Something went wrong while accessing the database. Please try again.'
+  }
 }
 


### PR DESCRIPTION
Fixes #593

Description
Added timeout handling, retry logic, and structured error classification 
for Supabase queries via a new opt-in helper, runSupabaseQuery(), in 
lib/supabase-admin.js:

- Wraps a query with a configurable timeout (default 8s), racing the 
  actual Supabase call against it
- Retries up to 2 times (configurable) on transient failures — network 
  errors, timeouts — with a short backoff between attempts
- Classifies every failure into timeout / auth / schema / unknown via 
  classifySupabaseError(), so logs distinguish "retry this" from 
  "credentials are wrong" from "the schema doesn't match", instead of 
  every failure looking identical
- Logs each classified failure through the existing lib/logger.js 
  (structured JSON, already redacts sensitive fields — no changes needed 
  there)
- Returns a safe, generic friendlyError message per category via 
  toFriendlyMessage(), never the raw Postgres error or stack trace

Scope note
lib/db.js was listed as a relevant file in the issue, but it's the 
browser-side IndexedDB offline-cache layer — unrelated to Supabase server 
connections. Left untouched.

runSupabaseQuery() is additive and opt-in: getSupabaseAdmin() itself is 
otherwise unchanged (only a minor db.schema config addition), and no 
existing API route currently calls the new helper — existing routes keep 
working exactly as before. Wiring it into specific routes (cycles, 
pcod-risk, etc.) is a natural, low-risk follow-up, kept out of this PR 
to avoid touching many routes and their tests in one change.

Type of Change
- Bug fix (non-breaking change which fixes an issue)

Testing
npm run build completes successfully, all 24 routes generated. 
npm run test:e2e — 7/7 suites passing.

