### PR TITLE
[ECSoC26] Frontend: Fix relative import path and add 'use client' directive in ThemeToggle.jsx

### DIFF
--- a/components/ThemeToggle.jsx
+++ b/components/ThemeToggle.jsx
@@ -1,5 +1,7 @@
+'use client'
+
 import React from 'react';
-import { useTheme } from '../context/ThemeContext';
+import { useTheme } from './context/ThemeContext';
 import { Sun, Moon, Eye } from 'lucide-react';
 
 export function ThemeToggle() {
@@ -8,6 +10,7 @@ export function ThemeToggle() {
   return (
     <div className="flex items-center gap-1 bg-gray-100 dark:bg-gray-800 p-1 rounded-xl border border-gray-200 dark:border-gray-700">
       <button
+        type="button"
         onClick={() => changeTheme('light')}
         aria-label="Light Theme"
         className={`p-2 rounded-lg text-xs font-semibold flex items-center gap-1.5 transition-colors ${
@@ -17,6 +20,7 @@ export function ThemeToggle() {
         <Sun className="w-4 h-4" />
       </button>
       <button
+        type="button"
         onClick={() => changeTheme('dark')}
         aria-label="Dark Theme"
         className={`p-2 rounded-lg text-xs font-semibold flex items-center gap-1.5 transition-colors ${
@@ -26,6 +30,7 @@ export function ThemeToggle() {
         <Moon className="w-4 h-4" />
       </button>
       <button
+        type="button"
         onClick={() => changeTheme('high-contrast')}
         aria-label="High Contrast Theme"
         className={`p-2 rounded-lg text-xs font-semibold flex items-center gap-1.5 transition-colors ${


### PR DESCRIPTION
## Linked Issue
Fixes #680

## Description
Fixed invalid relative import path and added mandatory `'use client'` directive in `components/ThemeToggle.jsx`.

- Corrects import path from `../context/ThemeContext` to `./context/ThemeContext`.
- Prepends `'use client'` to enable interactive state & click handlers in Next.js App Router.
- Adds explicit `type="button"` attributes to theme toggles.

## Type of Change
- [x] Bug fix
- [x] Code quality

## Checklist
- [x] Linked issue using `Fixes #680`.
- [x] Added ECSoc26 label.