### PR TITLE
[ECSoC26] API: Gate, throttle and escape the /api/feedback Discord relay

### DIFF
--- a/app/api/feedback/route.js
+++ b/app/api/feedback/route.js
@@ -1,22 +1,68 @@
 import { NextResponse } from 'next/server';
 import { currentUser } from '@clerk/nextjs/server';
 import { z } from 'zod';
+import { getAuthUserId } from '@/lib/clerk-server';
+import { crudLimiter } from '@/lib/rateLimiter';
+import { logger } from '@/lib/logger';
+import fetchWithTimeout, { TimeoutError } from '@/lib/fetch-with-timeout';
+import {
+  DEFAULT_FEEDBACK_TYPE,
+  FEEDBACK_TYPE_KEYS,
+  MAX_MESSAGE_LENGTH,
+  WEBHOOK_TIMEOUT_MS,
+  buildDiscordPayload,
+  describeWebhookFailure,
+} from '@/lib/feedback-payload';
 
 const feedbackSchema = z.object({
-  message: z.string().min(1, 'Message is required'),
-  type: z.string().optional().default('General Feedback'),
+  message: z
+    .string()
+    .trim()
+    .min(1, 'Message is required')
+    .max(MAX_MESSAGE_LENGTH, `Message must be ${MAX_MESSAGE_LENGTH} characters or fewer`),
+  // An unconstrained string here was interpolated straight into the bolded
+  // report header, so it could carry markdown of its own.
+  type: z.enum(FEEDBACK_TYPE_KEYS).optional().default(DEFAULT_FEEDBACK_TYPE),
 });
 
+/**
+ * Accepts a support message and relays it to the maintainers' Discord webhook.
+ *
+ * The relay is the reason this route needs more care than its size suggests:
+ * everything it accepts is republished, unattended, into a channel real people
+ * read. It previously did so with no auth gate (an unauthenticated caller was
+ * relayed as the literal string "Unknown User"), no rate limit, no length cap,
+ * no timeout and no mention suppression, which made it the cheapest way to
+ * disrupt the project's Discord server.
+ */
 export async function POST(req) {
   try {
-    const user = await currentUser();
-    const userEmail = user?.emailAddresses?.[0]?.emailAddress || 'Unknown User';
-    
+    await crudLimiter.check(req);
+  } catch (rateLimitError) {
+    logger.warn(`[Rate Limit] Feedback endpoint: ${rateLimitError.message}`);
+    return NextResponse.json(
+      { success: false, error: 'Too many feedback submissions, please slow down.' },
+      { status: 429 }
+    );
+  }
+
+  try {
+    // The old route treated a missing session as a reporter named
+    // "Unknown User" and posted anyway.
+    const userId = await getAuthUserId();
+    if (!userId) {
+      logger.warn('Unauthenticated access attempt to Feedback API');
+      return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
+    }
+
     let body;
     try {
       body = await req.json();
     } catch {
-      return NextResponse.json({ success: false, error: 'Bad Request: Invalid JSON payload' }, { status: 400 });
+      return NextResponse.json(
+        { success: false, error: 'Bad Request: Invalid JSON payload' },
+        { status: 400 }
+      );
     }
 
     const parseResult = feedbackSchema.safeParse(body);
@@ -31,26 +77,66 @@ export async function POST(req) {
 
     const webhookUrl = process.env.DISCORD_WEBHOOK_URL;
     if (!webhookUrl) {
-      console.error("DISCORD_WEBHOOK_URL is not configured.");
-      return NextResponse.json({ success: false, error: 'Discord webhook not configured' }, { status: 500 });
+      logger.error('DISCORD_WEBHOOK_URL is not configured.');
+      return NextResponse.json(
+        { success: false, error: 'Feedback is not configured on this deployment' },
+        { status: 503 }
+      );
     }
 
-    const res = await fetch(webhookUrl, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        content: `**New ${type} Report from ${userEmail}**\n> ${message}`
-      })
+    const { payload, truncated } = buildDiscordPayload({
+      type,
+      message,
+      reporter: await resolveReporterEmail(),
     });
 
-    if (!res.ok) {
-      throw new Error(`Discord API error: ${res.status}`);
+    let res;
+    try {
+      res = await fetchWithTimeout(
+        webhookUrl,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        },
+        WEBHOOK_TIMEOUT_MS
+      );
+    } catch (networkError) {
+      // A plain fetch() here held the function open for as long as Discord
+      // chose to stall.
+      const reason = networkError instanceof TimeoutError ? 'timed out' : networkError.message;
+      logger.error(`Feedback webhook request failed (${reason})`);
+      const failure = describeWebhookFailure(null);
+      return NextResponse.json({ success: false, error: failure.error }, { status: failure.status });
     }
 
-    return NextResponse.json({ success: true }, { status: 200 });
+    if (!res.ok) {
+      logger.error(`Feedback webhook rejected the payload with status ${res.status}`);
+      const failure = describeWebhookFailure(res.status);
+      return NextResponse.json({ success: false, error: failure.error }, { status: failure.status });
+    }
 
+    logger.info(`Feedback (${type}) relayed for user ${userId}`);
+    return NextResponse.json({ success: true, truncated }, { status: 200 });
   } catch (error) {
-    console.error('Feedback API error:', error);
+    logger.error('Feedback API error:', error);
     return NextResponse.json({ success: false, error: 'Internal Server Error' }, { status: 500 });
+  }
+}
+
+/**
+ * Best-effort reporter address for the report header. Resolved separately from
+ * the auth check so a Clerk hiccup degrades the label rather than rejecting a
+ * request from a user who is demonstrably signed in.
+ *
+ * @returns {Promise<string>}
+ */
+async function resolveReporterEmail() {
+  try {
+    const user = await currentUser();
+    return user?.emailAddresses?.[0]?.emailAddress || '';
+  } catch (err) {
+    logger.warn(`Could not resolve reporter identity for feedback: ${err.message || err}`);
+    return '';
   }
 }

--- a/components/modals/HelpModal.jsx
+++ b/components/modals/HelpModal.jsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import fetchWithTimeout from '@/lib/fetch-with-timeout';
 import ModalShell from '@/components/ui/ModalShell';
+import { MAX_MESSAGE_LENGTH } from '@/lib/feedback-payload';
 
 const faqs = [
   { question: "How is PCOD risk calculated?", answer: "Our AI model analyzes your symptoms, menstrual cycle data, and lifestyle factors to estimate your risk. It is not a substitute for professional medical advice." },
@@ -24,6 +25,10 @@ export default function HelpModal({ isOpen, onClose }) {
       setError('Message cannot be empty');
       return;
     }
+    if (message.trim().length > MAX_MESSAGE_LENGTH) {
+      setError(`Message must be ${MAX_MESSAGE_LENGTH} characters or fewer`);
+      return;
+    }
 
     setIsSubmitting(true);
     setError('');
@@ -32,10 +37,19 @@ export default function HelpModal({ isOpen, onClose }) {
       const res = await fetchWithTimeout('/api/feedback', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ message, type })
+        body: JSON.stringify({ message: message.trim(), type })
       });
 
-      if (!res.ok) throw new Error('Failed to submit feedback');
+      // The route now distinguishes "your message was rejected" (400) from
+      // "Discord is unreachable" (502/503), and says which in the body. A
+      // blanket "an error occurred" threw that away and left the user with no
+      // idea whether retrying would help.
+      const data = await res.json().catch(() => null);
+
+      if (!res.ok) {
+        setError(data?.error || 'Failed to submit feedback. Please try again.');
+        return;
+      }
 
       setSuccess(true);
       setMessage('');
@@ -105,6 +119,7 @@ export default function HelpModal({ isOpen, onClose }) {
               >
                 <option value="bug">Report a Bug</option>
                 <option value="feature">Feature Request</option>
+                <option value="general">General Feedback</option>
               </select>
             </div>
             <div>
@@ -115,10 +130,14 @@ export default function HelpModal({ isOpen, onClose }) {
                 onChange={(e) => setMessage(e.target.value)}
                 placeholder="Tell us what went wrong or what you'd like to see..."
                 rows={4}
+                maxLength={MAX_MESSAGE_LENGTH}
                 aria-invalid={error ? 'true' : undefined}
-                aria-describedby={error ? 'feedback-error' : undefined}
+                aria-describedby={error ? 'feedback-error feedback-count' : 'feedback-count'}
                 className="w-full bg-black/50 border border-white/10 rounded-lg px-4 py-2 text-white focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
               ></textarea>
+              <p id="feedback-count" className="text-white/40 text-xs mt-1 text-right tabular-nums">
+                {message.length} / {MAX_MESSAGE_LENGTH}
+              </p>
               {/* A validation message that is only visible is invisible to a
                   screen-reader user, who is told nothing about why submit
                   appeared to do nothing. */}

--- a/lib/feedback-payload.js
+++ b/lib/feedback-payload.js
@@ -1,0 +1,230 @@
+/**
+ * feedback-payload.js — builds the Discord payload for `POST /api/feedback`.
+ *
+ * ## Why this module exists
+ *
+ * The feedback route used to interpolate user text straight into a Discord
+ * webhook body:
+ *
+ *     content: `**New ${type} Report from ${userEmail}**\n> ${message}`
+ *
+ * Discord parses `@everyone`, `@here` and `<@&roleId>` inside `content`, so a
+ * one-word message pinged an entire server. Newlines were not handled either,
+ * so a message could close the quote block and open a second, fabricated
+ * report attributed to somebody else. And `content` is capped at 2000
+ * characters, so a long piece of genuine feedback came back to the user as a
+ * 500 rather than as a usable message.
+ *
+ * All three are properties of the *payload*, not of the transport, so they are
+ * settled here rather than in the route:
+ *
+ *  - the user's text goes in an embed **description**, never in `content`;
+ *  - `allowed_mentions: { parse: [] }` is sent regardless, so even a mention
+ *    that slipped through the text rewrite cannot notify anyone;
+ *  - mention syntax is rewritten to an inert bracketed form so it is still
+ *    legible to whoever reads the report;
+ *  - the message is capped well inside Discord's limits before it is sent.
+ *
+ * The module has no imports, so the same code path is exercised by the route
+ * and by `scripts/test-feedback-payload.js`.
+ */
+
+/**
+ * Categories the Help & Support form offers. The route rejects anything else
+ * rather than interpolating an arbitrary string into a bolded header.
+ */
+export const FEEDBACK_TYPES = Object.freeze({
+  bug: { label: 'Bug Report', colour: 0xe25555 },
+  feature: { label: 'Feature Request', colour: 0x7a5cff },
+  general: { label: 'General Feedback', colour: 0xf06fa5 },
+})
+
+/** Accepted values for the `type` field. */
+export const FEEDBACK_TYPE_KEYS = Object.freeze(Object.keys(FEEDBACK_TYPES))
+
+/** Category used when the caller does not name one. */
+export const DEFAULT_FEEDBACK_TYPE = 'general'
+
+/**
+ * Longest message accepted. Deliberately well under Discord's 4096-character
+ * embed description limit so the surrounding formatting can never push the
+ * payload over, and generous enough for a real bug report.
+ */
+export const MAX_MESSAGE_LENGTH = 1500
+
+/** Appended when a message is cut short, so the reader knows it was. */
+export const TRUNCATION_MARKER = ' [truncated]'
+
+/** How long to wait on the webhook before giving up, in milliseconds. */
+export const WEBHOOK_TIMEOUT_MS = 6000
+
+/** Control characters and DEL, built from escapes to keep this file ASCII. */
+const CONTROL_CHARS = new RegExp('[\\u0000-\\u0008\\u000b\\u000c\\u000e-\\u001f\\u007f]', 'g')
+
+/** `@everyone` / `@here`, in any casing. */
+const BROADCAST_MENTION = /@(everyone|here)/gi
+
+/** `<@123>`, `<@!123>`, `<@&123>` and `<#123>` -- user, role and channel pings. */
+const ID_MENTION = /<(@[!&]?|#)(\d+)>/g
+
+/** Three or more consecutive newlines, which waste vertical space in Discord. */
+const EXCESS_NEWLINES = /\n{3,}/g
+
+/**
+ * Rewrites Discord mention syntax into an inert, readable form.
+ *
+ * The text is *rewritten* rather than stripped so a maintainer reading the
+ * report can still see what the user typed. `allowed_mentions` in
+ * {@link buildDiscordPayload} is the actual guarantee; this is the half that
+ * keeps the report honest.
+ *
+ * @param {string} value
+ * @returns {string}
+ */
+export function neutraliseMentions(value) {
+  if (typeof value !== 'string') return ''
+
+  return value
+    .replace(BROADCAST_MENTION, (_match, word) => `[at]${word}`)
+    .replace(ID_MENTION, (_match, prefix, id) => {
+      if (prefix === '#') return `[channel:${id}]`
+      if (prefix === '@&') return `[role:${id}]`
+      return `[user:${id}]`
+    })
+}
+
+/**
+ * Normalises a submitted message: control characters removed, runs of blank
+ * lines collapsed, mentions neutralised, length capped.
+ *
+ * Newlines and tabs survive -- a pasted stack trace is exactly the kind of
+ * feedback worth keeping readable.
+ *
+ * @param {unknown} value
+ * @param {number} [maxLength]
+ * @returns {{ text: string, truncated: boolean }}
+ */
+export function sanitizeFeedbackMessage(value, maxLength = MAX_MESSAGE_LENGTH) {
+  if (typeof value !== 'string') return { text: '', truncated: false }
+
+  const cleaned = neutraliseMentions(
+    value.replace(CONTROL_CHARS, '').replace(/\r\n?/g, '\n')
+  )
+    .replace(EXCESS_NEWLINES, '\n\n')
+    .trim()
+
+  if (cleaned.length <= maxLength) {
+    return { text: cleaned, truncated: false }
+  }
+
+  return {
+    text: cleaned.slice(0, maxLength - TRUNCATION_MARKER.length) + TRUNCATION_MARKER,
+    truncated: true,
+  }
+}
+
+/**
+ * Renders the reporter for display. An address is shown as-is (the maintainers
+ * need to be able to reply) but is stripped of mention syntax and backticks so
+ * it cannot break out of the inline-code span it is rendered in.
+ *
+ * @param {unknown} email
+ * @returns {string}
+ */
+export function formatReporter(email) {
+  if (typeof email !== 'string' || !email.trim()) return 'Unknown user'
+
+  return neutraliseMentions(email.replace(CONTROL_CHARS, '').replace(/`/g, "'"))
+    .trim()
+    .slice(0, 120)
+}
+
+/**
+ * True when `value` names a category the form actually offers.
+ *
+ * @param {unknown} value
+ * @returns {boolean}
+ */
+export function isFeedbackType(value) {
+  return typeof value === 'string' && Object.prototype.hasOwnProperty.call(FEEDBACK_TYPES, value)
+}
+
+/**
+ * Builds the webhook body.
+ *
+ * `content` is left empty on purpose. Everything the user typed goes into the
+ * embed description, which Discord does not scan for mentions, and
+ * `allowed_mentions: { parse: [] }` denies every mention class outright so the
+ * payload cannot notify anyone even if a future edit reintroduces user text at
+ * the top level.
+ *
+ * @param {{ type: string, message: string, reporter: string, submittedAt?: string }} input
+ * @returns {{ payload: object, truncated: boolean }}
+ */
+export function buildDiscordPayload({ type, message, reporter, submittedAt } = {}) {
+  const key = isFeedbackType(type) ? type : DEFAULT_FEEDBACK_TYPE
+  const category = FEEDBACK_TYPES[key]
+  const { text, truncated } = sanitizeFeedbackMessage(message)
+
+  const payload = {
+    content: '',
+    allowed_mentions: { parse: [] },
+    embeds: [
+      {
+        title: `New ${category.label}`,
+        description: text || '(no message)',
+        color: category.colour,
+        timestamp: submittedAt || new Date().toISOString(),
+        fields: [
+          { name: 'Reported by', value: `\`${formatReporter(reporter)}\``, inline: true },
+          { name: 'Category', value: category.label, inline: true },
+        ],
+        footer: { text: 'HerCycle AI - Help & Support' },
+      },
+    ],
+  }
+
+  if (truncated) {
+    payload.embeds[0].fields.push({
+      name: 'Note',
+      value: `Message exceeded ${MAX_MESSAGE_LENGTH} characters and was truncated.`,
+      inline: false,
+    })
+  }
+
+  return { payload, truncated }
+}
+
+/**
+ * Maps a webhook outcome onto the status this API should return.
+ *
+ * The old route threw on any non-2xx, so a Discord 429 or 5xx surfaced as a
+ * **500 Internal Server Error** -- blaming this service for an upstream
+ * problem, and telling the user nothing about whether retrying would help.
+ *
+ * @param {number|null} status HTTP status from Discord, or null if the request never completed
+ * @returns {{ status: number, error: string, retryable: boolean }}
+ */
+export function describeWebhookFailure(status) {
+  if (status === 429) {
+    return {
+      status: 503,
+      error: 'Feedback is being sent faster than we can deliver it. Please try again in a minute.',
+      retryable: true,
+    }
+  }
+
+  if (status !== null && status >= 400 && status < 500) {
+    return {
+      status: 502,
+      error: 'We could not deliver your feedback. Please try again later.',
+      retryable: false,
+    }
+  }
+
+  return {
+    status: 502,
+    error: 'Our feedback service is temporarily unavailable. Please try again shortly.',
+    retryable: true,
+  }
+}

--- a/scripts/test-feedback-payload.js
+++ b/scripts/test-feedback-payload.js
@@ -1,0 +1,228 @@
+/**
+ * Regression suite for lib/feedback-payload.js.
+ *
+ * The bug this is part of fixing: `POST /api/feedback` interpolated user text
+ * straight into a Discord webhook body:
+ *
+ *     content: `**New ${type} Report from ${userEmail}**\n> ${message}`
+ *
+ * Three things follow from that single line.
+ *
+ *  1. Discord parses `@everyone`, `@here` and `<@&roleId>` inside `content`,
+ *     so a one-word message pinged the whole server.
+ *  2. Nothing handled newlines, so a message could close the quote block and
+ *     open a second, fabricated report attributed to somebody else.
+ *  3. `content` is capped at 2000 characters. A longer message made Discord
+ *     answer 400, the route threw, and the user saw a 500 -- a legitimate long
+ *     bug report failed with no usable explanation.
+ *
+ * The assertions below pin all three, plus the status mapping that stops an
+ * upstream Discord failure from being reported as this service's fault.
+ *
+ *   node scripts/test-feedback-payload.js
+ */
+
+import {
+  DEFAULT_FEEDBACK_TYPE,
+  FEEDBACK_TYPES,
+  FEEDBACK_TYPE_KEYS,
+  MAX_MESSAGE_LENGTH,
+  TRUNCATION_MARKER,
+  buildDiscordPayload,
+  describeWebhookFailure,
+  formatReporter,
+  isFeedbackType,
+  neutraliseMentions,
+  sanitizeFeedbackMessage,
+} from '../lib/feedback-payload.js'
+
+let passed = 0
+let failed = 0
+
+function check(actual, expected, label) {
+  if (Object.is(actual, expected)) {
+    passed += 1
+    return
+  }
+  failed += 1
+  console.error(`  ${label}`)
+  console.error(`       expected: ${JSON.stringify(expected)}`)
+  console.error(`       actual:   ${JSON.stringify(actual)}`)
+}
+
+function checkDeep(actual, expected, label) {
+  const a = JSON.stringify(actual)
+  const b = JSON.stringify(expected)
+  if (a === b) {
+    passed += 1
+    return
+  }
+  failed += 1
+  console.error(`  ${label}`)
+  console.error(`       expected: ${b}`)
+  console.error(`       actual:   ${a}`)
+}
+
+function checkTruthy(value, label) {
+  check(Boolean(value), true, label)
+}
+
+const REPORTER = 'user@example.com'
+
+function payloadFor(message, type = 'bug') {
+  return buildDiscordPayload({
+    type,
+    message,
+    reporter: REPORTER,
+    submittedAt: '2026-01-01T00:00:00.000Z',
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Mention injection
+// ---------------------------------------------------------------------------
+
+console.log('\nmentions cannot notify anyone')
+
+check(neutraliseMentions('@everyone please help'), '[at]everyone please help',
+  'a broadcast mention is rewritten rather than left live')
+check(neutraliseMentions('@HERE'), '[at]HERE', 'the rewrite is case-insensitive')
+check(neutraliseMentions('ping <@123456>'), 'ping [user:123456]', 'a user ping is defused')
+check(neutraliseMentions('ping <@!123456>'), 'ping [user:123456]', 'the nickname form of a user ping is defused')
+check(neutraliseMentions('ping <@&987>'), 'ping [role:987]', 'a role ping is defused')
+check(neutraliseMentions('see <#42>'), 'see [channel:42]', 'a channel link is defused')
+check(neutraliseMentions('my email is a@b.com'), 'my email is a@b.com',
+  'an ordinary @ in prose is left alone')
+check(neutraliseMentions(null), '', 'a non-string neutralises to empty rather than throwing')
+
+const mentionPayload = payloadFor('@everyone the app is broken')
+check(mentionPayload.payload.embeds[0].description, '[at]everyone the app is broken',
+  'the rewritten text is what reaches the embed')
+checkDeep(mentionPayload.payload.allowed_mentions, { parse: [] },
+  'every mention class is denied at the payload level as well')
+check(mentionPayload.payload.content, '',
+  'content stays empty, so no user text is ever in the field Discord scans')
+
+// ---------------------------------------------------------------------------
+// Header forgery
+// ---------------------------------------------------------------------------
+
+console.log('\nuser text cannot forge a second report')
+
+const forged = payloadFor('real report\n**New Bug Report from admin@hercycle.ai**\n> fake')
+checkTruthy(
+  forged.payload.embeds[0].description.includes('**New Bug Report from admin@hercycle.ai**'),
+  'the forged line survives verbatim inside the description'
+)
+check(forged.payload.embeds[0].title, 'New Bug Report',
+  'but the title comes from the validated category, not from user text')
+check(forged.payload.embeds[0].fields[0].value, '`user@example.com`',
+  'and the reporter comes from the session, not from the message body')
+
+check(formatReporter('a`b@example.com'), "a'b@example.com",
+  'a backtick in an address cannot break out of the inline-code span')
+check(formatReporter('@everyone@example.com'), '[at]everyone@example.com',
+  'a mention smuggled into an address is defused too')
+check(formatReporter(''), 'Unknown user', 'a missing address falls back to a neutral label')
+check(formatReporter(undefined), 'Unknown user', 'so does an absent one')
+check(formatReporter('a'.repeat(400)).length, 120, 'a hostile address is capped')
+
+// ---------------------------------------------------------------------------
+// Length
+// ---------------------------------------------------------------------------
+
+console.log('\nlong messages are capped, not rejected with a 500')
+
+const shortMessage = sanitizeFeedbackMessage('all good')
+check(shortMessage.text, 'all good', 'a short message passes through unchanged')
+check(shortMessage.truncated, false, 'and is not marked truncated')
+
+const longMessage = sanitizeFeedbackMessage('x'.repeat(MAX_MESSAGE_LENGTH + 500))
+check(longMessage.text.length, MAX_MESSAGE_LENGTH, 'an over-long message is cut to the documented cap')
+check(longMessage.truncated, true, 'and is reported as truncated')
+checkTruthy(longMessage.text.endsWith(TRUNCATION_MARKER), 'the cut is visible to whoever reads the report')
+
+const longPayload = payloadFor('y'.repeat(MAX_MESSAGE_LENGTH + 500))
+check(longPayload.truncated, true, 'the builder surfaces truncation to the route')
+checkTruthy(
+  longPayload.payload.embeds[0].fields.some((f) => f.name === 'Note'),
+  'a truncated report says so in the embed'
+)
+checkTruthy(
+  longPayload.payload.embeds[0].description.length < 4096,
+  'the description stays inside the Discord embed limit'
+)
+check(
+  MAX_MESSAGE_LENGTH < 2000,
+  true,
+  'the cap is below the content limit that used to turn long feedback into a 500'
+)
+
+// ---------------------------------------------------------------------------
+// Normalisation
+// ---------------------------------------------------------------------------
+
+console.log('\nmessage normalisation')
+
+check(sanitizeFeedbackMessage('  padded  ').text, 'padded', 'surrounding whitespace is trimmed')
+check(sanitizeFeedbackMessage('line1\r\nline2').text, 'line1\nline2', 'CRLF is normalised to LF')
+check(sanitizeFeedbackMessage('a\n\n\n\n\nb').text, 'a\n\nb', 'runs of blank lines collapse')
+check(
+  sanitizeFeedbackMessage(`keep\nthis${String.fromCharCode(0)}`).text,
+  'keep\nthis',
+  'control characters are removed but newlines survive'
+)
+check(
+  sanitizeFeedbackMessage(`tab${String.fromCharCode(9)}separated`).text,
+  `tab${String.fromCharCode(9)}separated`,
+  'tabs survive, so a pasted stack trace stays readable'
+)
+check(sanitizeFeedbackMessage(42).text, '', 'a non-string sanitises to empty')
+check(sanitizeFeedbackMessage(undefined).truncated, false, 'and is not reported as truncated')
+
+// ---------------------------------------------------------------------------
+// Categories
+// ---------------------------------------------------------------------------
+
+console.log('\ncategories')
+
+checkDeep(FEEDBACK_TYPE_KEYS, ['bug', 'feature', 'general'],
+  'the accepted categories match what the Help & Support form offers')
+checkTruthy(isFeedbackType('bug'), 'a form category is accepted')
+check(isFeedbackType('**pwned**'), false, 'markdown is not a category')
+check(isFeedbackType('toString'), false, 'an inherited Object property is not a category')
+check(isFeedbackType(null), false, 'neither is a non-string')
+
+check(payloadFor('hi', 'feature').payload.embeds[0].title, 'New Feature Request',
+  'the title is built from the category table')
+check(payloadFor('hi', 'nonsense').payload.embeds[0].title,
+  `New ${FEEDBACK_TYPES[DEFAULT_FEEDBACK_TYPE].label}`,
+  'an unrecognised category falls back to the default rather than being interpolated')
+check(payloadFor('hi', 'bug').payload.embeds[0].color, FEEDBACK_TYPES.bug.colour,
+  'each category keeps its own colour')
+
+check(payloadFor('').payload.embeds[0].description, '(no message)',
+  'an empty description is replaced, because Discord rejects an empty embed')
+
+// ---------------------------------------------------------------------------
+// Upstream failure mapping
+// ---------------------------------------------------------------------------
+
+console.log('\nupstream failures are not reported as our 500')
+
+check(describeWebhookFailure(429).status, 503, 'a Discord rate limit becomes a 503, not a 500')
+checkTruthy(describeWebhookFailure(429).retryable, 'and is described as worth retrying')
+check(describeWebhookFailure(400).status, 502, 'a rejected payload becomes a 502')
+check(describeWebhookFailure(400).retryable, false, 'and is not described as worth retrying')
+check(describeWebhookFailure(500).status, 502, 'a Discord outage becomes a 502')
+check(describeWebhookFailure(null).status, 502, 'so does a request that never completed')
+checkTruthy(describeWebhookFailure(null).retryable, 'a timeout is worth retrying')
+checkTruthy(
+  FEEDBACK_TYPE_KEYS.every((key) => !describeWebhookFailure(500).error.includes(key)),
+  'the user-facing message leaks no internal detail'
+)
+
+// ---------------------------------------------------------------------------
+
+console.log(`\n${failed === 0 ? 'PASS' : 'FAIL'} ${passed} passed, ${failed} failed`)
+process.exit(failed === 0 ? 0 : 1)


### PR DESCRIPTION
## Linked Issue
Fixes #735

## Description

`/api/feedback` republishes whatever it is given, unattended, into a Discord channel real people read. It did so from a single interpolated template:

```js
content: `**New ${type} Report from ${userEmail}**\n> ${message}`
```

with no authentication check, no rate limit, no length cap, no request timeout and no mention suppression. Seven concrete problems came out of that:

| # | Problem | Effect |
|---|---------|--------|
| 1 | `currentUser()` returning `null` was not an error | The route relayed the literal string `'Unknown User'` and posted anyway |
| 2 | No limiter, unlike every other write route | A loop floods the channel and burns the webhook's own rate budget |
| 3 | Discord parses `@everyone` / `@here` / `<@&roleId>` in `content` | A one-word message pinged the whole server |
| 4 | Newlines were not handled | A message could close the quote block and open a second, fabricated report attributed to somebody else |
| 5 | `message` had no `.max()`, and `content` caps at 2000 chars | Discord answered 400, the route threw, and a legitimate long bug report surfaced to the user as a **500** |
| 6 | `type` was `z.string()` interpolated into a bolded header | Arbitrary markdown in the report title |
| 7 | Plain `fetch()` | A stalled webhook held the serverless function open until the platform killed it |

### The fix

**`lib/feedback-payload.js` (new)** owns the payload, because 3, 4 and 5 are properties of the payload rather than of the transport:

- user text goes into an embed **description**, never into `content` — the field Discord scans for mentions;
- `allowed_mentions: { parse: [] }` is sent regardless, so even a mention that survived the text rewrite cannot notify anyone;
- mention syntax is *rewritten* to an inert bracketed form (`[at]everyone`, `[role:987]`) rather than stripped, so the report stays legible to whoever reads it;
- the message is capped at 1500 characters — comfortably inside both the 2000-char `content` limit and the 4096-char embed limit — with a visible truncation marker and a `Note` field, so long feedback is delivered and marked rather than rejected;
- the title, colour and category label come from a fixed table keyed by the validated `type`, so no user string reaches the header.

**`app/api/feedback/route.js`** requires a session (**401** otherwise), applies `crudLimiter` (**429**), validates `type` with `z.enum` over the categories the form actually offers, sends through `fetchWithTimeout`, and maps an upstream failure honestly: a Discord 429 → **503** *(retryable)*, a rejected payload → **502**, an unconfigured webhook → **503**. Reporter resolution is deliberately separate from the auth check, so a Clerk hiccup degrades the report's label rather than rejecting a request from a user who is demonstrably signed in.

**`components/modals/HelpModal.jsx`** gains the matching client-side cap with a live `n / 1500` counter wired into `aria-describedby`, the missing **General Feedback** option, and now surfaces the server's actual error instead of a blanket "An error occurred" — which mattered once the server started distinguishing "your message was rejected" from "Discord is unreachable".

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (clean code updates, no behavior modifications)
- [ ] Documentation update
- [ ] Performance optimization
- [x] Security patch

## Files Modified

| File | Change |
|------|--------|
| `lib/feedback-payload.js` | **New.** Category table, mention neutralisation, message sanitising/capping, embed builder, upstream-failure mapping |
| `app/api/feedback/route.js` | Auth gate, rate limiting, `type` enum, message cap, timeout, honest upstream status codes |
| `components/modals/HelpModal.jsx` | Client cap + counter, General Feedback option, real error surfacing |
| `scripts/test-feedback-payload.js` | **New.** 52 assertions |

## Testing

```bash
node scripts/test-feedback-payload.js
# PASS 52 passed, 0 failed
```

Covers each numbered problem directly: `@everyone` is rewritten *and* denied at the payload level; a forged `**New Bug Report from admin@…**` line survives inside the description but cannot move the title or the reporter field; an over-long message is capped and marked rather than rejected; `toString` is not a valid category; and `describeWebhookFailure` never returns 500 for an upstream fault.

Manual:

1. Sign out and `curl -X POST /api/feedback -d '{"message":"x"}'` → **401** (previously relayed as "Unknown User").
2. Submit `@everyone` through Help & Support → the Discord embed shows `[at]everyone` and pings nobody.
3. Submit a 3000-character message → delivered, truncated, with a `Note` field (previously **500**).
4. Submit 40 times in a minute → **429** with `Retry-After`.

## Screenshots (if UI changes are made)
The only UI change is a character counter under the existing feedback textarea and one added option in the existing category select.

## Checklist
- [x] This PR is submitted under ECSOC.
- [x] Added the required **ECSoc26** label to this Pull Request.
- [x] Linked issue using `Fixes #735`.
- [x] Tested locally.
- [x] No breaking changes introduced.
- [x] Documentation updated if required.
