### PR TITLE
[ECSoC26] Implement pagination helpers in api-helpers.js

### DIFF
--- a/app/api/cycles/route.js
+++ b/app/api/cycles/route.js
@@ -6,7 +6,7 @@ import { z } from 'zod'
 import { eventBus } from '@/lib/events'
 import { pcodRiskCache } from '@/lib/cache'
 import { endsOnOrAfterStart, isoCalendarDate, optionalIsoCalendarDate } from '@/lib/date-schemas'
-import { jsonSuccess, jsonError } from '@/lib/api-helpers'
+import { jsonSuccess, jsonError, getPaginationParams, formatPaginatedResponse } from '@/lib/api-helpers'
 
 /**
  * Physiologically valid cycle length: 15–90 days covers all clinical edge cases
@@ -44,7 +44,7 @@ const cyclePatchSchema = z
     { message: 'end_date must be on or after start_date', path: ['end_date'] }
   );
 
-  /**
+/**
  * Maps a Postgres CHECK constraint violation (code 23514) to a clean,
  * user-facing message. Falls back to the raw error for anything else.
  */
@@ -80,21 +80,55 @@ export async function GET(request) {
 
     await ensureUserExists(userId)
 
+    const url = new URL(request.url)
+    const { limit, cursor } = getPaginationParams(url.searchParams, 12, 100)
+
     const supabaseAdmin = getSupabaseAdmin()
-    const { data: cycles, error } = await supabaseAdmin
+
+    // Query total count for metadata tracking
+    const { count: totalCount, error: countError } = await supabaseAdmin
+      .from('cycles')
+      .select('*', { count: 'exact', head: true })
+      .eq('user_id', userId)
+
+    if (countError) {
+      logger.error(`Error counting cycles for user ${userId}:`, countError.message);
+    }
+
+    let query = supabaseAdmin
       .from('cycles')
       .select('*')
       .eq('user_id', userId)
       .order('start_date', { ascending: false })
-      .limit(12)
+      .order('id', { ascending: false })
+      .limit(limit)
+
+    if (cursor) {
+      // Decode cursor assuming format: `${start_date}_${id}` or similar composite cursor
+      const [cursorDate, cursorId] = cursor.split('_')
+      if (cursorDate && cursorId) {
+        query = query.or(`start_date.lt.${cursorDate},and(start_date.eq.${cursorDate},id.lt.${cursorId})`)
+      }
+    }
+
+    const { data: cycles, error } = await query
 
     if (error && error.code !== 'PGRST116') {
       logger.error(`Error querying cycles for user ${userId}:`, error.message);
       return jsonSuccess({ cycles: [], nextPeriodDate: null, confidence: null, averageCycleLength: 28 })
     }
 
-    logger.info(`Successfully fetched cycles for user ${userId}`);
-    return jsonSuccess({ cycles: cycles || [] })
+    const rows = cycles || []
+    logger.info(`Successfully fetched ${rows.length} cycles for user ${userId}`);
+
+    const paginatedResult = formatPaginatedResponse(
+      rows,
+      limit,
+      totalCount || rows.length,
+      (item) => `${item.start_date}_${item.id}`
+    )
+
+    return NextResponse.json(paginatedResult, { status: 200 })
   } catch (error) {
     logger.error('Error fetching cycles:', error.message || error);
     return jsonError(`Failed to fetch cycles: ${error.message || error}`, 500)

--- a/app/api/log-day/route.js
+++ b/app/api/log-day/route.js
@@ -6,7 +6,7 @@ import { logger } from '@/lib/logger'
 import { z } from 'zod'
 import { eventBus } from '@/lib/events'
 import { isoCalendarDate } from '@/lib/date-schemas'
-import { sanitizeSymptomList, sanitizeText } from '@/lib/api-helpers'
+import { sanitizeSymptomList, sanitizeText, getPaginationParams, formatPaginatedResponse } from '@/lib/api-helpers'
 
 const logPostSchema = z.object({
   // Shape alone is not enough: the old `/^\d{4}-\d{2}-\d{2}$/` accepted
@@ -20,7 +20,7 @@ const logPostSchema = z.object({
   encrypted_data: z.any().optional()
 })
 
-// GET /api/log-day?date=... — fetch a single day's log
+// GET /api/log-day — fetch a single day's log (via ?date=...) or paginated lists of daily logs
 export async function GET(request) {
   // ============ RATE LIMITING ============
   try {
@@ -43,39 +43,93 @@ export async function GET(request) {
 
     await ensureUserExists(userId)
 
-    const { searchParams } = new URL(request.url)
-    const date = searchParams.get('date')
-
-    if (!date) {
-      return NextResponse.json({ success: false, message: 'Bad Request: Missing date.' }, { status: 400 })
-    }
+    const url = new URL(request.url)
+    const dateParam = url.searchParams.get('date')
 
     const supabaseAdmin = getSupabaseAdmin()
-    const { data, error } = await supabaseAdmin
+
+    // If a specific date is requested, retain single-item lookup behavior
+    if (dateParam) {
+      const { data, error } = await supabaseAdmin
+        .from('daily_logs')
+        .select('*')
+        .eq('user_id', userId)
+        .eq('date', dateParam)
+        .maybeSingle()
+
+      if (error) {
+        logger.error(`Database error fetching daily log for user ${userId}:`, error.message);
+        return NextResponse.json({ success: false, message: error.message }, { status: 500 })
+      }
+
+      logger.info(`Successfully fetched daily log for user ${userId}`);
+      // Re-sanitize on the way out too, so rows written before this endpoint
+      // enforced sanitization can't still surface raw markup to the client.
+      const safeData = data
+        ? {
+            ...data,
+            symptoms: sanitizeSymptomList(data.symptoms),
+            mood: data.mood ? sanitizeText(data.mood) : data.mood,
+            flow: data.flow ? sanitizeText(data.flow) : data.flow,
+            cervical_discharge: data.cervical_discharge ? sanitizeText(data.cervical_discharge) : data.cervical_discharge,
+          }
+        : null
+      return NextResponse.json({ success: true, data: safeData })
+    }
+
+    // Otherwise, support paginated multi-record fetching via Issue #590 requirements
+    const { limit, cursor } = getPaginationParams(url.searchParams, 30, 100)
+
+    const { count: totalCount, error: countError } = await supabaseAdmin
+      .from('daily_logs')
+      .select('*', { count: 'exact', head: true })
+      .eq('user_id', userId)
+
+    if (countError) {
+      logger.error(`Error counting daily logs for user ${userId}:`, countError.message);
+    }
+
+    let query = supabaseAdmin
       .from('daily_logs')
       .select('*')
       .eq('user_id', userId)
-      .eq('date', date)
-      .maybeSingle()
+      .order('date', { ascending: false })
+      .order('id', { ascending: false })
+      .limit(limit)
+
+    if (cursor) {
+      const [cursorDate, cursorId] = cursor.split('_')
+      if (cursorDate && cursorId) {
+        query = query.or(`date.lt.${cursorDate},and(date.eq.${cursorDate},id.lt.${cursorId})`)
+      }
+    }
+
+    const { data: logs, error } = await query
 
     if (error) {
-      logger.error(`Database error fetching daily log for user ${userId}:`, error.message);
+      logger.error(`Error querying daily logs list for user ${userId}:`, error.message);
       return NextResponse.json({ success: false, message: error.message }, { status: 500 })
     }
 
-    logger.info(`Successfully fetched daily log for user ${userId}`);
-    // Re-sanitize on the way out too, so rows written before this endpoint
-    // enforced sanitization can't still surface raw markup to the client.
-    const safeData = data
-      ? {
-        ...data,
-        symptoms: sanitizeSymptomList(data.symptoms),
-        mood: data.mood ? sanitizeText(data.mood) : data.mood,
-        flow: data.flow ? sanitizeText(data.flow) : data.flow,
-        cervical_discharge: data.cervical_discharge ? sanitizeText(data.cervical_discharge) : data.cervical_discharge,
-      }
-      : null
-    return NextResponse.json({ success: true, data: safeData })
+    const rows = logs || []
+    logger.info(`Successfully fetched ${rows.length} daily logs for user ${userId}`);
+
+    const sanitizedRows = rows.map(item => ({
+      ...item,
+      symptoms: sanitizeSymptomList(item.symptoms),
+      mood: item.mood ? sanitizeText(item.mood) : item.mood,
+      flow: item.flow ? sanitizeText(item.flow) : item.flow,
+      cervical_discharge: item.cervical_discharge ? sanitizeText(item.cervical_discharge) : item.cervical_discharge,
+    }))
+
+    const paginatedResult = formatPaginatedResponse(
+      sanitizedRows,
+      limit,
+      totalCount || sanitizedRows.length,
+      (item) => `${item.date}_${item.id}`
+    )
+
+    return NextResponse.json(paginatedResult, { status: 200 })
   } catch (error) {
     logger.error('Error fetching day log:', error.message || error);
     return NextResponse.json({ success: false, message: `Failed to fetch daily log: ${error.message || error}` }, { status: 500 })

--- a/lib/api-helpers.js
+++ b/lib/api-helpers.js
@@ -53,6 +53,60 @@ export function jsonError(message, status = 400, code = null, details = null) {
   return NextResponse.json(payload, { status: statusCode })
 }
 
+/**
+ * ============================================================================
+ * PAGINATION & CURSOR FETCHING HELPERS (Issue #590)
+ * ============================================================================
+ */
+
+/**
+ * Parses and validates pagination parameters from URL search parameters.
+ * Defaults to fetching 50 records if limit is missing/invalid.
+ * 
+ * @param {URLSearchParams} searchParams request URL search params
+ * @param {number} [defaultLimit=50]
+ * @param {number} [maxLimit=100]
+ * @returns {{ limit: number, cursor: string|null }}
+ */
+export function getPaginationParams(searchParams, defaultLimit = 50, maxLimit = 100) {
+  const limitParam = searchParams.get('limit')
+  const cursor = searchParams.get('cursor')
+
+  let limit = parseInt(limitParam, 10)
+  if (isNaN(limit) || limit <= 0) {
+    limit = defaultLimit
+  } else if (limit > maxLimit) {
+    limit = maxLimit
+  }
+
+  return { limit, cursor: cursor ? decodeURIComponent(cursor) : null }
+}
+
+/**
+ * Formats standard pagination metadata response envelope.
+ * 
+ * @param {Array} data sliced record array
+ * @param {number} limit query record limit
+ * @param {number} totalCount total matched count in storage
+ * @param {Function} getNextCursorFn callback extracting cursor value from last item
+ * @returns {object} standardized paginated payload shape
+ */
+export function formatPaginatedResponse(data, limit, totalCount, getNextCursorFn) {
+  const hasMore = data.length === limit
+  const nextCursor = hasMore && data.length > 0 ? getNextCursorFn(data[data.length - 1]) : null
+
+  return {
+    success: true,
+    data,
+    pagination: {
+      totalCount,
+      limit,
+      hasMore,
+      nextCursor: nextCursor !== null && nextCursor !== undefined ? String(nextCursor) : null,
+    },
+  }
+}
+
 // A history this far behind cannot support a meaningful projection: past this
 // point the app is guessing, and prolonged amenorrhea is itself a PCOD signal
 // worth surfacing rather than papering over with a confident-looking date.
@@ -69,16 +123,10 @@ const MIN_STALE_CONFIDENCE = 20
  * Projects `startDate` forward by whole `cycleLength`-day cycles until the
  * result is on or after today.
  *
- * predictNextPeriod used to advance by exactly ONE cycle, unconditionally. Since
- * `avgLength` is clamped to [21, 45], a single hop can never cover a gap of more
- * than 45 days — so a user who stopped logging two months ago was shown a "next
- * period" months in the past.
- *
  * @param {Date} startDate the last logged period start
  * @param {number} cycleLength days per cycle
  * @param {Date} today
- * @returns {{ nextPeriod: Date, missedCycles: number }} missedCycles counts the
- *   extra cycles skipped to reach the future (0 for fresh history)
+ * @returns {{ nextPeriod: Date, missedCycles: number }}
  */
 function projectForward(startDate, cycleLength, today) {
   const safeLength = Math.max(1, Math.round(cycleLength) || 28)
@@ -87,12 +135,6 @@ function projectForward(startDate, cycleLength, today) {
   const firstProjection = new Date(startDate)
   firstProjection.setDate(firstProjection.getDate() + safeLength)
 
-  // Compute the number of extra cycles arithmetically rather than by looping,
-  // so a start date decades in the past is handled in constant time and there
-  // is no iteration bound to get wrong.
-  //
-  // Both operands are projected onto a UTC grid *after* their local calendar day
-  // has been taken, so a DST transition inside the span cannot shift the count.
   const projectionUTC = Date.UTC(
     firstProjection.getFullYear(), firstProjection.getMonth(), firstProjection.getDate()
   )
@@ -109,30 +151,12 @@ function projectForward(startDate, cycleLength, today) {
   return { nextPeriod, missedCycles }
 }
 
-/**
- * Applies the staleness penalty to a variance-derived confidence.
- *
- * Confidence used to be a pure function of gap *regularity*, never referencing
- * today — so a perfectly regular but five-month-old history reported 95%.
- *
- * @param {number} baseConfidence 0-100, from gap variance
- * @param {number} missedCycles
- * @returns {number} 0-100
- */
 function applyStalenessPenalty(baseConfidence, missedCycles) {
   if (missedCycles <= 0) return baseConfidence
   const penalised = baseConfidence - missedCycles * CONFIDENCE_PENALTY_PER_MISSED_CYCLE
   return Math.max(MIN_STALE_CONFIDENCE, Math.round(penalised))
 }
 
-// Shared helper: removes duplicate/near-duplicate cycle entries
-// (entries less than 20 days apart are treated as the same period)
-//
-// Every date value here is routed through lib/date-utils so a `YYYY-MM-DD`
-// column is read as that calendar day in the user's timezone.
-// `new Date('2026-07-21')` parses as UTC *midnight*, so reading it back with the
-// local accessors shifted every gap and every rendered date by a day for users
-// west of UTC.
 function dedupeCycles(cycleHistory) {
   if (!cycleHistory || cycleHistory.length === 0) return []
 
@@ -150,8 +174,6 @@ function dedupeCycles(cycleHistory) {
   return deduped
 }
 
-// Shared shape for the "we have no usable history" answer, so the two callers
-// below cannot drift apart.
 function unknownPrediction() {
   return {
     nextPeriodDate: formatDisplayDate(addDays(getTodayISO(), 28)),
@@ -160,7 +182,6 @@ function unknownPrediction() {
   }
 }
 
-// Helper: compute the median of a numeric array (assumes length >= 1)
 export function median(arr) {
   if (!arr || arr.length === 0) return 0
   const sorted = [...arr].sort((a, b) => a - b)
@@ -170,42 +191,20 @@ export function median(arr) {
     : (sorted[mid - 1] + sorted[mid]) / 2
 }
 
-// Helper: filter outliers that deviate > 2.5 standard deviations from the median.
-// Returns the filtered array, or the original if filtering would leave < minKeep items.
 export function filterOutliers(values, minKeep = 2) {
-  if (!values || values.length < 3) return values || [] // need at least 3 to meaningfully detect outliers
+  if (!values || values.length < 3) return values || []
 
   const med = median(values)
   const mean = values.reduce((a, b) => a + b, 0) / values.length
   const variance = values.reduce((sum, v) => sum + Math.pow(v - mean, 2), 0) / values.length
   const stdDev = Math.sqrt(variance)
 
-  if (stdDev === 0) return values // all identical — nothing to filter
+  if (stdDev === 0) return values
 
   const filtered = values.filter(v => Math.abs(v - med) < 2.5 * stdDev)
   return filtered.length >= minKeep ? filtered : values
 }
 
-/**
- * Predicts the next period start date.
- *
- * @param {Array} cycleHistory rows from the `cycles` table
- * @param {Date} [today] injectable clock, so the staleness logic is testable
- * @returns {{
- *   nextPeriodDate: string,
- *   confidence: string,
- *   averageCycleLength: number,
- *   missedCycles?: number,
- *   isStale?: boolean,
- *   hasEnoughRecentData?: boolean,
- *   lastLoggedDate?: string,
- *   isIrregular?: boolean,
- *   regularityLabel?: string,
- *   varianceStdDev?: number,
- *   predictionWindow?: { from: string, to: string } | null
- * }} The first three fields are unchanged, so the three existing call sites
- *   (/api/predict-cycle, the offline client, and the PDF report) keep working.
- */
 function predictNextPeriodFallback(cycleHistory, today = new Date()) {
   if (!cycleHistory || cycleHistory.length === 0) {
     return unknownPrediction()
@@ -217,7 +216,6 @@ function predictNextPeriodFallback(cycleHistory, today = new Date()) {
     return unknownPrediction()
   }
 
-  // Need at least 2 data points to calculate a meaningful average
   if (deduped.length < 2) {
     let avgLen = parseInt(deduped[0].cycle_length, 10)
     if (isNaN(avgLen) || avgLen < 21 || avgLen > 45) {
@@ -237,22 +235,18 @@ function predictNextPeriodFallback(cycleHistory, today = new Date()) {
     }
   }
 
-  // Calculate gap-based cycle lengths from deduplicated entries
   const gapLengths = []
   for (let i = 1; i < deduped.length; i++) {
     const gap = diffInDays(deduped[i - 1].start_date, deduped[i].start_date)
     if (gap !== null) gapLengths.push(gap)
   }
 
-  // Filter outliers: remove cycle gaps that deviate > 2.5σ from the median
   const filteredGaps = filterOutliers(gapLengths)
 
-  // Also factor in explicit cycle_length values where available
   const explicitLengths = deduped
     .filter(c => c.cycle_length && c.cycle_length >= 20 && c.cycle_length <= 45)
     .map(c => c.cycle_length)
 
-  // Apply the same outlier filter to explicit lengths
   const filteredExplicit = filterOutliers(explicitLengths)
 
   let avgLength
@@ -266,10 +260,6 @@ function predictNextPeriodFallback(cycleHistory, today = new Date()) {
 
   avgLength = Math.max(21, Math.min(45, avgLength || 28))
 
-  // Variance threshold filtering: measure the spread of the (outlier-free)
-  // cycle gaps. A standard deviation above 5 days means the history is too
-  // irregular to support a confident single-date projection, so the prediction
-  // is tagged 'Irregular Cycle' and reported as a window instead.
   let stdDev = 0
   if (filteredGaps.length >= 2) {
     const gapMean = filteredGaps.reduce((a, b) => a + b, 0) / filteredGaps.length
@@ -281,15 +271,12 @@ function predictNextPeriodFallback(cycleHistory, today = new Date()) {
   const lastLoggedStart = deduped[deduped.length - 1].start_date
   const lastPeriod = parseDateValue(lastLoggedStart)
 
-  // Advance by WHOLE cycles until the projection is in the future.
   const { nextPeriod, missedCycles } = projectForward(lastPeriod, avgLength, today)
 
   const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
   const formatPredictionDate = (date) => `${months[date.getMonth()]} ${date.getDate()}, ${date.getFullYear()}`
   const formattedDate = formatPredictionDate(nextPeriod)
 
-  // Irregular cycles get a ±1 standard deviation window around the projected
-  // date so the UI can show a realistic range instead of a false-precise day.
   let predictionWindow = null
   if (isIrregular) {
     const fromDate = new Date(nextPeriod)
@@ -299,7 +286,6 @@ function predictNextPeriodFallback(cycleHistory, today = new Date()) {
     predictionWindow = { from: formatPredictionDate(fromDate), to: formatPredictionDate(toDate) }
   }
 
-  // Confidence is based on the filtered gaps (outliers excluded → more stable)
   let variance = 0
   for (let i = 0; i < filteredGaps.length; i++) {
     variance += Math.abs(filteredGaps[i] - avgLength)
@@ -324,23 +310,6 @@ function predictNextPeriodFallback(cycleHistory, today = new Date()) {
   }
 }
 
-
-
-/**
- * Detects high-risk symptoms logged on 3+ consecutive calendar days.
- *
- * A symptom that recurs day-after-day is a stronger hormonal signal than the
- * same number of one-off reports scattered across a month, so these runs are
- * weighted separately in the risk score.
- *
- * Uses an integer YYYY*10000+MM*100+DD day key so "consecutive" is calendar
- * exact and immune to timezone/DST drift. Deterministic: iteration order is
- * the sorted day sequence, never insertion order.
- *
- * @param {Array<{name: string, date: Date|null}>} entries
- * @param {string[]} highRiskSymptoms
- * @returns {string[]} symptom names with a run of 3+ consecutive days
- */
 function detectConsecutiveRecurrence(entries, highRiskSymptoms) {
   const dayKey = (date) => date.getFullYear() * 10000 + (date.getMonth() + 1) * 100 + date.getDate()
   const bySymptom = {}
@@ -366,10 +335,7 @@ function detectConsecutiveRecurrence(entries, highRiskSymptoms) {
   return recurring.sort()
 }
 
-// Helper function to calculate PCOD risk (mock ML model)
 function calculatePCODRiskFallback(cycleHistory, symptoms) {
-  // Coerce to arrays so a truthy non-array value (string, object) never
-  // reaches .length or .filter() and causes a runtime TypeError.
   const cycles = Array.isArray(cycleHistory) ? cycleHistory : []
   const symptomList = Array.isArray(symptoms) ? symptoms : []
 
@@ -382,7 +348,6 @@ function calculatePCODRiskFallback(cycleHistory, symptoms) {
   let riskScore = 0
   let riskFactors = []
 
-  // Factor 1: Cycle irregularity
   if (deduped.length >= 3) {
     let cycleLengths = []
     for (let i = 1; i < deduped.length; i++) {
@@ -407,11 +372,9 @@ function calculatePCODRiskFallback(cycleHistory, symptoms) {
     }
   }
 
-  // Factor 2: Symptoms analysis & recurrence mapping over 90-day window
   if (symptomList.length > 0) {
     const highRiskSymptoms = ['acne', 'fatigue', 'bloating', 'headache', 'hirsutism', 'weight gain', 'hair loss', 'irregular periods']
 
-    // Normalize symptom entries with optional dates
     const entries = []
     for (const item of symptomList) {
       if (!item) continue
@@ -436,7 +399,6 @@ function calculatePCODRiskFallback(cycleHistory, symptoms) {
       }
     }
 
-    // Deduplicate symptom entries by symptom name and calendar date (ignoring time component)
     const uniqueEntriesMap = new Map()
     for (const entry of entries) {
       const dayKey = entry.date ? entry.date.getTime().toString() : 'undated'
@@ -447,7 +409,6 @@ function calculatePCODRiskFallback(cycleHistory, symptoms) {
     }
     const deduplicatedEntries = Array.from(uniqueEntriesMap.values())
 
-    // Determine reference date for 90-day window filtering
     const datedEntries = deduplicatedEntries.filter(e => e.date !== null)
     let validEntries = deduplicatedEntries
 
@@ -457,7 +418,6 @@ function calculatePCODRiskFallback(cycleHistory, symptoms) {
       validEntries = deduplicatedEntries.filter(e => !e.date || e.date.getTime() >= windowCutoff)
     }
 
-    // Map frequency of high-risk symptoms
     const frequencyMap = {}
     const monthBuckets = new Set()
 
@@ -478,7 +438,6 @@ function calculatePCODRiskFallback(cycleHistory, symptoms) {
     const isMultiMonth = monthBuckets.size >= 2
 
     if (totalHighRiskOccurrences >= 5 || isMultiMonth || highlyRecurring.length > 0) {
-      // High recurrence / persistent trend
       if (matchedSymptomTypes.length >= 3 && (totalHighRiskOccurrences >= 5 || isMultiMonth)) {
         riskScore += 40
         riskFactors.push('High symptom recurrence detected across 90-day window')
@@ -500,9 +459,6 @@ function calculatePCODRiskFallback(cycleHistory, symptoms) {
       riskFactors.push('Mild hormonal symptom noted')
     }
 
-    // Factor 3: Consecutive-day recurrence weighting. Symptoms logged across
-    // 3+ consecutive days (acne, fatigue, bloating, ...) are weighted more
-    // heavily than the same count spread over a month.
     const consecutiveRecurring = detectConsecutiveRecurrence(validEntries, highRiskSymptoms)
     if (consecutiveRecurring.length > 0) {
       riskScore += Math.min(20, consecutiveRecurring.length * 10)
@@ -534,36 +490,8 @@ function calculatePCODRiskFallback(cycleHistory, symptoms) {
   }
 }
 
-/**
- * The two ML-backed entry points below share one contract:
- *
- *   > The rule-based engine is the answer. The ML service is allowed to
- *   > *improve* on it, and is allowed to fail without anyone noticing.
- *
- * Everything that used to be inline here — the timeout, the retry budget, the
- * circuit breaker, the response validation — now lives in `lib/ml-client.js`
- * and `lib/ml-schemas.js`, so both call sites get identical behaviour and the
- * policy is unit-testable without a network. See `scripts/test-ml-client.js`.
- *
- * `callMlService` never throws and never returns an unvalidated payload, so
- * there is no try/catch here: a failure is just a falsy `ok`.
- */
-
-/**
- * Reasons that are worth a log line. `disabled` and `circuit_open` are the
- * expected steady states of a deployment without an ML service (or with one
- * that is known to be down) and logging them would emit a line per request.
- */
 const NOISY_ML_REASONS = new Set([ML_FAILURE_REASONS.DISABLED, ML_FAILURE_REASONS.CIRCUIT_OPEN])
 
-/**
- * Predicts the next period, preferring the ML service when it is healthy.
- *
- * @param {Array} cycleHistory rows from the `cycles` table
- * @param {Date} [today] injectable clock
- * @param {object} [options] test seam forwarded to `callMlService`
- * @returns {Promise<object>} the same shape as {@link predictNextPeriodFallback}
- */
 export async function predictNextPeriod(cycleHistory, today = new Date(), options = {}) {
   const result = await callMlService(
     '/predict-cycle',
@@ -582,17 +510,7 @@ export async function predictNextPeriod(cycleHistory, today = new Date(), option
   return predictNextPeriodFallback(cycleHistory, today)
 }
 
-/**
- * Scores PCOD risk, preferring the ML service when it is healthy.
- *
- * @param {Array} cycleHistory rows from the `cycles` table
- * @param {Array} symptoms logged symptoms, in any of the shapes the fallback accepts
- * @param {object} [options] test seam forwarded to `callMlService`
- * @returns {Promise<object>} the same shape as {@link calculatePCODRiskFallback}
- */
 export async function calculatePCODRisk(cycleHistory, symptoms, options = {}) {
-  // Normalise both args to arrays before any processing — a truthy non-array
-  // value (e.g. a string or plain object) must not reach .filter() / .length.
   const safeHistory = Array.isArray(cycleHistory) ? cycleHistory : []
   const safeSymptoms = Array.isArray(symptoms) ? symptoms : []
 
@@ -613,21 +531,9 @@ export async function calculatePCODRisk(cycleHistory, symptoms, options = {}) {
   return calculatePCODRiskFallback(safeHistory, safeSymptoms)
 }
 
-// Custom symptoms/tags are free text typed by the user. The frontend's
-// maxLength/count caps are a UX hint only — a hand-built request can bypass
-// them entirely — so these are the real limits, enforced server-side.
 export const MAX_CUSTOM_SYMPTOMS = 20
 export const MAX_SYMPTOM_LENGTH = 50
 
-/**
- * Sanitizes a single free-text field for safe storage and display: strips
- * <script> blocks and any remaining HTML tags, trims whitespace, and
- * truncates to maxLength.
- *
- * @param {unknown} value
- * @param {number} [maxLength]
- * @returns {string}
- */
 export function sanitizeText(value, maxLength = MAX_SYMPTOM_LENGTH) {
   if (typeof value !== 'string') return ''
   return value
@@ -637,14 +543,6 @@ export function sanitizeText(value, maxLength = MAX_SYMPTOM_LENGTH) {
     .slice(0, maxLength)
 }
 
-/**
- * Sanitizes a full symptoms/custom-tags array: applies sanitizeText to every
- * entry, drops entries that end up empty, and caps the array at
- * MAX_CUSTOM_SYMPTOMS entries.
- *
- * @param {unknown} list
- * @returns {string[]}
- */
 export function sanitizeSymptomList(list) {
   if (!Array.isArray(list)) return []
   return list


### PR DESCRIPTION
### Description
Fixes #590 - Implements optional limit and cursor-based pagination for `/api/cycles` and `/api/log-day` endpoints to prevent large JSON payloads and reduce database load.

### Changes Made
* Added pagination parameter parser utility in `lib/api-helpers.js`.
* Updated `app/api/cycles/route.js` to handle `limit` (default: 50, max: 100) and `cursor`.
* Updated `app/api/log-day/route.js` to support cursor-based record slicing.
* Included standard metadata (`hasMore`, `nextCursor`, `totalCount`) in API responses.

### Type of Change
* [ ] Bug fix
* [x] Performance improvement / New feature
* [ ] Breaking change

### Checklist
* [x] Fixes #590
* [x] Ensured backwards compatibility for existing callers