### PR TITLE
[ECSoC26] [OPT] Implement pagination and cursor-based fetching for /api/cycles and /api/log-day

### DIFF
--- a/app/api/cycles/route.js
+++ b/app/api/cycles/route.js
@@ -61,6 +61,9 @@ function toCleanCycleError(error) {
   return { message: error?.message || 'Unknown database error', status: 500 }
 }
 
+const CYCLES_DEFAULT_LIMIT = 50
+const CYCLES_MAX_LIMIT = 365
+
 export async function GET(request) {
   // ============ RATE LIMITING ============
   try {
@@ -80,21 +83,43 @@ export async function GET(request) {
 
     await ensureUserExists(userId)
 
+    // Pagination params — optional. A caller that never sends page/limit
+    // (every existing caller, today) gets page 0 at the new 50-record
+    // default, up from the old hardcoded 12, so nothing that worked before
+    // stops working.
+    const { searchParams } = new URL(request.url)
+    const page = Math.max(0, parseInt(searchParams.get('page') || '0', 10))
+    const limit = Math.min(
+      CYCLES_MAX_LIMIT,
+      Math.max(1, parseInt(searchParams.get('limit') || String(CYCLES_DEFAULT_LIMIT), 10))
+    )
+    const from = page * limit
+    const to = from + limit - 1
+
     const supabaseAdmin = getSupabaseAdmin()
-    const { data: cycles, error } = await supabaseAdmin
+    const { data: cycles, error, count } = await supabaseAdmin
       .from('cycles')
-      .select('*')
+      .select('*', { count: 'exact' })
       .eq('user_id', userId)
       .order('start_date', { ascending: false })
-      .limit(12)
+      .range(from, to)
 
     if (error && error.code !== 'PGRST116') {
       logger.error(`Error querying cycles for user ${userId}:`, error.message);
       return jsonSuccess({ cycles: [], nextPeriodDate: null, confidence: null, averageCycleLength: 28 })
     }
 
-    logger.info(`Successfully fetched cycles for user ${userId}`);
-    return jsonSuccess({ cycles: cycles || [] })
+    logger.info(`Successfully fetched cycles (page=${page}, limit=${limit}) for user ${userId}`);
+    return jsonSuccess({
+      cycles: cycles || [],
+      pagination: {
+        page,
+        limit,
+        totalCount: count ?? null,
+        hasMore: count != null ? from + limit < count : (cycles || []).length === limit,
+        nextCursor: count != null && from + limit < count ? page + 1 : null,
+      },
+    })
   } catch (error) {
     logger.error('Error fetching cycles:', error.message || error);
     return jsonError(`Failed to fetch cycles: ${error.message || error}`, 500)

--- a/app/api/log-day/all/route.js
+++ b/app/api/log-day/all/route.js
@@ -51,14 +51,16 @@ export async function GET(request) {
     }
 
     logger.info(`Successfully fetched daily logs (page=${page}, limit=${limit}) for user ${userId}`);
-    return NextResponse.json({
+       return NextResponse.json({
       success: true,
       data: data || [],
       pagination: {
         page,
         limit,
         total: count ?? null,
+        totalCount: count ?? null,
         hasMore: count != null ? from + limit < count : (data || []).length === limit,
+        nextCursor: count != null && from + limit < count ? page + 1 : null,
       },
     })
   } catch (error) {


### PR DESCRIPTION
Fixes #590

Description
Added pagination (page/limit query params) and metadata (hasMore, 
nextCursor, totalCount) to GET /api/cycles, which previously had a 
hardcoded, unpageable limit of 12 records.

Scope clarifications
- GET /api/log-day/all already had working page/limit pagination in 
  place — added nextCursor to its response to fully match this issue's 
  requested metadata shape (hasMore, nextCursor, totalCount).
- /api/log-day (singular) is a single-day lookup by date 
  (?date=YYYY-MM-DD), not a list endpoint — pagination doesn't apply. 
  The actual "list all logs" endpoint is /api/log-day/all.
- lib/api-helpers.js has no pagination-related logic (confirmed by 
  reviewing every exported function) — left unchanged.

Backwards compatibility
No caller currently sends page/limit to either route, so every existing 
call gets page 0 at the new default limit — 50 for /api/cycles (per this 
issue's explicit requirement), unchanged 100 for /api/log-day/all. The 
response shape is unchanged at every existing field path (e.g. 
data.cycles stays an array in the same place); pagination metadata is 
purely additive.

Type of Change
- Enhancement (non-breaking)

Testing
npm run build completes successfully. npm run test:e2e — all 7 suites 
passing.