### PR TITLE
[ECSoC26] API: Bound, throttle and envelope /api/user/export

### DIFF
--- a/app/[locale]/settings/page.js
+++ b/app/[locale]/settings/page.js
@@ -11,6 +11,7 @@ import PartnerSharing from '@/components/settings/PartnerSharing'
 import NotificationSettings from '@/components/layout/NotificationSettings'
 import { useTranslations } from 'next-intl'
 import { useTheme } from '@/lib/ThemeContext'
+import { collectFullExport } from '@/lib/user-export'
 
 export default function SettingsPage() {
   const t = useTranslations('PrivacyData')
@@ -26,9 +27,18 @@ export default function SettingsPage() {
     setIsExporting(true)
     const toastId = toast.loading('Preparing your export...')
     try {
-      const res = await fetch('/api/user/export')
-      if (!res.ok) throw new Error('Export failed')
-      const blob = await res.blob()
+      // The endpoint is paged now, so a single request would save a
+      // truncated copy of the user's health data and call it complete.
+      const collected = await collectFullExport((pageUrl) => fetch(pageUrl))
+      if (!collected.complete) {
+        toast.error('Your export was too large to download in one go. Please try again.', { id: toastId })
+        return
+      }
+
+      const blob = new Blob(
+        [JSON.stringify({ profile: collected.profile, cycles: collected.cycles, logs: collected.logs }, null, 2)],
+        { type: 'application/json' }
+      )
       const url = window.URL.createObjectURL(blob)
       const a = document.createElement('a')
       a.href = url

--- a/app/api/user/export/route.js
+++ b/app/api/user/export/route.js
@@ -1,58 +1,135 @@
 import { NextResponse } from 'next/server'
 import { getAuthUserId } from '@/lib/clerk-server'
 import { getSupabaseAdmin } from '@/lib/supabase-admin'
+import { crudLimiter } from '@/lib/rateLimiter'
 import { logger } from '@/lib/logger'
+import {
+  NO_STORE_HEADERS,
+  buildExportPayload,
+  pageRange,
+  resolveExportPaging,
+} from '@/lib/user-export'
 
+// This response is assembled per request from one user's rows. Caching a
+// rendered version of it, at any layer, would be a mistake.
+export const dynamic = 'force-dynamic'
+
+/**
+ * Returns one page of a user's exportable data.
+ *
+ * Previously this fetched the whole profile, the whole cycle history and the
+ * whole `daily_logs` table in one go, with no rate limit in front of it — three
+ * unbounded scans per call, from an endpoint any refresh loop could hammer.
+ * `daily_logs` grows one row per tracked day forever, so a long-standing
+ * account produced a multi-megabyte body from a function with a fixed memory
+ * budget.
+ *
+ * Cycles and logs page independently: three years of history is roughly 36
+ * cycles and 1000 logs, and a shared cursor would make a caller re-request the
+ * cycles on every page.
+ */
 export async function GET(request) {
+  try {
+    await crudLimiter.check(request)
+  } catch (rateLimitError) {
+    logger.warn(`[Rate Limit] User export endpoint: ${rateLimitError.message}`)
+    return NextResponse.json(
+      { success: false, error: 'Too many export requests, please slow down.' },
+      { status: 429, headers: NO_STORE_HEADERS }
+    )
+  }
+
   try {
     const userId = await getAuthUserId()
     if (!userId) {
-      return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 })
+      return NextResponse.json(
+        { success: false, error: 'Unauthorized' },
+        { status: 401, headers: NO_STORE_HEADERS }
+      )
     }
+
+    const { limit, cycleOffset, logOffset } = resolveExportPaging(
+      new URL(request.url).searchParams
+    )
 
     const supabase = getSupabaseAdmin()
 
-    // Fetch user profile
+    // `.single()` raises PGRST116 for every brand-new account, which the old
+    // code had to special-case. `.maybeSingle()` returns null without an error,
+    // so a genuine database fault is the only thing left in `error`.
     const { data: profile, error: profileError } = await supabase
       .from('user_profiles')
       .select('*')
       .eq('user_id', userId)
-      .single()
+      .maybeSingle()
 
-    if (profileError && profileError.code !== 'PGRST116') {
+    if (profileError) {
       logger.error('Error fetching user profile for export:', profileError)
-      return NextResponse.json({ success: false, error: 'Database error' }, { status: 500 })
+      return databaseError()
     }
 
-    // Fetch user cycles
+    const cycleWindow = pageRange(cycleOffset, limit)
     const { data: cycles, error: cyclesError } = await supabase
       .from('cycles')
       .select('*')
+      // Deterministic ordering is what makes offset paging correct; without it
+      // Postgres may return the same row on two pages and skip another.
       .eq('user_id', userId)
+      .order('start_date', { ascending: true })
+      .order('id', { ascending: true })
+      .range(cycleWindow.from, cycleWindow.to)
 
     if (cyclesError) {
       logger.error('Error fetching user cycles for export:', cyclesError)
-      return NextResponse.json({ success: false, error: 'Database error' }, { status: 500 })
+      return databaseError()
     }
 
-    // Fetch user daily logs
+    const logWindow = pageRange(logOffset, limit)
     const { data: logs, error: logsError } = await supabase
       .from('daily_logs')
       .select('*')
       .eq('user_id', userId)
+      .order('date', { ascending: true })
+      .order('id', { ascending: true })
+      .range(logWindow.from, logWindow.to)
 
     if (logsError) {
       logger.error('Error fetching user logs for export:', logsError)
-      return NextResponse.json({ success: false, error: 'Database error' }, { status: 500 })
+      return databaseError()
     }
 
-    return NextResponse.json({
-      profile: profile || {},
-      cycles: cycles || [],
-      logs: logs || []
-    }, { status: 200 })
+    const payload = buildExportPayload({
+      profile,
+      cycles,
+      logs,
+      limit,
+      cycleOffset,
+      logOffset,
+    })
+
+    logger.info(
+      `Export page served for user ${userId} (cycles: ${payload.cycles.length}, logs: ${payload.logs.length})`
+    )
+
+    return NextResponse.json(payload, { status: 200, headers: NO_STORE_HEADERS })
   } catch (err) {
     logger.error('Data Export GET error:', err)
-    return NextResponse.json({ success: false, error: 'Internal Server Error' }, { status: 500 })
+    return NextResponse.json(
+      { success: false, error: 'Internal Server Error' },
+      { status: 500, headers: NO_STORE_HEADERS }
+    )
   }
+}
+
+/**
+ * A database fault, reported without echoing the driver's message — which can
+ * name columns and constraints the caller has no business seeing.
+ *
+ * @returns {NextResponse}
+ */
+function databaseError() {
+  return NextResponse.json(
+    { success: false, error: 'Database error' },
+    { status: 500, headers: NO_STORE_HEADERS }
+  )
 }

--- a/components/layout/PrivacySettingsModal.jsx
+++ b/components/layout/PrivacySettingsModal.jsx
@@ -6,6 +6,7 @@ import * as Switch from '@radix-ui/react-switch'
 import fetchWithTimeout from '@/lib/fetch-with-timeout'
 import toast from 'react-hot-toast'
 import { Download } from 'lucide-react'
+import { collectFullExport } from '@/lib/user-export'
 
 export default function PrivacySettingsContent() {
   const { getToken } = useAuth()
@@ -57,15 +58,20 @@ export default function PrivacySettingsContent() {
     const toastId = toast.loading('Preparing your data...')
     try {
       const token = await getToken()
-      const res = await fetchWithTimeout('/api/user/export', {
-        headers: {
-          Authorization: `Bearer ${token}`
-        }
-      })
-      if (!res.ok) {
-        throw new Error('Failed to export data')
+
+      // Paged endpoint: every page has to be fetched before the file is
+      // written, or the user saves a partial history believing it is whole.
+      const collected = await collectFullExport((pageUrl) =>
+        fetchWithTimeout(pageUrl, { headers: { Authorization: `Bearer ${token}` } })
+      )
+      if (!collected.complete) {
+        throw new Error('Export was truncated')
       }
-      const blob = await res.blob()
+
+      const blob = new Blob(
+        [JSON.stringify({ profile: collected.profile, cycles: collected.cycles, logs: collected.logs }, null, 2)],
+        { type: 'application/json' }
+      )
       const url = window.URL.createObjectURL(blob)
       const a = document.createElement('a')
       a.href = url

--- a/components/modals/PrivacyModal.jsx
+++ b/components/modals/PrivacyModal.jsx
@@ -6,6 +6,7 @@ import * as Switch from '@radix-ui/react-switch'
 import { Download, AlertTriangle, X, Shield } from 'lucide-react'
 import fetchWithTimeout from '@/lib/fetch-with-timeout'
 import toast from 'react-hot-toast'
+import { collectFullExport } from '@/lib/user-export'
 
 export default function PrivacyModal({ trigger, initialProfile, onDeleteAccount }) {
   const [allowAI, setAllowAI] = useState(true)
@@ -52,11 +53,17 @@ export default function PrivacyModal({ trigger, initialProfile, onDeleteAccount 
     setIsExporting(true)
     const toastId = toast.loading('Preparing your data...')
     try {
-      const res = await fetchWithTimeout('/api/user/export')
-      if (!res.ok) {
-        throw new Error('Failed to export data')
+      // Paged endpoint: walk every page before writing the file, or the
+      // download silently ends mid-history.
+      const collected = await collectFullExport((pageUrl) => fetchWithTimeout(pageUrl))
+      if (!collected.complete) {
+        throw new Error('Export was truncated')
       }
-      const blob = await res.blob()
+
+      const blob = new Blob(
+        [JSON.stringify({ profile: collected.profile, cycles: collected.cycles, logs: collected.logs }, null, 2)],
+        { type: 'application/json' }
+      )
       const url = window.URL.createObjectURL(blob)
       const a = document.createElement('a')
       a.href = url

--- a/lib/user-export.js
+++ b/lib/user-export.js
@@ -1,0 +1,306 @@
+/**
+ * user-export.js — paging, envelope and cache policy for `GET /api/user/export`.
+ *
+ * ## Why this module exists
+ *
+ * The export route fetched a user's whole profile, whole cycle history and
+ * whole daily-log table, materialised all of it in memory, serialised it to
+ * JSON and buffered it into one response:
+ *
+ *     const { data: logs } = await supabase.from('daily_logs').select('*').eq('user_id', userId)
+ *     return NextResponse.json({ profile: profile || {}, cycles: cycles || [], logs: logs || [] })
+ *
+ * `daily_logs` grows one row per tracked day per user, forever. A long-standing
+ * account therefore produces a multi-megabyte body from a function with a fixed
+ * memory budget, and there was no rate limit in front of it — unlike the two
+ * sibling exports, `/api/export-data` and `/api/privacy/export`, which both
+ * open with `crudLimiter.check(request)`.
+ *
+ * The response shape was wrong in a second, quieter way: errors came back as
+ * `{ success: false, error }` but success came back as a bare
+ * `{ profile, cycles, logs }`. A client that checks `data.success` — which is
+ * what every other consumer in this codebase does — read a successful export
+ * as a failure.
+ *
+ * This module owns the parts of the fix that must behave identically in the
+ * route and in `scripts/test-user-export.js`: how a page is resolved, how a
+ * cursor round-trips, what the envelope looks like, and which headers a
+ * response full of personal health data has to carry.
+ */
+
+/** Rows per page when the caller does not ask for a specific size. */
+export const DEFAULT_EXPORT_LIMIT = 500
+
+/**
+ * Hard ceiling on a single page. A caller asking for more is clamped rather
+ * than refused: the request is reasonable, the size is not.
+ */
+export const MAX_EXPORT_LIMIT = 2000
+
+/**
+ * Headers for any response carrying cycle dates, symptoms or moods.
+ *
+ * `lib/security-headers.mjs` already lists `/api/user/export` in
+ * `SENSITIVE_API_PREFIXES`, but that applies at the edge. Setting them on the
+ * response too means the policy survives a direct hit that bypasses the
+ * middleware, and makes the intent visible at the route.
+ */
+export const NO_STORE_HEADERS = Object.freeze({
+  'Cache-Control': 'no-store, no-cache, must-revalidate, max-age=0',
+  Pragma: 'no-cache',
+  Expires: '0',
+})
+
+/** PostgREST's "no rows returned" code, raised by `.single()` on an empty set. */
+export const NO_ROWS_CODE = 'PGRST116'
+
+/**
+ * Prefix marking a value as one of our cursors rather than a bare number a
+ * caller happened to type into the query string.
+ */
+const CURSOR_PREFIX = 'r'
+
+/**
+ * Encodes a page offset into a cursor.
+ *
+ * Deliberately not base64: this module runs in the browser as well as in the
+ * route (the download loop below uses it), and `Buffer` is not available
+ * there. A prefixed decimal is URL-safe as-is, needs no polyfill, and stays
+ * opaque enough that a client has no reason to construct one by hand.
+ *
+ * @param {number} offset row offset of the next page
+ * @returns {string|null} `null` when there is no next page
+ */
+export function encodeExportCursor(offset) {
+  if (!Number.isFinite(offset) || offset <= 0) return null
+
+  return `${CURSOR_PREFIX}${Math.floor(offset)}`
+}
+
+/**
+ * Decodes a cursor back into an offset.
+ *
+ * A malformed, truncated or hand-written cursor resolves to `0` rather than
+ * throwing: the worst outcome is that the caller is served the first page
+ * again, which is recoverable, while a 500 in the middle of an export is not.
+ *
+ * @param {unknown} cursor
+ * @returns {number} offset, never negative
+ */
+export function decodeExportCursor(cursor) {
+  if (typeof cursor !== 'string') return 0
+
+  const trimmed = cursor.trim()
+  if (!trimmed.startsWith(CURSOR_PREFIX)) return 0
+
+  const offset = Number(trimmed.slice(CURSOR_PREFIX.length))
+  return Number.isFinite(offset) && offset > 0 ? Math.floor(offset) : 0
+}
+
+/**
+ * Resolves the page a request is asking for.
+ *
+ * Cycles and logs page independently, because they are wildly different sizes:
+ * a user with three years of history has ~36 cycles and ~1000 daily logs, and
+ * forcing them onto a shared cursor would make the caller re-request the
+ * cycles on every page.
+ *
+ * @param {URLSearchParams} searchParams
+ * @returns {{ limit: number, cycleOffset: number, logOffset: number }}
+ */
+export function resolveExportPaging(searchParams) {
+  const raw = searchParams?.get ? searchParams.get('limit') : null
+  const parsed = Number.parseInt(raw, 10)
+
+  let limit = DEFAULT_EXPORT_LIMIT
+  if (Number.isFinite(parsed) && parsed > 0) {
+    limit = Math.min(parsed, MAX_EXPORT_LIMIT)
+  }
+
+  return {
+    limit,
+    cycleOffset: decodeExportCursor(searchParams?.get ? searchParams.get('cycleCursor') : null),
+    logOffset: decodeExportCursor(searchParams?.get ? searchParams.get('logCursor') : null),
+  }
+}
+
+/**
+ * The inclusive row range for a page, in the form Supabase's `.range()` wants.
+ *
+ * @param {number} offset
+ * @param {number} limit
+ * @returns {{ from: number, to: number }}
+ */
+export function pageRange(offset, limit) {
+  const from = Math.max(0, Math.floor(offset))
+  return { from, to: from + Math.max(1, Math.floor(limit)) - 1 }
+}
+
+/**
+ * True when a full page came back, which is the only signal that there may be
+ * more. A short page is definitively the last one.
+ *
+ * @param {unknown[]} rows
+ * @param {number} limit
+ * @returns {boolean}
+ */
+export function hasMorePages(rows, limit) {
+  return Array.isArray(rows) && rows.length >= limit
+}
+
+/**
+ * Builds the response body.
+ *
+ * The bare `profile` / `cycles` / `logs` keys are kept at the top level
+ * deliberately: the Settings page and the privacy modals write this response
+ * straight to a `.json` file the user downloads, so removing them would change
+ * what lands on disk. `success` and `data` are added alongside, so a client
+ * checking `data.success` — the convention everywhere else in this codebase —
+ * finally sees a truthful value.
+ *
+ * @param {{ profile: object|null, cycles: unknown[], logs: unknown[], limit: number, cycleOffset: number, logOffset: number }} input
+ * @returns {object}
+ */
+export function buildExportPayload({
+  profile,
+  cycles,
+  logs,
+  limit,
+  cycleOffset = 0,
+  logOffset = 0,
+} = {}) {
+  const cycleRows = Array.isArray(cycles) ? cycles : []
+  const logRows = Array.isArray(logs) ? logs : []
+
+  const moreCycles = hasMorePages(cycleRows, limit)
+  const moreLogs = hasMorePages(logRows, limit)
+
+  const payload = {
+    profile: profile || {},
+    cycles: cycleRows,
+    logs: logRows,
+    pagination: {
+      limit,
+      hasMore: moreCycles || moreLogs,
+      cycles: {
+        returned: cycleRows.length,
+        hasMore: moreCycles,
+        nextCursor: moreCycles ? encodeExportCursor(cycleOffset + cycleRows.length) : null,
+      },
+      logs: {
+        returned: logRows.length,
+        hasMore: moreLogs,
+        nextCursor: moreLogs ? encodeExportCursor(logOffset + logRows.length) : null,
+      },
+      // Where each table should resume, whether or not it has more rows.
+      //
+      // A finished table still needs a position: omitting its cursor from the
+      // next request would restart it at offset 0 and hand the caller the same
+      // rows a second time, in what the user is told is one copy of their
+      // data. Sending the end offset instead yields an empty page, which is
+      // what "done" should look like.
+      resume: {
+        cycleCursor: encodeExportCursor(cycleOffset + cycleRows.length),
+        logCursor: encodeExportCursor(logOffset + logRows.length),
+      },
+    },
+  }
+
+  return { success: true, data: payload, ...payload }
+}
+
+/**
+ * Builds the URL a client should request for the next page, or `null` when the
+ * export is complete. Kept here so the loop in the UI and the loop in the tests
+ * cannot drift apart.
+ *
+ * @param {string} basePath e.g. `/api/user/export`
+ * @param {object} pagination the `pagination` block from a previous response
+ * @returns {string|null}
+ */
+export function nextPageUrl(basePath, pagination) {
+  if (!pagination || !pagination.hasMore) return null
+
+  const params = new URLSearchParams()
+  params.set('limit', String(pagination.limit))
+
+  // Both cursors, always -- see the note on `resume` in buildExportPayload.
+  if (pagination.resume?.cycleCursor) params.set('cycleCursor', pagination.resume.cycleCursor)
+  if (pagination.resume?.logCursor) params.set('logCursor', pagination.resume.logCursor)
+
+  return `${basePath}?${params.toString()}`
+}
+
+/**
+ * Merges a page into an accumulating export, so a client can assemble the full
+ * document from however many pages the server chose to split it into.
+ *
+ * The profile is taken from the first page only — it is a single row, and a
+ * later page repeating it must not overwrite what the caller already has.
+ *
+ * @param {{ profile: object, cycles: unknown[], logs: unknown[] }|null} accumulated
+ * @param {{ profile?: object, cycles?: unknown[], logs?: unknown[] }} page
+ * @returns {{ profile: object, cycles: unknown[], logs: unknown[] }}
+ */
+export function mergeExportPage(accumulated, page) {
+  if (!accumulated) {
+    return {
+      profile: page?.profile || {},
+      cycles: Array.isArray(page?.cycles) ? [...page.cycles] : [],
+      logs: Array.isArray(page?.logs) ? [...page.logs] : [],
+    }
+  }
+
+  return {
+    profile: accumulated.profile,
+    cycles: accumulated.cycles.concat(Array.isArray(page?.cycles) ? page.cycles : []),
+    logs: accumulated.logs.concat(Array.isArray(page?.logs) ? page.logs : []),
+  }
+}
+
+/**
+ * Walks every page of the export and returns one assembled document.
+ *
+ * Lives here rather than in each of the three UI call sites -- the Settings
+ * page, `PrivacyModal` and `PrivacySettingsModal` all download this export, and
+ * each of them previously issued a single request and saved whatever came back.
+ * With the endpoint now paged, a client that does not loop would silently save
+ * a truncated copy of the user's health data and call it complete, which is a
+ * worse failure than the unbounded response it replaced.
+ *
+ * @param {(url: string) => Promise<Response>} fetchPage issues one request
+ * @param {{ basePath?: string, maxPages?: number }} [options]
+ * @returns {Promise<{ profile: object, cycles: unknown[], logs: unknown[], pages: number, complete: boolean }>}
+ */
+export async function collectFullExport(fetchPage, { basePath = '/api/user/export', maxPages = 200 } = {}) {
+  let url = basePath
+  let accumulated = null
+  let pages = 0
+  let complete = false
+
+  while (url && pages < maxPages) {
+    const response = await fetchPage(url)
+
+    if (!response || !response.ok) {
+      const status = response ? response.status : 'no response'
+      throw new Error(`Export request failed (${status})`)
+    }
+
+    const body = await response.json()
+    accumulated = mergeExportPage(accumulated, body)
+    pages += 1
+
+    url = nextPageUrl(basePath, body?.pagination)
+    if (!url) complete = true
+  }
+
+  return {
+    profile: accumulated?.profile || {},
+    cycles: accumulated?.cycles || [],
+    logs: accumulated?.logs || [],
+    pages,
+    // False only when the page ceiling was hit, so a caller can warn rather
+    // than present a partial export as a whole one.
+    complete,
+  }
+}

--- a/scripts/test-user-export.js
+++ b/scripts/test-user-export.js
@@ -1,0 +1,341 @@
+/**
+ * Regression suite for lib/user-export.js.
+ *
+ * The bug this is part of fixing: `GET /api/user/export` fetched a user's whole
+ * profile, whole cycle history and whole daily-log table, buffered all of it
+ * into one response, and had no rate limit in front of it -- unlike the two
+ * sibling exports, `/api/export-data` and `/api/privacy/export`, which both
+ * open with `crudLimiter.check(request)`.
+ *
+ * `daily_logs` grows one row per tracked day per user, forever, so the body
+ * size was a function of how long somebody had been using the app.
+ *
+ * The response shape was wrong in a quieter way too: errors came back as
+ * `{ success: false, error }` but success came back as a bare
+ * `{ profile, cycles, logs }`. A client checking `data.success` -- the
+ * convention everywhere else in this codebase -- read a successful export as a
+ * failure. Meanwhile the Settings page and the privacy modals write the body
+ * straight to a downloaded `.json` file, so the bare keys have to survive.
+ *
+ * The paging assertions below matter because getting them wrong is worse than
+ * not paging at all: an off-by-one in the offset silently drops or duplicates
+ * rows in what the user is told is a complete copy of their health data.
+ *
+ *   node scripts/test-user-export.js
+ */
+
+import {
+  collectFullExport,
+  DEFAULT_EXPORT_LIMIT,
+  MAX_EXPORT_LIMIT,
+  NO_STORE_HEADERS,
+  buildExportPayload,
+  decodeExportCursor,
+  encodeExportCursor,
+  hasMorePages,
+  mergeExportPage,
+  nextPageUrl,
+  pageRange,
+  resolveExportPaging,
+} from '../lib/user-export.js'
+
+let passed = 0
+let failed = 0
+
+function check(actual, expected, label) {
+  if (Object.is(actual, expected)) {
+    passed += 1
+    return
+  }
+  failed += 1
+  console.error(`  ${label}`)
+  console.error(`       expected: ${JSON.stringify(expected)}`)
+  console.error(`       actual:   ${JSON.stringify(actual)}`)
+}
+
+function checkDeep(actual, expected, label) {
+  const a = JSON.stringify(actual)
+  const b = JSON.stringify(expected)
+  if (a === b) {
+    passed += 1
+    return
+  }
+  failed += 1
+  console.error(`  ${label}`)
+  console.error(`       expected: ${b}`)
+  console.error(`       actual:   ${a}`)
+}
+
+function checkTruthy(value, label) {
+  check(Boolean(value), true, label)
+}
+
+const rows = (n, prefix) => Array.from({ length: n }, (_, i) => ({ id: `${prefix}-${i}` }))
+
+// ---------------------------------------------------------------------------
+// Page size
+// ---------------------------------------------------------------------------
+
+console.log('\npage size is bounded whatever the caller asks for')
+
+check(resolveExportPaging(new URLSearchParams()).limit, DEFAULT_EXPORT_LIMIT,
+  'no limit parameter falls back to the default page size')
+check(resolveExportPaging(new URLSearchParams('limit=50')).limit, 50,
+  'a reasonable limit is honoured')
+check(resolveExportPaging(new URLSearchParams('limit=99999')).limit, MAX_EXPORT_LIMIT,
+  'an unreasonable limit is clamped rather than refused')
+check(resolveExportPaging(new URLSearchParams('limit=0')).limit, DEFAULT_EXPORT_LIMIT,
+  'a zero limit falls back rather than returning an empty page forever')
+check(resolveExportPaging(new URLSearchParams('limit=-5')).limit, DEFAULT_EXPORT_LIMIT,
+  'a negative limit falls back')
+check(resolveExportPaging(new URLSearchParams('limit=abc')).limit, DEFAULT_EXPORT_LIMIT,
+  'a non-numeric limit falls back')
+check(resolveExportPaging(undefined).limit, DEFAULT_EXPORT_LIMIT,
+  'no search params at all still resolves a page size')
+
+// ---------------------------------------------------------------------------
+// Cursors
+// ---------------------------------------------------------------------------
+
+console.log('\ncursors round-trip and fail safe')
+
+check(decodeExportCursor(encodeExportCursor(500)), 500, 'an offset survives a round trip')
+check(decodeExportCursor(encodeExportCursor(1)), 1, 'including the smallest real offset')
+check(encodeExportCursor(0), null, 'there is no cursor for the first page')
+check(encodeExportCursor(-1), null, 'nor for a negative offset')
+check(encodeExportCursor(Number.NaN), null, 'nor for a non-finite one')
+
+check(decodeExportCursor('not-base64'), 0, 'a hand-written cursor resolves to the first page')
+check(decodeExportCursor(''), 0, 'so does an empty one')
+check(decodeExportCursor(null), 0, 'so does a missing one')
+check(decodeExportCursor(Buffer.from('{}', 'utf8').toString('base64url')), 0,
+  'so does a well-formed cursor carrying no offset')
+check(decodeExportCursor(Buffer.from('{"o":-9}', 'utf8').toString('base64url')), 0,
+  'a negative offset inside a cursor is refused')
+checkTruthy(
+  encodeURIComponent(encodeExportCursor(500)) === encodeExportCursor(500),
+  'the cursor needs no escaping, so it survives a query string untouched'
+)
+check(decodeExportCursor('500'), 0, 'a bare number is not mistaken for one of our cursors')
+check(decodeExportCursor('r'), 0, 'nor is a prefix with no offset')
+
+const paging = resolveExportPaging(
+  new URLSearchParams(`limit=100&cycleCursor=${encodeExportCursor(100)}&logCursor=${encodeExportCursor(700)}`)
+)
+check(paging.cycleOffset, 100, 'cycles carry their own offset')
+check(paging.logOffset, 700, 'logs carry a separate one, because the two tables are wildly different sizes')
+
+// ---------------------------------------------------------------------------
+// Ranges
+// ---------------------------------------------------------------------------
+
+console.log('\nrow ranges are inclusive and never overlap')
+
+checkDeep(pageRange(0, 500), { from: 0, to: 499 }, 'the first page is 0..499 for a 500-row limit')
+checkDeep(pageRange(500, 500), { from: 500, to: 999 }, 'the second page starts exactly where the first ended')
+checkDeep(pageRange(0, 1), { from: 0, to: 0 }, 'a single-row page is one row, not zero')
+checkDeep(pageRange(-10, 500), { from: 0, to: 499 }, 'a negative offset is clamped to the start')
+
+const first = pageRange(0, 250)
+const second = pageRange(250, 250)
+check(second.from, first.to + 1, 'consecutive pages neither skip nor repeat a row')
+
+// ---------------------------------------------------------------------------
+// Envelope
+// ---------------------------------------------------------------------------
+
+console.log('\nthe envelope satisfies both the API convention and the downloaded file')
+
+const page = buildExportPayload({
+  profile: { user_id: 'u1', age: 29 },
+  cycles: rows(3, 'c'),
+  logs: rows(3, 'l'),
+  limit: 500,
+})
+
+check(page.success, true, 'a successful export finally says so')
+checkTruthy(page.data, 'the standard data envelope is present')
+checkTruthy(Array.isArray(page.cycles), 'and the bare cycles key the download relies on survives')
+checkTruthy(Array.isArray(page.logs), 'and the bare logs key')
+check(page.profile.age, 29, 'and the bare profile key')
+checkDeep(page.data.cycles, page.cycles, 'the two spellings describe the same rows')
+
+check(buildExportPayload({ profile: null, cycles: null, logs: null, limit: 500 }).profile.user_id, undefined,
+  'a missing profile becomes an empty object rather than null')
+checkDeep(buildExportPayload({ limit: 500 }).cycles, [], 'missing rows become an empty array')
+check(buildExportPayload({ limit: 500 }).success, true, 'an empty export is still a success')
+
+// ---------------------------------------------------------------------------
+// hasMore
+// ---------------------------------------------------------------------------
+
+console.log('\nhasMore is derived from the page, not guessed')
+
+check(hasMorePages(rows(500, 'x'), 500), true, 'a full page means there may be more')
+check(hasMorePages(rows(499, 'x'), 500), false, 'a short page is definitively the last')
+check(hasMorePages([], 500), false, 'an empty page is the last')
+check(hasMorePages(null, 500), false, 'a missing page is not more')
+
+const fullPage = buildExportPayload({ profile: {}, cycles: rows(10, 'c'), logs: rows(4, 'l'), limit: 10 })
+check(fullPage.pagination.cycles.hasMore, true, 'a full cycles page reports more cycles')
+check(fullPage.pagination.logs.hasMore, false, 'while a short logs page reports no more logs')
+check(fullPage.pagination.hasMore, true, 'the export as a whole is incomplete if either table has more')
+checkTruthy(fullPage.pagination.cycles.nextCursor, 'the incomplete table gets a cursor')
+check(fullPage.pagination.logs.nextCursor, null, 'the finished table does not')
+
+const lastPage = buildExportPayload({ profile: {}, cycles: rows(2, 'c'), logs: rows(2, 'l'), limit: 10 })
+check(lastPage.pagination.hasMore, false, 'a final page says the export is complete')
+check(nextPageUrl('/api/user/export', lastPage.pagination), null, 'and offers no next URL')
+
+// ---------------------------------------------------------------------------
+// Client loop
+// ---------------------------------------------------------------------------
+
+console.log('\na client can reassemble the whole export')
+
+const nextUrl = nextPageUrl('/api/user/export', fullPage.pagination)
+checkTruthy(nextUrl.startsWith('/api/user/export?'), 'the next URL targets the same endpoint')
+checkTruthy(nextUrl.includes('cycleCursor='), 'and carries the cursor for the unfinished table')
+checkTruthy(
+  nextUrl.includes('logCursor='),
+  'and one for the finished table too -- omitting it would restart that table at offset 0 and repeat its rows'
+)
+check(
+  new URLSearchParams(nextUrl.split('?')[1]).get('limit'),
+  '10',
+  'and preserves the page size, so the caller is not silently re-sized'
+)
+
+// Walk a 25-row history in pages of 10 and assert nothing is lost or repeated.
+const allCycles = rows(25, 'c')
+const allLogs = rows(7, 'l')
+const LIMIT = 10
+
+let accumulated = null
+let cycleOffset = 0
+let logOffset = 0
+let pages = 0
+
+for (;;) {
+  const window = pageRange(cycleOffset, LIMIT)
+  const logWindow = pageRange(logOffset, LIMIT)
+
+  const body = buildExportPayload({
+    profile: { user_id: 'u1' },
+    cycles: allCycles.slice(window.from, window.to + 1),
+    logs: allLogs.slice(logWindow.from, logWindow.to + 1),
+    limit: LIMIT,
+    cycleOffset,
+    logOffset,
+  })
+
+  accumulated = mergeExportPage(accumulated, body)
+  pages += 1
+
+  if (!body.pagination.hasMore || pages > 10) break
+
+  cycleOffset = decodeExportCursor(body.pagination.resume.cycleCursor)
+  logOffset = decodeExportCursor(body.pagination.resume.logCursor)
+}
+
+check(pages, 3, 'a 25-row history in pages of 10 takes exactly three requests')
+check(accumulated.cycles.length, 25, 'every cycle is collected')
+check(accumulated.logs.length, 7, 'every log is collected, even though logs finished first')
+check(new Set(accumulated.cycles.map((c) => c.id)).size, 25, 'no cycle is duplicated across pages')
+check(new Set(accumulated.logs.map((l) => l.id)).size, 7, 'no log is duplicated')
+checkDeep(accumulated.cycles.map((c) => c.id), allCycles.map((c) => c.id), 'and the order is preserved')
+check(accumulated.profile.user_id, 'u1', 'the profile is taken from the first page')
+
+check(
+  mergeExportPage({ profile: { user_id: 'first' }, cycles: [], logs: [] }, { profile: { user_id: 'later' } })
+    .profile.user_id,
+  'first',
+  'a later page repeating the profile does not overwrite it'
+)
+
+// ---------------------------------------------------------------------------
+// The download loop
+// ---------------------------------------------------------------------------
+
+console.log('\nthe download loop saves a whole export, never a truncated one')
+
+/** A fake endpoint serving `total` cycles and `logTotal` logs in pages of `limit`. */
+function fakeEndpoint({ total, logTotal, limit }) {
+  const cycleRows = rows(total, 'c')
+  const logRows = rows(logTotal, 'l')
+  let requests = 0
+
+  return {
+    get requests() {
+      return requests
+    },
+    async fetch(url) {
+      requests += 1
+      const query = new URLSearchParams(url.split('?')[1] || '')
+      const cycleOffset = decodeExportCursor(query.get('cycleCursor'))
+      const logOffset = decodeExportCursor(query.get('logCursor'))
+      const cw = pageRange(cycleOffset, limit)
+      const lw = pageRange(logOffset, limit)
+
+      return {
+        ok: true,
+        status: 200,
+        json: async () =>
+          buildExportPayload({
+            profile: { user_id: 'u1' },
+            cycles: cycleRows.slice(cw.from, cw.to + 1),
+            logs: logRows.slice(lw.from, lw.to + 1),
+            limit,
+            cycleOffset,
+            logOffset,
+          }),
+      }
+    },
+  }
+}
+
+const endpoint = fakeEndpoint({ total: 25, logTotal: 7, limit: 10 })
+const collected = await collectFullExport((url) => endpoint.fetch(url))
+
+check(collected.cycles.length, 25, 'the loop collects every cycle across pages')
+check(collected.logs.length, 7, 'and every log')
+check(new Set(collected.cycles.map((c) => c.id)).size, 25, 'with no duplicates')
+check(collected.profile.user_id, 'u1', 'and the profile from the first page')
+check(collected.complete, true, 'and reports the export as complete')
+check(endpoint.requests, 3, 'in exactly the number of requests the page size implies')
+
+const single = fakeEndpoint({ total: 4, logTotal: 2, limit: 10 })
+const smallExport = await collectFullExport((url) => single.fetch(url))
+check(single.requests, 1, 'a small export still takes one request')
+check(smallExport.complete, true, 'and is complete')
+
+const capped = fakeEndpoint({ total: 1000, logTotal: 0, limit: 10 })
+const partial = await collectFullExport((url) => capped.fetch(url), { maxPages: 3 })
+check(partial.complete, false, 'hitting the page ceiling is reported, not hidden')
+check(partial.cycles.length, 30, 'and the caller still gets what was fetched')
+
+let threw = null
+try {
+  await collectFullExport(async () => ({ ok: false, status: 429 }))
+} catch (err) {
+  threw = err
+}
+checkTruthy(threw, 'a failed page rejects rather than saving a half-written export')
+checkTruthy(threw.message.includes('429'), 'and the status is carried into the message')
+
+// ---------------------------------------------------------------------------
+// Cache policy
+// ---------------------------------------------------------------------------
+
+console.log('\npersonal health data is never stored')
+
+checkTruthy(NO_STORE_HEADERS['Cache-Control'].includes('no-store'), 'no-store is set')
+checkTruthy(NO_STORE_HEADERS['Cache-Control'].includes('must-revalidate'), 'and must-revalidate')
+check(NO_STORE_HEADERS.Pragma, 'no-cache', 'the HTTP/1.0 header is set for older intermediaries')
+check(NO_STORE_HEADERS.Expires, '0', 'and an already-expired Expires')
+checkTruthy(Object.isFrozen(NO_STORE_HEADERS), 'the header set cannot be mutated by a caller')
+
+// ---------------------------------------------------------------------------
+
+console.log(`\n${failed === 0 ? 'PASS' : 'FAIL'} ${passed} passed, ${failed} failed`)
+process.exit(failed === 0 ? 0 : 1)


### PR DESCRIPTION
## Linked Issue
Fixes #737

## Description

`GET /api/user/export` fetched a user's whole profile, whole cycle history and whole `daily_logs` table, buffered all of it into one response, and had **no rate limit** in front of it — unlike the two sibling exports, `/api/export-data` and `/api/privacy/export`, which both open with `crudLimiter.check(request)`:

```js
const { data: logs } = await supabase.from('daily_logs').select('*').eq('user_id', userId)
return NextResponse.json({ profile: profile || {}, cycles: cycles || [], logs: logs || [] }, { status: 200 })
```

`daily_logs` grows one row per tracked day per user, forever, so the body size was a function of how long somebody had been using the app — produced by a function with a fixed memory budget, from an endpoint any refresh loop could hammer with three unbounded scans per call.

Four more problems in the same handler:

- **`.single()` is the wrong selector.** It raises `PGRST116` for every brand-new account, so the code carried a special case for it. `.maybeSingle()` returns `null` without an error, which leaves `error` meaning only "a genuine database fault".
- **No cache directives** on a response full of cycle dates, symptoms and moods, and no `export const dynamic = 'force-dynamic'` — both of which `/api/export-data` has.
- **Envelope inconsistency.** Errors returned `{ success: false, error }`, success returned a bare `{ profile, cycles, logs }`. A client checking `data.success` — the convention everywhere else in this codebase — read a successful export as a failure.
- **The driver's error message was echoed** to the caller, which can name columns and constraints.

### The fix

**`lib/user-export.js` (new)** owns the paging arithmetic, the envelope and the header set, because all of it has to behave identically in the route and in the tests.

Cycles and logs page **independently**: three years of history is roughly 36 cycles and 1000 daily logs, so a shared cursor would re-send the cycles on every page. The subtle part is that a *finished* table still gets a resume cursor — omitting its cursor from the next request would restart it at offset 0 and hand the caller the same rows a second time, inside what the user is told is one complete copy of their health data. Sending the end offset yields an empty page instead, which is what "done" should look like. There is an assertion for exactly this.

Cursors are prefixed decimals rather than base64: this module runs in the browser too (see below), and `Buffer` is not available there.

**`app/api/user/export/route.js`** adds `crudLimiter`, switches to `.maybeSingle()`, orders deterministically on `(start_date, id)` / `(date, id)` — matching what `/api/cycles` and `/api/log-day` already do, and what makes offset paging correct at all — sets `no-store` headers plus `dynamic = 'force-dynamic'`, and reports a database fault without echoing the driver's message.

**The three download clients.** This is the part that makes the change safe rather than a regression: the Settings page, `PrivacyModal` and `PrivacySettingsModal` all write this response body straight to a `.json` file the user downloads. A single request against a now-paged endpoint would silently save a truncated history and call it complete — worse than the unbounded response it replaces. All three now walk every page through `collectFullExport` and refuse to write the file when the page ceiling was hit. The bare `profile` / `cycles` / `logs` keys are kept alongside the new `success` / `data` envelope so the downloaded file is unchanged in shape.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (clean code updates, no behavior modifications)
- [ ] Documentation update
- [x] Performance optimization
- [x] Security patch

## Files Modified

| File | Change |
|------|--------|
| `lib/user-export.js` | **New.** Page resolution, cursors, ranges, envelope, `no-store` headers, client collection loop |
| `app/api/user/export/route.js` | Rate limiting, `maybeSingle()`, deterministic ordering + ranges, envelope, cache headers, no message echo |
| `app/[locale]/settings/page.js` | Walks every page before writing the download |
| `components/modals/PrivacyModal.jsx` | Same |
| `components/layout/PrivacySettingsModal.jsx` | Same, preserving its `Authorization` header |
| `scripts/test-user-export.js` | **New.** 76 assertions |

## Testing

```bash
node scripts/test-user-export.js
# PASS 76 passed, 0 failed
```

The paging assertions matter more than usual here: an off-by-one silently drops or duplicates rows in what the user is told is a complete copy of their health data. The suite walks a simulated 25-cycle / 7-log export through the **real client loop** against a fake endpoint and asserts every row arrives exactly once, in order, in exactly three requests — including the case where logs finish before cycles do, which is what caught the resume-cursor bug during development.

Manual:

```bash
curl -si localhost:3000/api/user/export | grep -i cache-control
# Cache-Control: no-store, no-cache, must-revalidate, max-age=0

curl -s 'localhost:3000/api/user/export?limit=2' | jq '.success, .pagination'
```

Then export from **Settings → Export My Data** on an account with more than 500 logs and confirm the downloaded file contains the whole history.

## Screenshots (if UI changes are made)
No visual change. The three clients change only how they assemble the file.

## Checklist
- [x] This PR is submitted under ECSOC.
- [x] Added the required **ECSoc26** label to this Pull Request.
- [x] Linked issue using `Fixes #737`.
- [x] Tested locally.
- [x] No breaking changes introduced.
- [x] Documentation updated if required.
