### PR TITLE
[ECSoC26] Frontend: Guard MarkdownRenderer against non-string content values

### DIFF
--- a/components/editor/MarkdownRenderer.jsx
+++ b/components/editor/MarkdownRenderer.jsx
@@ -4,7 +4,8 @@ import React from 'react';
 import ReactMarkdown from 'react-markdown';
 
 export default function MarkdownRenderer({ content, className = '' }) {
-  if (!content || !content.trim()) {
+  const safeContent = typeof content === 'string' ? content : '';
+  if (!safeContent || !safeContent.trim()) {
     return (
       <div className="text-slate-400 dark:text-slate-500 italic text-sm py-4">
         Nothing to preview yet. Start typing on the left...
@@ -14,7 +15,7 @@ export default function MarkdownRenderer({ content, className = '' }) {
 
   return (
     <div className={`prose dark:prose-invert max-w-none text-slate-800 dark:text-slate-200 prose-headings:font-bold prose-a:text-pink-500 hover:prose-a:underline prose-code:bg-slate-100 dark:prose-code:bg-slate-800 prose-code:px-1.5 prose-code:py-0.5 prose-code:rounded prose-code:text-pink-600 dark:prose-code:text-pink-400 prose-pre:bg-slate-900 prose-pre:text-slate-100 prose-img:rounded-lg ${className}`}>
-      <ReactMarkdown>{content}</ReactMarkdown>
+      <ReactMarkdown>{safeContent}</ReactMarkdown>
     </div>
   );
 }


### PR DESCRIPTION
## Linked Issue
Fixes #705

## Description
Added type safety checks for `content` prop in `components/editor/MarkdownRenderer.jsx`.

- Validates that `content` is a string before attempting `.trim()` operations.
- Prevents client-side unhandled `TypeError: content.trim is not a function` when parent components pass non-string values.

## Type of Change
- [x] Bug fix
- [x] Reliability

## Checklist
- [x] Linked issue using `Fixes #705`.
- [x] Added ECSoc26 label.