### PR TITLE
[ECSoC26] API: Apply partial updates in /api/profile instead of upserting a row of defaults

### DIFF
--- a/app/api/profile/route.js
+++ b/app/api/profile/route.js
@@ -1,48 +1,33 @@
-import { z } from 'zod'
 import { getAuthUserId } from '@/lib/clerk-server'
 import { getSupabaseAdmin } from '@/lib/supabase-admin'
 import { logger } from '@/lib/logger'
+import { crudLimiter } from '@/lib/rateLimiter'
 import { jsonSuccess, jsonError } from '@/lib/api-helpers'
+import {
+  buildInsertRecord,
+  buildUpdateRecord,
+  mergeProfile,
+  readProfilePatch,
+} from '@/lib/profile-merge'
 
-const profileSchema = z.object({
-  age: z
-    .union([z.number(), z.string()])
-    .nullable()
-    .optional()
-    .transform((val) => (val === '' || val === null || val === undefined ? null : Number(val)))
-    .refine((val) => val === null || (Number.isFinite(val) && val >= 1 && val <= 120), {
-      message: 'Age must be a valid number between 1 and 120',
-    }),
-  weight_kg: z
-    .union([z.number(), z.string()])
-    .nullable()
-    .optional()
-    .transform((val) => (val === '' || val === null || val === undefined ? null : Number(val)))
-    .refine((val) => val === null || (Number.isFinite(val) && val >= 1 && val <= 500), {
-      message: 'Weight must be a valid number between 1 and 500 kg',
-    }),
-  height_cm: z
-    .union([z.number(), z.string()])
-    .nullable()
-    .optional()
-    .transform((val) => (val === '' || val === null || val === undefined ? null : Number(val)))
-    .refine((val) => val === null || (Number.isFinite(val) && val >= 1 && val <= 300), {
-      message: 'Height must be a valid number between 1 and 300 cm',
-    }),
-  cycleLength: z
-    .union([z.number(), z.string()])
-    .nullable()
-    .optional()
-    .transform((val) => (val === '' || val === null || val === undefined ? null : Number(val)))
-    .refine((val) => val === null || (Number.isFinite(val) && val >= 15 && val <= 60), {
-      message: 'Cycle length must be between 15 and 60 days',
-    }),
-  known_conditions: z.array(z.string()).optional().default([]),
-  cycle_goal: z.string().nullable().optional(),
-  allow_ai_analysis: z.boolean().optional().default(true),
-})
+/**
+ * Postgres unique-violation. Raised when two concurrent first-time saves both
+ * find no row and both try to insert; the loser retries as an update.
+ */
+const UNIQUE_VIOLATION = '23505'
+
+/** Columns the client is allowed to read back. */
+const PROFILE_COLUMNS =
+  'user_id, age, weight_kg, height_cm, cycle_length, known_conditions, cycle_goal, allow_ai_analysis, updated_at'
 
 export async function GET(request) {
+  try {
+    await crudLimiter.check(request)
+  } catch (rateLimitError) {
+    logger.warn(`[Rate Limit] Profile GET endpoint: ${rateLimitError.message}`)
+    return jsonError('Too many requests, please slow down.', 429)
+  }
+
   try {
     const userId = await getAuthUserId()
     if (!userId) {
@@ -68,7 +53,32 @@ export async function GET(request) {
   }
 }
 
+/**
+ * Applies a partial profile update.
+ *
+ * This route used to parse the body with a Zod schema carrying `.default(...)`
+ * values and then upsert the whole row it built from the result. Because every
+ * caller sends a subset, that wrote defaults over columns nobody mentioned:
+ *
+ *  - `PrivacySettingsModal` posts only `{ allow_ai_analysis }`, so toggling the
+ *    AI switch cleared the user's age, weight, height, conditions and goal;
+ *  - `HealthProfileSettings` posts no `allow_ai_analysis`, so saving the health
+ *    form flipped a stored opt-*out* back to `true` and re-enabled the model
+ *    call that `app/api/chat/route.js` gates on that flag.
+ *
+ * `readProfilePatch` now reports only the columns the body actually mentions,
+ * and the write path below touches only those. An absent key cannot reach the
+ * database; an explicit `null` still can, because clearing a field is a real
+ * instruction and has to remain expressible.
+ */
 export async function POST(request) {
+  try {
+    await crudLimiter.check(request)
+  } catch (rateLimitError) {
+    logger.warn(`[Rate Limit] Profile POST endpoint: ${rateLimitError.message}`)
+    return jsonError('Too many requests, please slow down.', 429)
+  }
+
   try {
     const userId = await getAuthUserId()
     if (!userId) {
@@ -83,46 +93,85 @@ export async function POST(request) {
       return jsonError('Bad Request: Invalid JSON payload', 400)
     }
 
-    if (!body || typeof body !== 'object' || Array.isArray(body)) {
-      return jsonError('Invalid payload', 400)
-    }
-
-    const parseResult = profileSchema.safeParse(body)
-    if (!parseResult.success) {
-      const firstIssue = parseResult.error.issues[0]
-      return jsonError(firstIssue?.message || 'Invalid payload', 400)
-    }
-
-    const validatedData = parseResult.data
-
-    const profileRecord = {
-      user_id: userId,
-      age: validatedData.age,
-      weight_kg: validatedData.weight_kg,
-      height_cm: validatedData.height_cm,
-      known_conditions: validatedData.known_conditions || [],
-      cycle_goal: validatedData.cycle_goal || null,
-      allow_ai_analysis: validatedData.allow_ai_analysis,
-      updated_at: new Date().toISOString()
+    const { ok, patch, errors, touched } = readProfilePatch(body)
+    if (!ok) {
+      return jsonError(errors[0], 400, null, errors.length > 1 ? errors : null)
     }
 
     const supabase = getSupabaseAdmin()
-    const { data, error } = await supabase
-      .from('user_profiles')
-      .upsert(profileRecord, { onConflict: 'user_id' })
-      .select()
+    const saved = await writeProfilePatch(supabase, userId, patch)
 
-    if (error) {
-      logger.error('Error saving user profile:', error)
+    if (!saved.ok) {
+      logger.error('Error saving user profile:', saved.error)
       return jsonError('Database error', 500)
     }
 
-    const savedProfile = Array.isArray(data) ? (data[0] || profileRecord) : (data || profileRecord)
+    logger.info(`Profile updated for user ${userId} (fields: ${touched.join(', ')})`)
 
-    return jsonSuccess({ profile: savedProfile, ...savedProfile })
+    const profile = saved.profile
+    return jsonSuccess({ profile, ...profile, updatedFields: touched })
   } catch (err) {
     logger.error('Profile POST error:', err)
     return jsonError('Internal Server Error', 500)
   }
 }
 
+/**
+ * Writes `patch` for `userId`, touching no other column.
+ *
+ * `UPDATE` is attempted first because it names only the patched columns, so a
+ * concurrent write to a *different* field cannot be clobbered — which an
+ * upsert of a whole row would do. `INSERT` runs only when no row matched, and
+ * a unique violation from a racing first-time save falls back to `UPDATE`.
+ *
+ * @param {object} supabase Supabase admin client
+ * @param {string} userId
+ * @param {object} patch from `readProfilePatch`
+ * @returns {Promise<{ ok: true, profile: object } | { ok: false, error: object }>}
+ */
+async function writeProfilePatch(supabase, userId, patch) {
+  const updated = await supabase
+    .from('user_profiles')
+    .update(buildUpdateRecord(patch))
+    .eq('user_id', userId)
+    .select(PROFILE_COLUMNS)
+
+  if (updated.error) {
+    return { ok: false, error: updated.error }
+  }
+
+  if (Array.isArray(updated.data) && updated.data.length > 0) {
+    return { ok: true, profile: updated.data[0] }
+  }
+
+  const insertRecord = buildInsertRecord(userId, patch)
+  const inserted = await supabase
+    .from('user_profiles')
+    .insert(insertRecord)
+    .select(PROFILE_COLUMNS)
+
+  if (!inserted.error) {
+    const row = Array.isArray(inserted.data) ? inserted.data[0] : inserted.data
+    return { ok: true, profile: row || insertRecord }
+  }
+
+  if (inserted.error.code !== UNIQUE_VIOLATION) {
+    return { ok: false, error: inserted.error }
+  }
+
+  // Another request created the row between our UPDATE and our INSERT. Re-run
+  // the update so the patch still lands, and merge locally if the retry also
+  // returns no representation.
+  const retried = await supabase
+    .from('user_profiles')
+    .update(buildUpdateRecord(patch))
+    .eq('user_id', userId)
+    .select(PROFILE_COLUMNS)
+
+  if (retried.error) {
+    return { ok: false, error: retried.error }
+  }
+
+  const row = Array.isArray(retried.data) ? retried.data[0] : retried.data
+  return { ok: true, profile: mergeProfile(row, patch) }
+}

--- a/components/layout/HealthProfileSettings.jsx
+++ b/components/layout/HealthProfileSettings.jsx
@@ -20,6 +20,7 @@ export default function HealthProfileSettings() {
     age: '',
     weight_kg: '',
     height_cm: '',
+    cycle_length: '',
     known_conditions: [],
     cycle_goal: ''
   })
@@ -38,6 +39,7 @@ export default function HealthProfileSettings() {
           age: data.profile.age !== null && data.profile.age !== undefined ? data.profile.age : '',
           weight_kg: data.profile.weight_kg !== null && data.profile.weight_kg !== undefined ? data.profile.weight_kg : '',
           height_cm: data.profile.height_cm !== null && data.profile.height_cm !== undefined ? data.profile.height_cm : '',
+          cycle_length: data.profile.cycle_length !== null && data.profile.cycle_length !== undefined ? data.profile.cycle_length : '',
           known_conditions: data.profile.known_conditions || [],
           cycle_goal: data.profile.cycle_goal || ''
         })
@@ -76,10 +78,15 @@ export default function HealthProfileSettings() {
     e.preventDefault()
     setSaving(true)
     try {
+      // Only the fields this form owns. `allow_ai_analysis` is deliberately
+      // absent: the API treats an omitted key as "leave it alone", so saving
+      // here can no longer overwrite the consent choice made in Privacy
+      // settings.
       const payload = {
         age: formData.age ? parseInt(formData.age, 10) : null,
         weight_kg: formData.weight_kg ? parseFloat(formData.weight_kg) : null,
         height_cm: formData.height_cm ? parseFloat(formData.height_cm) : null,
+        cycle_length: formData.cycle_length ? parseInt(formData.cycle_length, 10) : null,
         known_conditions: formData.known_conditions,
         cycle_goal: formData.cycle_goal
       }
@@ -98,6 +105,7 @@ export default function HealthProfileSettings() {
             age: data.profile.age !== null && data.profile.age !== undefined ? data.profile.age : '',
             weight_kg: data.profile.weight_kg !== null && data.profile.weight_kg !== undefined ? data.profile.weight_kg : '',
             height_cm: data.profile.height_cm !== null && data.profile.height_cm !== undefined ? data.profile.height_cm : '',
+            cycle_length: data.profile.cycle_length !== null && data.profile.cycle_length !== undefined ? data.profile.cycle_length : '',
             known_conditions: data.profile.known_conditions || [],
             cycle_goal: data.profile.cycle_goal || ''
           })
@@ -172,6 +180,28 @@ export default function HealthProfileSettings() {
               className="w-full bg-white/10 border border-white/20 rounded-xl px-4 py-2 text-white placeholder:text-white/40 focus:outline-none focus:ring-2 focus:ring-pink-500/50"
               placeholder="e.g. 165"
             />
+          </div>
+
+          <div className="space-y-2 sm:col-span-2">
+            <label htmlFor="profile-cycle-length" className="text-sm font-medium text-white/90">
+              Average Cycle Length (days)
+            </label>
+            <input
+              id="profile-cycle-length"
+              type="number"
+              name="cycle_length"
+              value={formData.cycle_length}
+              onChange={handleChange}
+              step="1"
+              min="15"
+              max="60"
+              aria-describedby="profile-cycle-length-hint"
+              className="w-full bg-white/10 border border-white/20 rounded-xl px-4 py-2 text-white placeholder:text-white/40 focus:outline-none focus:ring-2 focus:ring-pink-500/50"
+              placeholder="e.g. 28"
+            />
+            <p id="profile-cycle-length-hint" className="text-xs text-white/50">
+              Leave blank to let predictions rely purely on your logged history.
+            </p>
           </div>
         </div>
 

--- a/lib/profile-merge.js
+++ b/lib/profile-merge.js
@@ -96,10 +96,28 @@ function isCleared(value) {
   return value === null || (typeof value === 'string' && value.trim() === '')
 }
 
+/** A balanced, non-nesting tag-like group, removed for readability. */
+const TAG_LIKE = /<[^<>]*>/g
+
+/** Any angle bracket at all. Removing these is what makes the result safe. */
+const ANGLE_BRACKETS = /[<>]/g
+
 /**
- * Strips tags and control characters from free text and trims it to length.
- * Mirrors `sanitizeText` in `lib/api-helpers.js`; kept local so this module
- * stays dependency-free.
+ * Normalises free text: control characters out, markup out, whitespace
+ * collapsed, length capped.
+ *
+ * This deliberately does *not* mirror `sanitizeText` in `lib/api-helpers.js`,
+ * which strips `<script>...</script>` and then `<[^>]*>`. Filtering HTML by
+ * removing tag patterns is incomplete by construction, and CodeQL flags it as
+ * such: `<scr<script>ipt>` becomes `<script>` after one pass, and `</script >`
+ * does not match the end-tag pattern at all.
+ *
+ * The approach here does not try to recognise markup. Tag-like groups are
+ * removed repeatedly, purely so a value stays readable, and then **every
+ * remaining angle bracket is removed**. That second pass is the guarantee: no
+ * element, partial or nested, can exist in a string containing no `<` and no
+ * `>`. It is also the right shape for this field specifically — a cycle goal
+ * or a condition name has no legitimate use for either character.
  *
  * @param {string} value
  * @param {number} [maxLength]
@@ -107,10 +125,17 @@ function isCleared(value) {
  */
 export function sanitizeProfileText(value, maxLength = MAX_TEXT_LENGTH) {
   if (typeof value !== 'string') return ''
-  return value
-    .replace(/<script[\s\S]*?<\/script>/gi, '')
-    .replace(/<[^>]*>/g, '')
-    .replace(CONTROL_CHARS, ' ')
+
+  let text = value.replace(CONTROL_CHARS, ' ')
+
+  let previous
+  do {
+    previous = text
+    text = text.replace(TAG_LIKE, '')
+  } while (text !== previous)
+
+  return text
+    .replace(ANGLE_BRACKETS, '')
     .replace(/\s+/g, ' ')
     .trim()
     .slice(0, maxLength)

--- a/lib/profile-merge.js
+++ b/lib/profile-merge.js
@@ -1,0 +1,336 @@
+/**
+ * profile-merge.js — turns a `POST /api/profile` body into a *patch*.
+ *
+ * ## Why this module exists
+ *
+ * `app/api/profile/route.js` used to validate the request with a Zod schema
+ * whose optional fields carried `.default(...)` values, and then upsert the
+ * whole row it built from the parsed result. That combination is a silent
+ * data-loss machine: a key the caller never sent does not stay untouched, it
+ * is materialised as `null` / `[]` / `true` and written over whatever was
+ * stored.
+ *
+ * Every caller in the app sends a subset, so both directions were broken:
+ *
+ *  - `PrivacySettingsModal` posts `{ allow_ai_analysis: false }` and nothing
+ *    else, so flipping the AI toggle wiped the user's age, weight, height,
+ *    conditions and cycle goal.
+ *  - `HealthProfileSettings` posts the health fields and no
+ *    `allow_ai_analysis`, so the `.default(true)` opted a user who had
+ *    explicitly opted *out* back in. `app/api/chat/route.js` gates the model
+ *    call on that flag, so the consequence was personal cycle data reaching a
+ *    third-party model against a recorded consent decision.
+ *
+ * The fix is to stop inferring absent fields at all. This module reports
+ * exactly which recognised fields a body *mentions*, normalised and range
+ * checked; the route writes only those columns. A field nobody mentioned is
+ * not in the patch, so it cannot be written.
+ *
+ * The module has no imports, so it is usable from a Route Handler, a Server
+ * Component and a plain Node test script alike.
+ */
+
+/** Widest range the UI can produce for each numeric field. */
+const NUMERIC_BOUNDS = {
+  age: { min: 1, max: 120, integer: true },
+  weight_kg: { min: 1, max: 500, integer: false },
+  height_cm: { min: 1, max: 300, integer: false },
+  cycle_length: { min: 15, max: 60, integer: true },
+}
+
+/**
+ * ASCII control characters and DEL. Built with `new RegExp` from an escaped
+ * string so the source file stays plain ASCII and stays reviewable in a diff.
+ */
+const CONTROL_CHARS = new RegExp('[\\u0000-\\u001f\\u007f]', 'g')
+
+/** Longest free-text value accepted, to keep a hostile body bounded. */
+export const MAX_TEXT_LENGTH = 120
+
+/** Most conditions a profile may carry. The picker offers far fewer. */
+export const MAX_CONDITIONS = 20
+
+/**
+ * Every column this endpoint may write. `aliases` exist because the app has
+ * historically spelled the same field two ways — `cycleLength` from the
+ * profile schema, `cycle_length` from onboarding — and dropping one of them
+ * silently is what this module is here to prevent.
+ *
+ * @type {ReadonlyArray<{ column: string, aliases: string[], kind: string }>}
+ */
+export const PROFILE_FIELDS = Object.freeze([
+  { column: 'age', aliases: ['age'], kind: 'number' },
+  { column: 'weight_kg', aliases: ['weight_kg', 'weightKg', 'weight'], kind: 'number' },
+  { column: 'height_cm', aliases: ['height_cm', 'heightCm', 'height'], kind: 'number' },
+  { column: 'cycle_length', aliases: ['cycle_length', 'cycleLength'], kind: 'number' },
+  { column: 'known_conditions', aliases: ['known_conditions', 'knownConditions'], kind: 'stringArray' },
+  { column: 'cycle_goal', aliases: ['cycle_goal', 'cycleGoal'], kind: 'text' },
+  { column: 'allow_ai_analysis', aliases: ['allow_ai_analysis', 'allowAiAnalysis'], kind: 'boolean' },
+])
+
+/**
+ * Human-readable field labels for error messages. Keyed by column so the
+ * message names the concept the user sees rather than the alias they happened
+ * to send.
+ */
+const FIELD_LABELS = {
+  age: 'Age',
+  weight_kg: 'Weight',
+  height_cm: 'Height',
+  cycle_length: 'Cycle length',
+  known_conditions: 'Known conditions',
+  cycle_goal: 'Cycle goal',
+  allow_ai_analysis: 'AI analysis preference',
+}
+
+/**
+ * True when `value` counts as "the user cleared this field" rather than "the
+ * user did not mention it". An explicit `null` or `''` is a real instruction
+ * and is kept in the patch as `null`; `undefined` is absence and never
+ * reaches a coercer.
+ *
+ * @param {unknown} value
+ * @returns {boolean}
+ */
+function isCleared(value) {
+  return value === null || (typeof value === 'string' && value.trim() === '')
+}
+
+/**
+ * Strips tags and control characters from free text and trims it to length.
+ * Mirrors `sanitizeText` in `lib/api-helpers.js`; kept local so this module
+ * stays dependency-free.
+ *
+ * @param {string} value
+ * @param {number} [maxLength]
+ * @returns {string}
+ */
+export function sanitizeProfileText(value, maxLength = MAX_TEXT_LENGTH) {
+  if (typeof value !== 'string') return ''
+  return value
+    .replace(/<script[\s\S]*?<\/script>/gi, '')
+    .replace(/<[^>]*>/g, '')
+    .replace(CONTROL_CHARS, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, maxLength)
+}
+
+/**
+ * Coerces and range-checks one numeric field.
+ *
+ * Strings are accepted because the profile form posts `<input type="number">`
+ * values, which arrive as strings whenever the field was typed rather than
+ * stepped.
+ *
+ * @param {string} column
+ * @param {unknown} raw
+ * @returns {{ ok: true, value: number|null } | { ok: false, message: string }}
+ */
+function coerceNumber(column, raw) {
+  if (isCleared(raw)) return { ok: true, value: null }
+
+  const bounds = NUMERIC_BOUNDS[column]
+  const numeric = typeof raw === 'number' ? raw : Number(String(raw).trim())
+
+  if (!Number.isFinite(numeric)) {
+    return { ok: false, message: `${FIELD_LABELS[column]} must be a number` }
+  }
+
+  const value = bounds.integer ? Math.round(numeric) : Math.round(numeric * 10) / 10
+
+  if (value < bounds.min || value > bounds.max) {
+    return {
+      ok: false,
+      message: `${FIELD_LABELS[column]} must be between ${bounds.min} and ${bounds.max}`,
+    }
+  }
+
+  return { ok: true, value }
+}
+
+/**
+ * Coerces the consent flag. Only real booleans and the two canonical string
+ * spellings are accepted — a truthy-string coercion here would turn `"false"`
+ * into `true`, which is the exact direction this bug already failed in once.
+ *
+ * @param {string} column
+ * @param {unknown} raw
+ * @returns {{ ok: true, value: boolean } | { ok: false, message: string }}
+ */
+function coerceBoolean(column, raw) {
+  if (typeof raw === 'boolean') return { ok: true, value: raw }
+  if (raw === 'true') return { ok: true, value: true }
+  if (raw === 'false') return { ok: true, value: false }
+
+  return { ok: false, message: `${FIELD_LABELS[column]} must be true or false` }
+}
+
+/**
+ * Coerces the conditions list: sanitised, de-duplicated case-insensitively,
+ * empties dropped, capped. An explicit empty array is a legitimate "clear my
+ * conditions" instruction and is preserved.
+ *
+ * @param {string} column
+ * @param {unknown} raw
+ * @returns {{ ok: true, value: string[] } | { ok: false, message: string }}
+ */
+function coerceStringArray(column, raw) {
+  if (raw === null) return { ok: true, value: [] }
+  if (!Array.isArray(raw)) {
+    return { ok: false, message: `${FIELD_LABELS[column]} must be a list` }
+  }
+
+  const seen = new Set()
+  const value = []
+
+  for (const entry of raw) {
+    if (typeof entry !== 'string') continue
+    const cleaned = sanitizeProfileText(entry, 60)
+    if (!cleaned) continue
+
+    const key = cleaned.toLowerCase()
+    if (seen.has(key)) continue
+
+    seen.add(key)
+    value.push(cleaned)
+    if (value.length >= MAX_CONDITIONS) break
+  }
+
+  return { ok: true, value }
+}
+
+/**
+ * Coerces a free-text field. A cleared value becomes `null` rather than `''`
+ * so the column reads the same whichever spelling the client used.
+ *
+ * @param {string} column
+ * @param {unknown} raw
+ * @returns {{ ok: true, value: string|null } | { ok: false, message: string }}
+ */
+function coerceText(column, raw) {
+  if (isCleared(raw)) return { ok: true, value: null }
+  if (typeof raw !== 'string') {
+    return { ok: false, message: `${FIELD_LABELS[column]} must be text` }
+  }
+
+  return { ok: true, value: sanitizeProfileText(raw) || null }
+}
+
+const COERCERS = {
+  number: coerceNumber,
+  boolean: coerceBoolean,
+  stringArray: coerceStringArray,
+  text: coerceText,
+}
+
+/**
+ * Finds the alias a body actually used for a field, preferring the canonical
+ * column name when a body redundantly supplies more than one spelling.
+ *
+ * @param {object} body
+ * @param {{ column: string, aliases: string[] }} field
+ * @returns {string|null} the key present in `body`, or `null`
+ */
+function findAlias(body, field) {
+  for (const alias of field.aliases) {
+    if (Object.prototype.hasOwnProperty.call(body, alias) && body[alias] !== undefined) {
+      return alias
+    }
+  }
+  return null
+}
+
+/**
+ * Reads a request body into a patch of the columns it mentions.
+ *
+ * Absence and clearing are deliberately distinct outcomes:
+ *
+ *  - a key that is missing, or present as `undefined`, does not appear in
+ *    `patch` at all, so the route never writes that column;
+ *  - a key present as `null` (or `''` for text) appears in `patch` as `null`,
+ *    which the route writes — the user asked to clear it.
+ *
+ * @param {unknown} body parsed JSON request body
+ * @returns {{ ok: boolean, patch: object, errors: string[], touched: string[] }}
+ */
+export function readProfilePatch(body) {
+  const patch = {}
+  const errors = []
+  const touched = []
+
+  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+    return { ok: false, patch, errors: ['Invalid payload'], touched }
+  }
+
+  for (const field of PROFILE_FIELDS) {
+    const alias = findAlias(body, field)
+    if (alias === null) continue
+
+    const result = COERCERS[field.kind](field.column, body[alias])
+
+    if (!result.ok) {
+      errors.push(result.message)
+      continue
+    }
+
+    patch[field.column] = result.value
+    touched.push(field.column)
+  }
+
+  if (errors.length === 0 && touched.length === 0) {
+    errors.push('No recognised profile fields were provided')
+  }
+
+  return { ok: errors.length === 0, patch, errors, touched }
+}
+
+/**
+ * The row to insert when a user has no profile yet. Only the patched columns
+ * carry a caller-supplied value; the rest are explicit defaults, which is safe
+ * here precisely because there is nothing to overwrite.
+ *
+ * @param {string} userId
+ * @param {object} patch from {@link readProfilePatch}
+ * @param {string} [timestamp] ISO timestamp, injectable for tests
+ * @returns {object}
+ */
+export function buildInsertRecord(userId, patch, timestamp = new Date().toISOString()) {
+  return {
+    user_id: userId,
+    age: null,
+    weight_kg: null,
+    height_cm: null,
+    cycle_length: null,
+    known_conditions: [],
+    cycle_goal: null,
+    allow_ai_analysis: true,
+    ...patch,
+    updated_at: timestamp,
+  }
+}
+
+/**
+ * The column set to send to `UPDATE` for an existing profile: the patch and
+ * nothing else, so an untouched column keeps its stored value.
+ *
+ * @param {object} patch from {@link readProfilePatch}
+ * @param {string} [timestamp] ISO timestamp, injectable for tests
+ * @returns {object}
+ */
+export function buildUpdateRecord(patch, timestamp = new Date().toISOString()) {
+  return { ...patch, updated_at: timestamp }
+}
+
+/**
+ * Applies a patch to an existing row in memory. Used to answer the request
+ * when the database returns no representation, and by the tests to assert the
+ * merge semantics directly.
+ *
+ * @param {object|null} existing
+ * @param {object} patch
+ * @returns {object}
+ */
+export function mergeProfile(existing, patch) {
+  return { ...(existing && typeof existing === 'object' ? existing : {}), ...patch }
+}

--- a/scripts/test-profile-merge.js
+++ b/scripts/test-profile-merge.js
@@ -222,7 +222,17 @@ check(readProfilePatch({ known_conditions: 'PCOS' }).ok, false,
 console.log('\ntext sanitisation')
 
 check(sanitizeProfileText('<b>Regular cycle</b>'), 'Regular cycle', 'tags are stripped from free text')
-check(sanitizeProfileText('<script>alert(1)</script>ok'), 'ok', 'script bodies are removed entirely')
+check(sanitizeProfileText('<script>alert(1)</script>ok'), 'alert(1)ok',
+  'the tags go and the text between them survives as plain text -- there is no script without a tag')
+check(sanitizeProfileText('<scr<script>ipt>alert(1)'), 'alert(1)',
+  'a nested construct that reassembles into a tag after one pass is removed by the next one')
+check(sanitizeProfileText('</script >x'), 'x',
+  'an end tag with trailing whitespace is removed, which a naive end-tag pattern misses')
+check(sanitizeProfileText('a < b > c'), 'a c', 'anything between stray angle brackets goes with them')
+checkTruthy(
+  !sanitizeProfileText('<img src=x onerror=alert(1)>').includes('<'),
+  'no angle bracket survives, whatever the input'
+)
 check(sanitizeProfileText(`a${String.fromCharCode(9)}b`), 'a b', 'control characters collapse to a space')
 check(sanitizeProfileText('a'.repeat(500)).length, 120, 'free text is capped at the documented length')
 check(sanitizeProfileText(42), '', 'a non-string sanitises to empty rather than throwing')

--- a/scripts/test-profile-merge.js
+++ b/scripts/test-profile-merge.js
@@ -1,0 +1,273 @@
+/**
+ * Regression suite for lib/profile-merge.js.
+ *
+ * The bug this is part of fixing: `POST /api/profile` validated the body with
+ * a Zod schema whose optional fields carried `.default(...)` values, then
+ * upserted the whole row it built from the parsed result. Because no caller in
+ * the app sends every field, each save silently overwrote the columns it left
+ * out.
+ *
+ * Two user-visible regressions came out of that, and both are asserted below:
+ *
+ *  1. `PrivacySettingsModal` posts `{ allow_ai_analysis: false }` and nothing
+ *     else. The old route then wrote `age: null, weight_kg: null,
+ *     height_cm: null, known_conditions: [], cycle_goal: null` — flipping the
+ *     AI toggle erased the health profile, with a success toast on top.
+ *
+ *  2. `HealthProfileSettings` posts the health fields and no
+ *     `allow_ai_analysis`. The `.default(true)` turned a recorded opt-*out*
+ *     back into an opt-in, and `app/api/chat/route.js` gates the Gemini call on
+ *     exactly that flag.
+ *
+ * The distinction the whole module turns on is absence vs. clearing: a key
+ * nobody sent must not appear in the patch, while an explicit `null` must,
+ * because "clear my weight" has to stay expressible.
+ *
+ *   node scripts/test-profile-merge.js
+ */
+
+import {
+  MAX_CONDITIONS,
+  PROFILE_FIELDS,
+  buildInsertRecord,
+  buildUpdateRecord,
+  mergeProfile,
+  readProfilePatch,
+  sanitizeProfileText,
+} from '../lib/profile-merge.js'
+
+let passed = 0
+let failed = 0
+
+function check(actual, expected, label) {
+  if (Object.is(actual, expected)) {
+    passed += 1
+    return
+  }
+  failed += 1
+  console.error(`  ${label}`)
+  console.error(`       expected: ${JSON.stringify(expected)}`)
+  console.error(`       actual:   ${JSON.stringify(actual)}`)
+}
+
+function checkDeep(actual, expected, label) {
+  const a = JSON.stringify(actual)
+  const b = JSON.stringify(expected)
+  if (a === b) {
+    passed += 1
+    return
+  }
+  failed += 1
+  console.error(`  ${label}`)
+  console.error(`       expected: ${b}`)
+  console.error(`       actual:   ${a}`)
+}
+
+function checkTruthy(value, label) {
+  check(Boolean(value), true, label)
+}
+
+// ---------------------------------------------------------------------------
+// The two regressions that motivated the change
+// ---------------------------------------------------------------------------
+
+console.log('\nprivacy toggle must not touch the health profile')
+
+const privacyOnly = readProfilePatch({ allow_ai_analysis: false })
+
+checkTruthy(privacyOnly.ok, 'a single-field privacy payload is accepted')
+checkDeep(privacyOnly.touched, ['allow_ai_analysis'], 'only the consent flag is reported as touched')
+checkDeep(
+  Object.keys(privacyOnly.patch),
+  ['allow_ai_analysis'],
+  'the patch names no column the caller did not send'
+)
+check(privacyOnly.patch.age, undefined, 'age is absent from the patch, not null')
+check(privacyOnly.patch.known_conditions, undefined, 'known_conditions is absent, not an empty array')
+check(privacyOnly.patch.cycle_goal, undefined, 'cycle_goal is absent, not null')
+
+const storedProfile = {
+  user_id: 'user_1',
+  age: 29,
+  weight_kg: 61.5,
+  height_cm: 165,
+  cycle_length: 30,
+  known_conditions: ['PCOS'],
+  cycle_goal: 'Understand my cycle',
+  allow_ai_analysis: true,
+}
+
+const afterToggle = mergeProfile(storedProfile, privacyOnly.patch)
+check(afterToggle.age, 29, 'age survives the privacy toggle')
+check(afterToggle.weight_kg, 61.5, 'weight survives the privacy toggle')
+check(afterToggle.height_cm, 165, 'height survives the privacy toggle')
+check(afterToggle.cycle_length, 30, 'cycle length survives the privacy toggle')
+checkDeep(afterToggle.known_conditions, ['PCOS'], 'conditions survive the privacy toggle')
+check(afterToggle.cycle_goal, 'Understand my cycle', 'cycle goal survives the privacy toggle')
+check(afterToggle.allow_ai_analysis, false, 'the flag the user actually changed is applied')
+
+console.log('\nsaving the health form must not re-enable AI analysis')
+
+const optedOut = { ...storedProfile, allow_ai_analysis: false }
+const healthOnly = readProfilePatch({
+  age: 30,
+  weight_kg: 62,
+  height_cm: 165,
+  known_conditions: ['PCOS', 'Thyroid'],
+  cycle_goal: 'Track symptoms',
+})
+
+checkTruthy(healthOnly.ok, 'the health-form payload is accepted')
+check(
+  Object.prototype.hasOwnProperty.call(healthOnly.patch, 'allow_ai_analysis'),
+  false,
+  'an omitted consent flag never enters the patch'
+)
+check(
+  mergeProfile(optedOut, healthOnly.patch).allow_ai_analysis,
+  false,
+  'a stored opt-out is still an opt-out after a health-profile save'
+)
+check(mergeProfile(optedOut, healthOnly.patch).age, 30, 'the health fields the form did send are applied')
+
+// ---------------------------------------------------------------------------
+// Absence vs. clearing
+// ---------------------------------------------------------------------------
+
+console.log('\nabsence and clearing are different instructions')
+
+const cleared = readProfilePatch({ weight_kg: null, cycle_goal: '' })
+checkTruthy(cleared.ok, 'an explicit clear is a valid request')
+check(cleared.patch.weight_kg, null, 'an explicit null clears the column')
+check(cleared.patch.cycle_goal, null, 'an empty string clears a text column')
+check(mergeProfile(storedProfile, cleared.patch).weight_kg, null, 'the clear reaches the merged row')
+check(mergeProfile(storedProfile, cleared.patch).age, 29, 'clearing one field leaves the others alone')
+
+const undefinedKeys = readProfilePatch({ age: 31, weight_kg: undefined })
+check(
+  Object.prototype.hasOwnProperty.call(undefinedKeys.patch, 'weight_kg'),
+  false,
+  'a key present as undefined counts as absent, not as a clear'
+)
+
+const emptyBody = readProfilePatch({})
+check(emptyBody.ok, false, 'a body with no recognised field is rejected')
+check(
+  emptyBody.errors[0],
+  'No recognised profile fields were provided',
+  'the rejection says why rather than writing a row of defaults'
+)
+
+const unknownOnly = readProfilePatch({ nickname: 'ada', favouriteColour: 'green' })
+check(unknownOnly.ok, false, 'unknown keys alone do not constitute an update')
+checkDeep(unknownOnly.patch, {}, 'unknown keys are never forwarded to the database')
+
+// ---------------------------------------------------------------------------
+// Field coercion and bounds
+// ---------------------------------------------------------------------------
+
+console.log('\nfield coercion')
+
+check(readProfilePatch({ age: '30' }).patch.age, 30, 'a numeric string from a number input is coerced')
+check(readProfilePatch({ age: 30.6 }).patch.age, 31, 'age is rounded to a whole year')
+check(readProfilePatch({ weight_kg: '61.47' }).patch.weight_kg, 61.5, 'weight keeps one decimal place')
+
+check(readProfilePatch({ age: 0 }).ok, false, 'age below the floor is rejected')
+check(readProfilePatch({ age: 121 }).ok, false, 'age above the ceiling is rejected')
+check(readProfilePatch({ height_cm: 301 }).ok, false, 'height above the ceiling is rejected')
+check(readProfilePatch({ weight_kg: 'heavy' }).ok, false, 'a non-numeric weight is rejected')
+check(
+  readProfilePatch({ age: 900 }).errors[0],
+  'Age must be between 1 and 120',
+  'the bounds error names the field and the range'
+)
+
+check(readProfilePatch({ allow_ai_analysis: 'false' }).patch.allow_ai_analysis, false,
+  'the string "false" is read as false, not as a truthy string')
+check(readProfilePatch({ allow_ai_analysis: 'true' }).patch.allow_ai_analysis, true,
+  'the string "true" is read as true')
+check(readProfilePatch({ allow_ai_analysis: 0 }).ok, false,
+  'a numeric consent value is rejected rather than guessed at')
+check(readProfilePatch({ allow_ai_analysis: null }).ok, false,
+  'consent cannot be cleared into an ambiguous state')
+
+console.log('\ncycle length is no longer discarded')
+
+check(readProfilePatch({ cycleLength: 31 }).patch.cycle_length, 31,
+  'the camelCase spelling the profile schema accepted maps to the column')
+check(readProfilePatch({ cycle_length: 31 }).patch.cycle_length, 31,
+  'the snake_case spelling onboarding uses maps to the same column')
+check(readProfilePatch({ cycle_length: 14 }).ok, false, 'a cycle length below 15 days is rejected')
+check(readProfilePatch({ cycle_length: 61 }).ok, false, 'a cycle length above 60 days is rejected')
+check(readProfilePatch({ cycleLength: 45, cycle_length: 28 }).patch.cycle_length, 28,
+  'when both spellings are sent the canonical column name wins')
+
+console.log('\nconditions list')
+
+const conditions = readProfilePatch({ known_conditions: ['PCOS', 'pcos', '  ', 'Thyroid', 42] })
+checkDeep(conditions.patch.known_conditions, ['PCOS', 'Thyroid'],
+  'the list is de-duplicated case-insensitively, with blanks and non-strings dropped')
+
+const manyConditions = readProfilePatch({
+  known_conditions: Array.from({ length: MAX_CONDITIONS + 10 }, (_, i) => `Condition ${i}`),
+})
+check(manyConditions.patch.known_conditions.length, MAX_CONDITIONS,
+  'the list is capped so a hostile body cannot grow the row without bound')
+
+check(readProfilePatch({ known_conditions: [] }).patch.known_conditions.length, 0,
+  'an explicit empty list clears the conditions')
+check(readProfilePatch({ known_conditions: 'PCOS' }).ok, false,
+  'a bare string is rejected rather than silently wrapped')
+
+console.log('\ntext sanitisation')
+
+check(sanitizeProfileText('<b>Regular cycle</b>'), 'Regular cycle', 'tags are stripped from free text')
+check(sanitizeProfileText('<script>alert(1)</script>ok'), 'ok', 'script bodies are removed entirely')
+check(sanitizeProfileText(`a${String.fromCharCode(9)}b`), 'a b', 'control characters collapse to a space')
+check(sanitizeProfileText('a'.repeat(500)).length, 120, 'free text is capped at the documented length')
+check(sanitizeProfileText(42), '', 'a non-string sanitises to empty rather than throwing')
+
+// ---------------------------------------------------------------------------
+// Record builders
+// ---------------------------------------------------------------------------
+
+console.log('\nrecord builders')
+
+const updateRecord = buildUpdateRecord({ allow_ai_analysis: false }, '2026-01-01T00:00:00.000Z')
+checkDeep(
+  Object.keys(updateRecord).sort(),
+  ['allow_ai_analysis', 'updated_at'],
+  'an UPDATE names only the patched columns plus the timestamp'
+)
+
+const insertRecord = buildInsertRecord('user_1', { allow_ai_analysis: false }, '2026-01-01T00:00:00.000Z')
+check(insertRecord.user_id, 'user_1', 'an INSERT carries the owner')
+check(insertRecord.allow_ai_analysis, false, 'the patch wins over the insert default')
+check(insertRecord.age, null, 'an unpatched column is explicitly null on a first insert')
+checkDeep(insertRecord.known_conditions, [], 'a first insert starts with an empty conditions list')
+check(insertRecord.cycle_length, null, 'a first insert leaves cycle length unknown rather than assuming 28')
+
+check(mergeProfile(null, { age: 30 }).age, 30, 'merging onto a missing row still yields the patch')
+check(mergeProfile('not a row', { age: 30 }).age, 30, 'a non-object existing row is treated as empty')
+
+// ---------------------------------------------------------------------------
+// Field table integrity
+// ---------------------------------------------------------------------------
+
+console.log('\nfield table')
+
+const columns = PROFILE_FIELDS.map((f) => f.column)
+check(new Set(columns).size, columns.length, 'every field maps to a distinct column')
+
+const allAliases = PROFILE_FIELDS.flatMap((f) => f.aliases)
+check(new Set(allAliases).size, allAliases.length, 'no alias is claimed by two fields')
+
+checkTruthy(
+  PROFILE_FIELDS.every((f) => f.aliases[0] === f.column),
+  'the canonical column name is the first alias, so it wins a tie'
+)
+
+// ---------------------------------------------------------------------------
+
+console.log(`\n${failed === 0 ? 'PASS' : 'FAIL'} ${passed} passed, ${failed} failed`)
+process.exit(failed === 0 ? 0 : 1)

--- a/supabase/09_user_profiles_cycle_length.sql
+++ b/supabase/09_user_profiles_cycle_length.sql
@@ -1,0 +1,26 @@
+-- Migration 09: give user_profiles a home for the average cycle length.
+--
+-- app/api/profile/route.js has always validated a `cycleLength` field (range
+-- 15-60) and then dropped it: the record it upserted never referenced the
+-- value, so the endpoint answered 200 OK and discarded what the user entered.
+-- There was no column to write it to.
+--
+-- The column is nullable with no default: "the user has not told us" and "the
+-- user says 28" are different facts, and only the second one should influence a
+-- prediction.
+
+ALTER TABLE public.user_profiles
+  ADD COLUMN IF NOT EXISTS cycle_length SMALLINT;
+
+-- Same bounds the API enforces, so a direct SQL write cannot store a value the
+-- application would refuse. Deliberately wider than the "normal" clinical range
+-- (21-35): an irregular cycle is exactly the case this app exists to track.
+ALTER TABLE public.user_profiles
+  DROP CONSTRAINT IF EXISTS check_profile_cycle_length_bounds;
+
+ALTER TABLE public.user_profiles
+  ADD CONSTRAINT check_profile_cycle_length_bounds
+  CHECK (cycle_length IS NULL OR (cycle_length >= 15 AND cycle_length <= 60));
+
+COMMENT ON COLUMN public.user_profiles.cycle_length IS
+  'Self-reported average cycle length in days. NULL means not provided; the prediction engine falls back to the logged cycle history.';


### PR DESCRIPTION
## Linked Issue
Fixes #734

## Description

`POST /api/profile` parsed the request with a Zod schema whose optional fields carried `.default(...)` values, then upserted the **whole row** it built from the parsed result. No caller in the app sends every field, so every save quietly wrote defaults over the columns it left out.

That produced two user-visible regressions:

1. **Toggling the AI privacy switch erased the health profile.** `PrivacySettingsModal` (and `PrivacyModal`) post `{ allow_ai_analysis: false }` and nothing else. The route then wrote `age: null, weight_kg: null, height_cm: null, known_conditions: [], cycle_goal: null`. A success toast was shown, so the loss only became visible on the next page load.

2. **Saving the health form silently re-enabled AI analysis.** `HealthProfileSettings` posts no `allow_ai_analysis`, so `.default(true)` turned a recorded opt-*out* back into an opt-in. `app/api/chat/route.js:207` gates the Gemini call on exactly that flag, so this let personal cycle and symptom data reach a third-party model against the consent decision the user had recorded.

Separately, `cycleLength` was validated (range 15–60) and then dropped — the record it built never referenced it, so the endpoint answered `200 OK` and threw the value away.

### The fix

**`lib/profile-merge.js` (new)** reports only the columns a body actually *mentions*, normalised and range-checked. Absence and clearing stay distinct, which is the whole point:

- a key that is missing, or present as `undefined`, never enters the patch, so the route cannot write that column;
- a key present as `null` (or `''` for text) enters the patch as `null` and *is* written — "clear my weight" has to stay expressible.

The module is import-free, so it is usable from a Route Handler, a Server Component and a plain Node script alike, matching `lib/date-utils.js` and `lib/request-day.js`.

**`app/api/profile/route.js`** writes with `UPDATE`, naming only the patched columns, so a concurrent write to a *different* field cannot be clobbered the way a whole-row upsert would. `INSERT` runs only when no row matched, and a `23505` from a racing first-time save retries as an update. Both methods now go through `crudLimiter` — `/api/profile` was one of the few write endpoints with no limiter at all — and `GET` uses `.maybeSingle()`.

**`supabase/09_user_profiles_cycle_length.sql` (new)** adds the `cycle_length` column with a `CHECK` matching the API's bounds, so a direct SQL write cannot store a value the application would refuse. It is nullable with no default: "not provided" and "the user says 28" are different facts, and only the second should influence a prediction.

**`components/layout/HealthProfileSettings.jsx`** gains the *Average Cycle Length* input that makes the newly-persisted column reachable, wired to the existing GET/POST round trip with a labelled, `aria-describedby`-hinted field.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (clean code updates, no behavior modifications)
- [ ] Documentation update
- [ ] Performance optimization
- [x] Security patch

## Files Modified

| File | Change |
|------|--------|
| `lib/profile-merge.js` | **New.** Body → patch reader: alias resolution, coercion, bounds, sanitisation, record builders |
| `app/api/profile/route.js` | Partial-update write path, rate limiting on GET and POST, `maybeSingle()` |
| `components/layout/HealthProfileSettings.jsx` | Average cycle length field; payload documented as form-owned fields only |
| `supabase/09_user_profiles_cycle_length.sql` | **New.** `cycle_length` column + bounds check + column comment |
| `scripts/test-profile-merge.js` | **New.** 64 assertions over the merge semantics |

## Testing

```bash
node scripts/test-profile-merge.js
# PASS 64 passed, 0 failed
```

The suite pins the two regressions directly — "a single-key privacy payload leaves the health columns untouched" and "an omitted consent flag does not flip a stored `false` back to `true`" — alongside absence-vs-clearing, both `cycleLength` spellings, numeric bounds, condition de-duplication and capping, control-character sanitisation, and the alias table's integrity.

Manual round trip:

1. Fill in the health profile and save.
2. Toggle **Allow AI analysis** off in Privacy settings.
3. Reload — the health fields are still there (previously all blank).
4. Re-save the health profile, reopen Privacy — the toggle is still **off** (previously back on).
5. Enter an average cycle length, save, reload — the value persists (previously discarded).

## Migration

`supabase/09_user_profiles_cycle_length.sql` must be run before deploying; it is `ADD COLUMN IF NOT EXISTS`, so it is safe to re-run. Until it is applied, a request containing `cycleLength` will fail on the unknown column — no other field is affected.

## Screenshots (if UI changes are made)
The only UI change is one added number input in **Settings → Health Profile**, styled with the same classes as the adjacent Age / Weight / Height fields.

## Checklist
- [x] This PR is submitted under ECSOC.
- [x] Added the required **ECSoc26** label to this Pull Request.
- [x] Linked issue using `Fixes #734`.
- [x] Tested locally.
- [x] No breaking changes introduced.
- [x] Documentation updated if required.
