### PR TITLE
[ECSoC26] Refactor functions to use normalized phase input

### DIFF
--- a/lib/partner-insights.js
+++ b/lib/partner-insights.js
@@ -3,7 +3,20 @@
  * care recommendations, energy battery levels, and sensitivity alerts.
  */
 
-export function getBiologicalPhaseContext(phase) {
+/**
+ * Normalizes an incoming cycle phase string to standard PascalCase 
+ * (e.g., 'menstrual' -> 'Menstrual', 'LUTEAL' -> 'Luteal') for switch matching.
+ */
+function normalizePhase(phase) {
+  if (!phase || typeof phase !== 'string') return '';
+  const cleaned = phase.trim().toLowerCase();
+  if (!cleaned) return '';
+  return cleaned.charAt(0).toUpperCase() + cleaned.slice(1);
+}
+
+export function getBiologicalPhaseContext(phaseInput) {
+  const phase = normalizePhase(phaseInput);
+
   switch (phase) {
     case 'Menstrual':
       return {
@@ -38,7 +51,8 @@ export function getBiologicalPhaseContext(phase) {
   }
 }
 
-export function getActionableCareTips(phase, symptoms = [], flow = null) {
+export function getActionableCareTips(phaseInput, symptoms = [], flow = null) {
+  const phase = normalizePhase(phaseInput);
   const tips = []
   const safeSymptoms = Array.isArray(symptoms)
     ? symptoms.filter(s => typeof s === 'string')
@@ -95,7 +109,8 @@ export function getActionableCareTips(phase, symptoms = [], flow = null) {
   return tips.slice(0, 3) // Return top 3 actionable tips
 }
 
-export function calculateEnergyBattery(phase, cycleDay, symptoms = []) {
+export function calculateEnergyBattery(phaseInput, cycleDay, symptoms = []) {
+  const phase = normalizePhase(phaseInput);
   let baseEnergy = 75
 
   switch (phase) {
@@ -149,7 +164,9 @@ export function calculateEnergyBattery(phase, cycleDay, symptoms = []) {
   return { level, label, color }
 }
 
-export function getPmsAlert(phase, cycleDay) {
+export function getPmsAlert(phaseInput, cycleDay) {
+  const phase = normalizePhase(phaseInput);
+
   if (phase === 'Luteal' && cycleDay >= 22) {
     return {
       active: true,


### PR DESCRIPTION
## Title
`fix(insights): Normalize cycle phase case sensitivity in partner-insights helpers (#678)`

## Description
Fixes #678

The underlying cycle phase calculations in `lib/calculateCyclePhase.js` produce lowercase phase strings (`menstrual`, `follicular`, `ovulation`, `luteal`), whereas the partner insight helper functions in `lib/partner-insights.js` previously relied on strict exact-match PascalCase evaluation (`Menstrual`, `Follicular`, etc.). This case mismatch caused incoming phase inputs to fall through the switch branches into generic default fallback values.

## Changes Made
- Introduced a robust `normalizePhase()` helper function inside `lib/partner-insights.js` to safely trim, lowercase, and properly capitalize incoming phase strings.
- Applied phase normalization across all partner insight helpers: `getBiologicalPhaseContext`, `getActionableCareTips`, `calculateEnergyBattery`, and `getPmsAlert`.
- Ensured seamless case-insensitive compatibility with lowercase phase keys emitted from core cycle calculations.

## Checklist
- [x] Added `Fixes #678` in the PR description.
- [x] Added the `ECSoc26` label to the Pull Request.
- [x] Verified that the project builds successfully and all helper functions handle lowercase inputs correctly.