### PR TITLE
[ECSoC26] API: Sanitize empty categoryId string to null in /api/drafts route

### DIFF
--- a/app/api/drafts/route.js
+++ b/app/api/drafts/route.js
@@ -51,6 +51,7 @@ export async function POST(req) {
     }
 
     const { title = '', content = '', categoryId = '', draftType = 'forum_post' } = body;
+    const sanitizedCategoryId = (typeof categoryId === 'string' && categoryId.trim()) ? categoryId.trim() : null;
 
     const supabase = getSupabaseAdmin();
     const { data, error } = await supabase
@@ -58,9 +59,9 @@ export async function POST(req) {
       .upsert({
         user_id: userId,
         draft_type: draftType,
-        title,
-        content,
-        category_id: categoryId,
+        title: typeof title === 'string' ? title : '',
+        content: typeof content === 'string' ? content : '',
+        category_id: sanitizedCategoryId,
         updated_at: new Date().toISOString(),
       }, { onConflict: 'user_id' })
       .select()


### PR DESCRIPTION
## Linked Issue
Fixes #704

## Description
Sanitized `categoryId` in `app/api/drafts/route.js` so empty strings or whitespace values are converted to `null` before inserting into Supabase.

- Fixes PostgreSQL error `invalid input syntax for type uuid: ""` when drafts are saved without an explicit category.
- Adds type-safe string guards for title and content fields.

## Type of Change
- [x] Bug fix
- [x] Reliability

## Checklist
- [x] Linked issue using `Fixes #704`.
- [x] Added ECSoc26 label.