### PR TITLE
[ECSoC26] API: Validate draftType against supported enum values in /api/drafts

### DIFF
--- a/app/api/drafts/route.js
+++ b/app/api/drafts/route.js
@@ -51,16 +51,19 @@ export async function POST(req) {
     }
 
     const { title = '', content = '', categoryId = '', draftType = 'forum_post' } = body;
+    const ALLOWED_DRAFT_TYPES = ['forum_post', 'comment', 'article'];
+    const validDraftType = (typeof draftType === 'string' && ALLOWED_DRAFT_TYPES.includes(draftType)) ? draftType : 'forum_post';
+    const sanitizedCategoryId = (typeof categoryId === 'string' && categoryId.trim()) ? categoryId.trim() : null;
 
     const supabase = getSupabaseAdmin();
     const { data, error } = await supabase
       .from('user_drafts')
       .upsert({
         user_id: userId,
-        draft_type: draftType,
-        title,
-        content,
-        category_id: categoryId,
+        draft_type: validDraftType,
+        title: typeof title === 'string' ? title : '',
+        content: typeof content === 'string' ? content : '',
+        category_id: sanitizedCategoryId,
         updated_at: new Date().toISOString(),
       }, { onConflict: 'user_id' })
       .select()


### PR DESCRIPTION
## Linked Issue
Fixes #708

## Description
Enforced validation for `draftType` against supported enum values (`forum_post`, `comment`, `article`) in `app/api/drafts/route.js`.

- Prevents arbitrary string values from being saved into the `user_drafts` table.
- Sanitizes empty `categoryId` strings to `null` to avoid UUID cast errors.
- Adds string type guarding for all user-supplied fields.

## Type of Change
- [x] Bug fix
- [x] Security / Validation

## Checklist
- [x] Linked issue using `Fixes #708`.
- [x] Added ECSoc26 label.