### PR TITLE
[ECSoC26] Frontend: Add 'use client' directive and improve button touch targets in components/CycleCalendar.jsx

### DIFF
--- a/components/CycleCalendar.jsx
+++ b/components/CycleCalendar.jsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { useState } from 'react';
 import { ChevronLeft, ChevronRight, Calendar as CalendarIcon } from 'lucide-react';
 
@@ -50,8 +52,9 @@ export function CycleCalendar() {
         </h2>
         
         <button
+          type="button"
           onClick={handleJumpToToday}
-          className="px-3 py-1.5 bg-emerald-50 dark:bg-emerald-950/40 border border-emerald-500/30 text-emerald-700 dark:text-emerald-300 rounded-xl text-xs font-semibold hover:bg-emerald-100 dark:hover:bg-emerald-900/50 transition-colors"
+          className="min-h-[44px] px-3.5 py-2 bg-emerald-50 dark:bg-emerald-950/40 border border-emerald-500/30 text-emerald-700 dark:text-emerald-300 rounded-xl text-xs font-semibold hover:bg-emerald-100 dark:hover:bg-emerald-900/50 transition-colors flex items-center justify-center"
         >
           Today
         </button>
@@ -60,18 +63,20 @@ export function CycleCalendar() {
       {/* Navigation Controls (< >) */}
       <div className="flex items-center justify-between mb-4">
         <button
+          type="button"
           onClick={handlePrevMonth}
           aria-label="Previous Month"
-          className="p-2 rounded-xl border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-800 text-gray-600 dark:text-gray-300 transition-colors"
+          className="min-h-[44px] min-w-[44px] p-2.5 rounded-xl border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-800 text-gray-600 dark:text-gray-300 transition-colors flex items-center justify-center"
         >
-          <ChevronLeft className="w-4 h-4" />
+          <ChevronLeft className="w-5 h-5" />
         </button>
         <button
+          type="button"
           onClick={handleNextMonth}
           aria-label="Next Month"
-          className="p-2 rounded-xl border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-800 text-gray-600 dark:text-gray-300 transition-colors"
+          className="min-h-[44px] min-w-[44px] p-2.5 rounded-xl border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-800 text-gray-600 dark:text-gray-300 transition-colors flex items-center justify-center"
         >
-          <ChevronRight className="w-4 h-4" />
+          <ChevronRight className="w-5 h-5" />
         </button>
       </div>
 


### PR DESCRIPTION
## Linked Issue
Fixes #681

## Description
Added `'use client'` directive and expanded navigation touch targets in `components/CycleCalendar.jsx`.

- Prepends `'use client'` to enable stateful calendar date selection in Next.js App Router.
- Increases previous/next month navigation buttons to meet WCAG 2.1 AAA minimum 44x44px touch targets on mobile.
- Adds explicit `type="button"` attributes.

## Type of Change
- [x] Bug fix
- [x] Accessibility

## Checklist
- [x] Linked issue using `Fixes #681`.
- [x] Added ECSoc26 label.