### PR TITLE
[ECSoC26] API: Enforce input validation and type safety in /api/admin/oauth/providers

### DIFF
--- a/app/api/admin/oauth/providers/route.js
+++ b/app/api/admin/oauth/providers/route.js
@@ -8,9 +8,15 @@ export const dynamic = 'force-dynamic';
 
 export async function GET(req) {
   try {
+    await crudLimiter.check(req);
+  } catch (rateLimitError) {
+    return NextResponse.json({ success: false, error: 'Too many requests, please slow down.' }, { status: 429 });
+  }
+
+  try {
     const { isAdmin, userId, reason } = await verifyAdminAccess();
     if (!isAdmin) {
-      return NextResponse.json({ error: reason || 'Forbidden: Admin access required' }, { status: 403 });
+      return NextResponse.json({ success: false, error: reason || 'Forbidden: Admin access required' }, { status: 403 });
     }
 
     const supabase = getSupabaseAdmin();
@@ -21,7 +27,7 @@ export async function GET(req) {
 
     if (error) {
       logger.error(`[Admin OAuth GET] Failed to fetch providers: ${error.message}`);
-      return NextResponse.json({ error: 'Failed to fetch OAuth providers' }, { status: 500 });
+      return NextResponse.json({ success: false, error: 'Failed to fetch OAuth providers' }, { status: 500 });
     }
 
     // Mask client secrets before returning to client UI
@@ -34,7 +40,7 @@ export async function GET(req) {
     return NextResponse.json({ success: true, providers: maskedProviders });
   } catch (error) {
     logger.error(`[Admin OAuth GET] Exception: ${error.message || error}`);
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+    return NextResponse.json({ success: false, error: 'Internal server error' }, { status: 500 });
   }
 }
 
@@ -42,49 +48,54 @@ export async function POST(req) {
   try {
     await crudLimiter.check(req);
   } catch (rateLimitError) {
-    return NextResponse.json({ error: 'Too many requests, please slow down.' }, { status: 429 });
+    return NextResponse.json({ success: false, error: 'Too many requests, please slow down.' }, { status: 429 });
   }
 
   try {
     const { isAdmin, userId, reason } = await verifyAdminAccess();
     if (!isAdmin) {
-      return NextResponse.json({ error: reason || 'Forbidden: Admin access required' }, { status: 403 });
+      return NextResponse.json({ success: false, error: reason || 'Forbidden: Admin access required' }, { status: 403 });
     }
 
     let body;
     try {
       body = await req.json();
     } catch (e) {
-      return NextResponse.json({ error: 'Invalid JSON payload' }, { status: 400 });
+      return NextResponse.json({ success: false, error: 'Invalid JSON payload' }, { status: 400 });
     }
 
     const { id, name, client_id, client_secret, is_enabled, scopes } = body;
 
-    if (!id) {
-      return NextResponse.json({ error: 'Provider ID is required' }, { status: 400 });
+    if (!id || typeof id !== 'string' || !id.trim()) {
+      return NextResponse.json({ success: false, error: 'Provider ID is required' }, { status: 400 });
     }
 
+    const sanitizedId = id.trim().toLowerCase();
     const supabase = getSupabaseAdmin();
 
     // Fetch existing provider record to compare changes
     const { data: existing } = await supabase
       .from('oauth_providers')
       .select('*')
-      .eq('id', id)
+      .eq('id', sanitizedId)
       .maybeSingle();
 
+    const sanitizedScopes = Array.isArray(scopes)
+      ? scopes.filter((s) => typeof s === 'string' && s.trim()).map((s) => s.trim())
+      : existing?.scopes || [];
+
     const updatePayload = {
-      id,
-      name: name || existing?.name || id,
-      client_id: client_id !== undefined ? client_id : existing?.client_id || '',
-      is_enabled: is_enabled !== undefined ? is_enabled : existing?.is_enabled || false,
-      scopes: Array.isArray(scopes) ? scopes : existing?.scopes || [],
+      id: sanitizedId,
+      name: typeof name === 'string' && name.trim() ? name.trim() : existing?.name || sanitizedId,
+      client_id: client_id !== undefined ? (typeof client_id === 'string' ? client_id.trim() : '') : existing?.client_id || '',
+      is_enabled: is_enabled !== undefined ? Boolean(is_enabled) : existing?.is_enabled || false,
+      scopes: sanitizedScopes,
       updated_at: new Date().toISOString(),
     };
 
     // Only update client_secret if provided and not masked
-    if (client_secret && !client_secret.startsWith('••••')) {
-      updatePayload.client_secret = client_secret;
+    if (typeof client_secret === 'string' && client_secret.trim() && !client_secret.startsWith('••••')) {
+      updatePayload.client_secret = client_secret.trim();
     }
 
     const { data: updated, error } = await supabase
@@ -94,25 +105,25 @@ export async function POST(req) {
       .single();
 
     if (error) {
-      logger.error(`[Admin OAuth POST] Failed to update provider ${id}: ${error.message}`);
-      return NextResponse.json({ error: 'Failed to update OAuth provider' }, { status: 500 });
+      logger.error(`[Admin OAuth POST] Failed to update provider ${sanitizedId}: ${error.message}`);
+      return NextResponse.json({ success: false, error: 'Failed to update OAuth provider' }, { status: 500 });
     }
 
     // Determine event type for auth_logs
     let eventType = 'CREDENTIALS_UPDATED';
     let eventStatus = 'info';
-    let eventMsg = `OAuth credentials updated for ${updated.name || id}`;
+    let eventMsg = `OAuth credentials updated for ${updated.name || sanitizedId}`;
 
     if (existing && existing.is_enabled !== updated.is_enabled) {
       eventType = updated.is_enabled ? 'PROVIDER_ENABLED' : 'PROVIDER_DISABLED';
       eventStatus = updated.is_enabled ? 'success' : 'warning';
-      eventMsg = `OAuth provider ${updated.name || id} ${updated.is_enabled ? 'enabled' : 'disabled'}`;
+      eventMsg = `OAuth provider ${updated.name || sanitizedId} ${updated.is_enabled ? 'enabled' : 'disabled'}`;
     }
 
     // Insert log entry into auth_logs
     await supabase.from('auth_logs').insert([
       {
-        provider: id,
+        provider: sanitizedId,
         event: eventType,
         status: eventStatus,
         message: eventMsg,
@@ -131,7 +142,7 @@ export async function POST(req) {
     });
   } catch (error) {
     logger.error(`[Admin OAuth POST] Exception: ${error.message || error}`);
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+    return NextResponse.json({ success: false, error: 'Internal server error' }, { status: 500 });
   }
 }
 


### PR DESCRIPTION
## Linked Issue
Fixes #728

## Description
Enforced rate limiting, input validation, and type safety in `app/api/admin/oauth/providers/route.js`.

- Added `crudLimiter.check(req)` to `GET` requests.
- Enforced boolean casting on `is_enabled` and string sanitization on `scopes` arrays to prevent malformed values from entering `oauth_providers`.
- Standardized error responses to use uniform `{ success: false, error: ... }` envelope.

## Type of Change
- [x] Bug fix
- [x] Security / Validation

## Checklist
- [x] Linked issue using `Fixes #728`.
- [x] Added ECSoc26 label.