### PR TITLE
[ECSoC26] Backend/Logic: Normalize cycle phase case sensitivity in partner-insights helpers

### DIFF
--- a/lib/partner-insights.js
+++ b/lib/partner-insights.js
@@ -4,26 +4,27 @@
  */
 
 export function getBiologicalPhaseContext(phase) {
-  switch (phase) {
-    case 'Menstrual':
+  const normalizedPhase = typeof phase === 'string' ? phase.trim().toLowerCase() : ''
+  switch (normalizedPhase) {
+    case 'menstrual':
       return {
         title: 'Menstrual Phase 🩸',
         summary: 'Estrogen and progesterone are at their lowest levels. Her body is shedding uterine lining and consuming extra energy.',
         physiologicalFocus: 'Rest, hydration, thermal warmth, and iron replenishment.',
       }
-    case 'Follicular':
+    case 'follicular':
       return {
         title: 'Follicular Phase 🌱',
         summary: 'Estrogen levels are steadily rising as new follicles develop. Stamina, mood, and mental focus are naturally climbing.',
         physiologicalFocus: 'High energy, creativity, social interaction, and outdoor activities.',
       }
-    case 'Ovulation':
+    case 'ovulation':
       return {
         title: 'Ovulation Phase 🌸',
         summary: 'Estrogen and Luteinizing Hormone (LH) reach peak levels. She experiences maximum confidence, energy, and closeness.',
         physiologicalFocus: 'Quality time, shared experiences, and high-vitality activities.',
       }
-    case 'Luteal':
+    case 'luteal':
       return {
         title: 'Luteal Phase 🌙',
         summary: 'Progesterone becomes the dominant hormone. Body temperature & metabolism rise, while natural energy gradually decreases.',
@@ -40,6 +41,7 @@ export function getBiologicalPhaseContext(phase) {
 
 export function getActionableCareTips(phase, symptoms = [], flow = null) {
   const tips = []
+  const normalizedPhase = typeof phase === 'string' ? phase.trim().toLowerCase() : ''
   const safeSymptoms = Array.isArray(symptoms)
     ? symptoms.filter(s => typeof s === 'string')
     : typeof symptoms === 'string' && symptoms.trim()
@@ -58,8 +60,8 @@ export function getActionableCareTips(phase, symptoms = [], flow = null) {
   }
 
   // Phase-specific tips
-  switch (phase) {
-    case 'Menstrual':
+  switch (normalizedPhase) {
+    case 'menstrual':
       tips.push('Prepare warm chamomile or ginger tea to assist with muscle relaxation.')
       tips.push('Keep her favorite dark chocolate or iron-rich snacks easily accessible.')
       if (!tips.some(t => t.includes('heating pad'))) {
@@ -67,19 +69,19 @@ export function getActionableCareTips(phase, symptoms = [], flow = null) {
       }
       break
 
-    case 'Follicular':
+    case 'follicular':
       tips.push('Great window to plan outdoor dates, walks, or try a new activity together!')
       tips.push('Her focus and energy are rising — great time for meaningful conversations.')
       tips.push('Encourage new creative goals or shared projects.')
       break
 
-    case 'Ovulation':
+    case 'ovulation':
       tips.push('Peak vitality & connection window! Plan a special evening or quality date night.')
       tips.push('Complement her confidence and express genuine appreciation for her.')
       tips.push('Enjoy active adventures or shared hobbies together.')
       break
 
-    case 'Luteal':
+    case 'luteal':
       tips.push('Offer extra emotional reassurance and avoid starting heavy or stressful debates.')
       tips.push('Prepare grounding, warm comfort meals (e.g., warm soups or complex carbs).')
       tips.push('Keep the evening calm and low-pressure to support her rising progesterone levels.')
@@ -97,18 +99,19 @@ export function getActionableCareTips(phase, symptoms = [], flow = null) {
 
 export function calculateEnergyBattery(phase, cycleDay, symptoms = []) {
   let baseEnergy = 75
+  const normalizedPhase = typeof phase === 'string' ? phase.trim().toLowerCase() : ''
 
-  switch (phase) {
-    case 'Menstrual':
+  switch (normalizedPhase) {
+    case 'menstrual':
       baseEnergy = 35
       break
-    case 'Follicular':
+    case 'follicular':
       baseEnergy = 80
       break
-    case 'Ovulation':
+    case 'ovulation':
       baseEnergy = 95
       break
-    case 'Luteal':
+    case 'luteal':
       // Energy drops as luteal phase progresses (late luteal phase)
       baseEnergy = cycleDay > 22 ? 45 : 65
       break
@@ -150,7 +153,8 @@ export function calculateEnergyBattery(phase, cycleDay, symptoms = []) {
 }
 
 export function getPmsAlert(phase, cycleDay) {
-  if (phase === 'Luteal' && cycleDay >= 22) {
+  const normalizedPhase = typeof phase === 'string' ? phase.trim().toLowerCase() : ''
+  if (normalizedPhase === 'luteal' && cycleDay >= 22) {
     return {
       active: true,
       title: 'Pre-Menstrual Window Active 🌙',


### PR DESCRIPTION
## Linked Issue
Fixes #678

## Description
Normalized `phase` input strings to lowercase and handled case-insensitive matching across `getBiologicalPhaseContext`, `getActionableCareTips`, `calculateEnergyBattery`, and `getPmsAlert` in `lib/partner-insights.js`.

- Fixes mismatch where lowercase phase keys from `lib/calculateCyclePhase.js` (`menstrual`, `follicular`, `ovulation`, `luteal`) failed to match PascalCase switch cases.
- Guarantees seamless biological phase recommendations and accurate PMS alerts.

## Type of Change
- [x] Bug fix
- [x] Code quality

## Checklist
- [x] Linked issue using `Fixes #678`.
- [x] Added ECSoc26 label.