### PR TITLE
[ECSoC26] Frontend: Roll the self-care trackers over at midnight and validate restored state

### DIFF
--- a/components/self-care/HydrationTracker.jsx
+++ b/components/self-care/HydrationTracker.jsx
@@ -4,6 +4,8 @@ import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { useTranslations } from 'next-intl';
 import { Droplet, Settings, X } from 'lucide-react';
 import { getTodayISO } from '@/lib/date-utils';
+import { RECORD_STATUS, clampNumber, readDailyRecord, writeDailyRecord } from '@/lib/daily-storage';
+import useDailyReset from '@/lib/useDailyReset';
 
 // ─── Constants ──────────────────────────────────────────────────────────────
 
@@ -24,34 +26,66 @@ function getTodayString() {
   return getTodayISO();
 }
 
+// Bounds the settings modal already enforces on save. They are repeated on the
+// *read* path because the modal's validation was being thrown away on the next
+// page load: `{ ...DEFAULT_SETTINGS, ...JSON.parse(raw) }` spread whatever was
+// stored straight over the defaults. A stored `cupCapacity: 0` then reached
+// `Math.round(dailyGoal / cupCapacity)`, and a stored `dailyGoal: 0` made the
+// ring's `strokeDashoffset` NaN, which renders as no ring at all.
+const GOAL_BOUNDS = { min: 500, max: 5000, fallback: DEFAULT_SETTINGS.dailyGoal, integer: true };
+const CAPACITY_BOUNDS = { min: 50, max: 1000, fallback: DEFAULT_SETTINGS.cupCapacity, integer: true };
+
+/**
+ * Normalises a stored settings payload. Never returns a value that can produce
+ * a division by zero or a non-finite percentage downstream.
+ */
+function sanitizeSettings(stored) {
+  const source = stored && typeof stored === 'object' ? stored : {};
+
+  return {
+    dailyGoal: clampNumber(source.dailyGoal, GOAL_BOUNDS),
+    cupCapacity: clampNumber(source.cupCapacity, CAPACITY_BOUNDS),
+    cupStyle: CUP_STYLES.includes(source.cupStyle) ? source.cupStyle : DEFAULT_SETTINGS.cupStyle,
+  };
+}
+
 function loadSettings() {
-  try {
-    const raw = localStorage.getItem(SETTINGS_KEY);
-    if (raw) return { ...DEFAULT_SETTINGS, ...JSON.parse(raw) };
-  } catch (_) {}
-  return { ...DEFAULT_SETTINGS };
+  // Settings are not day-scoped, so any stored date is accepted; only the
+  // values are validated.
+  const { value } = readDailyRecord(SETTINGS_KEY, {
+    sanitize: sanitizeSettings,
+    fallback: () => ({ ...DEFAULT_SETTINGS }),
+    onNewDay: (settings) => settings,
+  });
+
+  return value;
 }
 
 function saveSettings(settings) {
-  try {
-    localStorage.setItem(SETTINGS_KEY, JSON.stringify(settings));
-  } catch (_) {}
+  writeDailyRecord(SETTINGS_KEY, sanitizeSettings(settings), { today: getTodayString() });
 }
 
-function loadCount() {
-  try {
-    const saved = JSON.parse(localStorage.getItem(INTAKE_KEY));
-    if (saved && saved.date === getTodayString()) return saved.count;
-    // New day — reset but write the key so NotificationPreferences reads 0
-    localStorage.setItem(INTAKE_KEY, JSON.stringify({ date: getTodayString(), count: 0 }));
-  } catch (_) {}
-  return 0;
+function loadCount(maxGlasses) {
+  const ceiling = Number.isFinite(maxGlasses) ? maxGlasses : 16;
+
+  const { value, status } = readDailyRecord(INTAKE_KEY, {
+    sanitize: (stored) => clampNumber(stored.count, { min: 0, max: ceiling, fallback: 0, integer: true }),
+    fallback: () => 0,
+    // A record from another day resets to zero rather than carrying forward.
+    onNewDay: () => 0,
+    today: getTodayString(),
+  });
+
+  // Write the reset back immediately so NotificationPreferences, which reads
+  // this key directly to decide whether to nudge, sees today's zero rather
+  // than yesterday's total.
+  if (status !== RECORD_STATUS.CURRENT) saveCount(0);
+
+  return value;
 }
 
 function saveCount(count) {
-  try {
-    localStorage.setItem(INTAKE_KEY, JSON.stringify({ date: getTodayString(), count }));
-  } catch (_) {}
+  writeDailyRecord(INTAKE_KEY, { count }, { today: getTodayString() });
 }
 
 function clamp(value, min, max) {
@@ -352,10 +386,21 @@ export default function HydrationTracker({ phaseKey }) {
 
   // Load from localStorage on mount (client only)
   useEffect(() => {
-    setSettings(loadSettings());
-    setCount(loadCount());
+    const restored = loadSettings();
+    setSettings(restored);
+    setCount(loadCount(clamp(Math.round(restored.dailyGoal / restored.cupCapacity), 4, 16)));
     setMounted(true);
   }, []);
+
+  // Without this the ring kept yesterday's glasses for as long as the tab
+  // stayed open, and the next click stamped today's date onto them.
+  useDailyReset(
+    useCallback(() => {
+      setCount(0);
+      saveCount(0);
+    }, []),
+    { watchKeys: [INTAKE_KEY] }
+  );
 
   const numGlasses = clamp(Math.round(settings.dailyGoal / settings.cupCapacity), 4, 16);
   const currentMl = count * settings.cupCapacity;
@@ -370,10 +415,11 @@ export default function HydrationTracker({ phaseKey }) {
   }, [count, numGlasses]);
 
   const handleSaveSettings = useCallback((newSettings) => {
-    setSettings(newSettings);
-    saveSettings(newSettings);
+    const validated = sanitizeSettings(newSettings);
+    setSettings(validated);
+    saveSettings(validated);
     // Clamp count if numGlasses shrank
-    const newNumGlasses = clamp(Math.round(newSettings.dailyGoal / newSettings.cupCapacity), 4, 16);
+    const newNumGlasses = clamp(Math.round(validated.dailyGoal / validated.cupCapacity), 4, 16);
     if (count > newNumGlasses) {
       setCount(newNumGlasses);
       saveCount(newNumGlasses);

--- a/components/self-care/SelfCareChecklist.jsx
+++ b/components/self-care/SelfCareChecklist.jsx
@@ -1,9 +1,11 @@
 'use client'
 
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { useTranslations } from 'next-intl';
 import { Check, Plus, Trash2, Pencil, X } from 'lucide-react';
 import { getTodayISO } from '@/lib/date-utils';
+import { readDailyRecord, writeDailyRecord } from '@/lib/daily-storage';
+import useDailyReset from '@/lib/useDailyReset';
 
 // ─── Constants ───────────────────────────────────────────────────────────────
 
@@ -22,43 +24,75 @@ function makeDefaultTasks() {
   return DEFAULT_TASK_DEFS.map((def) => ({ ...def, completed: false }));
 }
 
-function loadTasks() {
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    if (!raw) return makeDefaultTasks();
+/** Most custom tasks a list may hold, so storage cannot grow without bound. */
+const MAX_TASKS = 50;
 
-    const saved = JSON.parse(raw);
-    const today = getTodayISO();
+/**
+ * Turns a stored task list into one that is safe to render.
+ *
+ * The previous version accepted `saved.tasks` as long as it was an array, so a
+ * malformed entry with no `id` produced duplicate React keys and a row that
+ * could never be deleted -- `deleteTask` filters on `id`, and `undefined ===
+ * undefined` matches every such row at once.
+ */
+function sanitizeTasks(stored) {
+  const raw = Array.isArray(stored?.tasks) ? stored.tasks : [];
+  const seen = new Set();
+  const tasks = [];
 
-    let tasks = Array.isArray(saved.tasks) ? saved.tasks : makeDefaultTasks();
+  for (const entry of raw) {
+    if (!entry || typeof entry !== 'object') continue;
+    if (typeof entry.id !== 'string' || entry.id.trim() === '') continue;
+    if (seen.has(entry.id)) continue;
 
-    // Ensure all default tasks are present (in case new defaults were added later)
-    const existingIds = new Set(tasks.map((t) => t.id));
-    const missingDefaults = DEFAULT_TASK_DEFS
-      .filter((d) => !existingIds.has(d.id))
-      .map((d) => ({ ...d, completed: false }));
-    if (missingDefaults.length > 0) {
-      tasks = [...missingDefaults, ...tasks];
-    }
+    const isDefault = entry.isDefault === true;
+    // A default task is rendered from `labelKey`; a custom one from `label`.
+    // An entry carrying neither has nothing to show.
+    if (isDefault && typeof entry.labelKey !== 'string') continue;
+    if (!isDefault && (typeof entry.label !== 'string' || entry.label.trim() === '')) continue;
 
-    // Daily reset: preserve tasks but clear completed state for a new day
-    if (saved.date !== today) {
-      tasks = tasks.map((t) => ({ ...t, completed: false }));
-    }
+    seen.add(entry.id);
+    tasks.push({
+      id: entry.id,
+      isDefault,
+      labelKey: isDefault ? entry.labelKey : undefined,
+      label: isDefault ? undefined : entry.label.trim().slice(0, 80),
+      completed: entry.completed === true,
+    });
 
-    return tasks;
-  } catch (_) {
-    return makeDefaultTasks();
+    if (tasks.length >= MAX_TASKS) break;
   }
+
+  return withDefaults(tasks);
+}
+
+/** Ensures every default task is present, in case new ones were added later. */
+function withDefaults(tasks) {
+  const existingIds = new Set(tasks.map((t) => t.id));
+  const missing = DEFAULT_TASK_DEFS
+    .filter((d) => !existingIds.has(d.id))
+    .map((d) => ({ ...d, completed: false }));
+
+  return missing.length > 0 ? [...missing, ...tasks] : tasks;
+}
+
+/** Keeps the list but clears every tick, which is what a new day means here. */
+function clearCompletion(tasks) {
+  return tasks.map((t) => ({ ...t, completed: false }));
+}
+
+function loadTasks() {
+  const { value } = readDailyRecord(STORAGE_KEY, {
+    sanitize: sanitizeTasks,
+    fallback: makeDefaultTasks,
+    onNewDay: clearCompletion,
+  });
+
+  return value;
 }
 
 function saveTasks(tasks) {
-  try {
-    localStorage.setItem(
-      STORAGE_KEY,
-      JSON.stringify({ date: getTodayISO(), tasks })
-    );
-  } catch (_) {}
+  writeDailyRecord(STORAGE_KEY, { tasks }, { today: getTodayISO() });
 }
 
 // ─── Component ────────────────────────────────────────────────────────────────
@@ -80,6 +114,21 @@ export default function SelfCareChecklist() {
     setTasks(loadTasks());
     setMounted(true);
   }, []);
+
+  // The list stays on screen across midnight on a tab nobody closed, so the
+  // ticks have to be cleared while the page is open rather than only on the
+  // next mount. Without this the next interaction saved yesterday's ticks
+  // under today's date.
+  useDailyReset(
+    useCallback(() => {
+      setTasks((current) => {
+        const rolled = clearCompletion(current);
+        saveTasks(rolled);
+        return rolled;
+      });
+    }, []),
+    { watchKeys: [STORAGE_KEY] }
+  );
 
   // Auto-focus the edit input whenever editing starts
   useEffect(() => {
@@ -103,9 +152,14 @@ export default function SelfCareChecklist() {
   const addTask = () => {
     const label = newTaskLabel.trim();
     if (!label) return;
+    if (tasks.length >= MAX_TASKS) return;
+
+    // `custom-${Date.now()}` collides for two tasks added inside the same
+    // millisecond, and a duplicate id makes both rows share a React key and
+    // both disappear when either is deleted.
     const newTask = {
-      id: `custom-${Date.now()}`,
-      label,
+      id: `custom-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      label: label.slice(0, 80),
       isDefault: false,
       completed: false,
     };
@@ -331,7 +385,7 @@ export default function SelfCareChecklist() {
         <button
           type="button"
           onClick={addTask}
-          disabled={!newTaskLabel.trim()}
+          disabled={!newTaskLabel.trim() || tasks.length >= MAX_TASKS}
           aria-label={t('checklistAdd')}
           className="btn-pill px-3 sm:px-4 py-2.5 text-sm disabled:opacity-40 disabled:cursor-not-allowed shrink-0 flex items-center gap-1.5"
         >

--- a/components/settings/NotificationPreferences.jsx
+++ b/components/settings/NotificationPreferences.jsx
@@ -9,6 +9,7 @@ import {
   getNotificationPermissionStatus,
 } from '@/lib/utils/notifications'
 import { getTodayISO } from '@/lib/date-utils'
+import { clampNumber, readDailyRecord } from '@/lib/daily-storage'
 
 // ─── Constants ───────────────────────────────────────────────────────────────
 
@@ -71,15 +72,21 @@ function calcEstimatedReminders(startTime, endTime, repeatMinutes) {
 
 /** Read today's water count from localStorage */
 function getTodayWaterCount() {
-  try {
-    const saved = JSON.parse(localStorage.getItem(WATER_KEY))
-    // The user's calendar day, not the UTC one — reading the UTC day here reset
-    // the water counter at 05:30 in the morning for the app's primary market
-    // and mid-afternoon for users in the Pacific.
-    const today = getTodayISO()
-    if (saved && saved.date === today) return saved.count
-  } catch (_) {}
-  return 0
+  // The user's calendar day, not the UTC one — reading the UTC day here reset
+  // the water counter at 05:30 in the morning for the app's primary market
+  // and mid-afternoon for users in the Pacific.
+  //
+  // `readDailyRecord` also coerces the stored count, which the hand-rolled
+  // version returned verbatim: a corrupted `count` propagated straight into
+  // `remaining` and the nudge arithmetic below.
+  const { value } = readDailyRecord(WATER_KEY, {
+    sanitize: (stored) => clampNumber(stored.count, { min: 0, max: 99, fallback: 0, integer: true }),
+    fallback: () => 0,
+    onNewDay: () => 0,
+    today: getTodayISO(),
+  })
+
+  return value
 }
 
 // ─── DarkSelect — custom dropdown (native <select> ignores option colors on ──

--- a/lib/daily-storage.js
+++ b/lib/daily-storage.js
@@ -1,0 +1,233 @@
+/**
+ * daily-storage.js — reads and writes `localStorage` records that belong to a
+ * calendar day.
+ *
+ * ## Why this module exists
+ *
+ * `HydrationTracker` and `SelfCareChecklist` both store a `{ date, ... }`
+ * record and both got two things wrong, in the same way, for the same reason:
+ * the day was resolved once, inside a mount effect, and never again.
+ *
+ *     useEffect(() => {
+ *       setSettings(loadSettings())
+ *       setCount(loadCount())      // reads getTodayISO() exactly once
+ *       setMounted(true)
+ *     }, [])
+ *
+ * **1. The daily rollover never fired while the page was open.** The self-care
+ * page is a dashboard people leave open. Past midnight the hydration ring still
+ * showed yesterday's glasses and the checklist still showed yesterday's ticks,
+ * so the new day began already "complete". Worse, the next interaction called
+ * the save path, which stamps *today's* date onto yesterday's numbers and makes
+ * the stale state permanent. `NotificationPreferences` reads
+ * `hercycle_water_intake` to decide whether to nudge, so it saw a full glass
+ * count for a day in which the user had drunk nothing.
+ *
+ * **2. Restored state was trusted unconditionally.**
+ *
+ *     if (raw) return { ...DEFAULT_SETTINGS, ...JSON.parse(raw) }
+ *
+ * The hydration settings *modal* validates carefully — `clamp(Number(...) ||
+ * default, 500, 5000)` — and then the reload path spreads the stored object
+ * straight over the defaults and throws that work away. A stored
+ * `cupCapacity: 0` reaches `Math.round(dailyGoal / cupCapacity)`; a stored
+ * `dailyGoal: 0` makes `percentage` `NaN`, `strokeDashoffset` `NaN`, and the
+ * progress ring disappears. `loadTasks` had the mirror problem: any array was
+ * accepted, so an entry with no `id` produced duplicate React keys and a task
+ * that could never be deleted.
+ *
+ * The fix for both is the same, so it lives in one place: validate on **read**,
+ * not only on save, and make the day a value that is resolved per read rather
+ * than captured once.
+ *
+ * `storage` and `today` are injectable so every branch here is testable in
+ * plain Node — see `scripts/test-daily-storage.js`.
+ */
+
+import { getTodayISO, isISODateString } from './date-utils.js'
+
+/** How a record was resolved, so a caller can react to a rollover if it wants. */
+export const RECORD_STATUS = Object.freeze({
+  /** The stored record is for today and passed validation. */
+  CURRENT: 'current',
+  /** A record existed for a different day and was rolled over. */
+  ROLLED_OVER: 'rolled-over',
+  /** Nothing was stored. */
+  MISSING: 'missing',
+  /** Something was stored but could not be used. */
+  CORRUPT: 'corrupt',
+})
+
+/** Milliseconds in a day, used to schedule the rollover. */
+const MS_PER_DAY = 24 * 60 * 60 * 1000
+
+/**
+ * `localStorage`, or `null` where there isn't one (SSR, a locked-down browser,
+ * a Node test). Every function here tolerates `null`, so a caller never has to
+ * branch on it.
+ *
+ * @returns {Storage|null}
+ */
+export function defaultStorage() {
+  try {
+    if (typeof window === 'undefined' || !window.localStorage) return null
+    return window.localStorage
+  } catch {
+    // Accessing localStorage throws outright when site data is blocked.
+    return null
+  }
+}
+
+/**
+ * Milliseconds from `now` until the next **local** midnight.
+ *
+ * Deliberately not `24h - elapsed`: on a DST boundary a local day is 23 or 25
+ * hours long, and a fixed-length timer would fire an hour early or late for
+ * the rest of the day. Constructing tomorrow's local midnight and subtracting
+ * gets both right.
+ *
+ * A minimum of one second is returned so a timer scheduled exactly at midnight
+ * cannot spin.
+ *
+ * @param {Date} [now]
+ * @returns {number}
+ */
+export function msUntilNextLocalMidnight(now = new Date()) {
+  const nextMidnight = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1, 0, 0, 0, 0)
+  const delta = nextMidnight.getTime() - now.getTime()
+
+  if (!Number.isFinite(delta) || delta <= 0) return 1000
+
+  return Math.min(delta, MS_PER_DAY)
+}
+
+/**
+ * Parses stored JSON without throwing.
+ *
+ * @param {string|null} raw
+ * @returns {unknown|undefined} `undefined` when the value is absent or unusable
+ */
+export function safeParseJson(raw) {
+  if (typeof raw !== 'string' || raw.trim() === '') return undefined
+
+  try {
+    return JSON.parse(raw)
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Coerces `value` to a finite number inside `[min, max]`, falling back when it
+ * is not usable.
+ *
+ * Written to reject rather than coerce the dangerous cases: `null`, `''`, `[]`
+ * and `true` all become numbers under `Number()`, and `0` for a divisor is
+ * exactly the value that produced `Infinity` and `NaN` in the hydration ring.
+ *
+ * @param {unknown} value
+ * @param {{ min: number, max: number, fallback: number, integer?: boolean }} bounds
+ * @returns {number}
+ */
+export function clampNumber(value, { min, max, fallback, integer = false }) {
+  const numeric =
+    typeof value === 'number' ? value : typeof value === 'string' && value.trim() !== '' ? Number(value) : NaN
+
+  if (!Number.isFinite(numeric)) return fallback
+
+  const bounded = Math.min(max, Math.max(min, numeric))
+  return integer ? Math.round(bounded) : bounded
+}
+
+/**
+ * Reads a day-scoped record.
+ *
+ * @param {string} key storage key
+ * @param {object} options
+ * @param {(value: unknown) => unknown} options.sanitize turns a stored payload into a usable value; return `undefined` to reject it
+ * @param {() => unknown} options.fallback value to use when there is nothing usable
+ * @param {(value: unknown) => unknown} [options.onNewDay] transform applied when the stored record belongs to another day; defaults to `fallback`
+ * @param {string} [options.today] the caller's local day; resolved per call, never captured
+ * @param {Storage|null} [options.storage]
+ * @returns {{ value: unknown, status: string, storedDate: string|null }}
+ */
+export function readDailyRecord(key, options = {}) {
+  const {
+    sanitize = (value) => value,
+    fallback = () => null,
+    onNewDay,
+    today = getTodayISO(),
+    storage = defaultStorage(),
+  } = options
+
+  const rollForward = typeof onNewDay === 'function' ? onNewDay : () => fallback()
+
+  let raw = null
+  try {
+    raw = storage ? storage.getItem(key) : null
+  } catch {
+    return { value: fallback(), status: RECORD_STATUS.MISSING, storedDate: null }
+  }
+
+  if (raw === null || raw === undefined) {
+    return { value: fallback(), status: RECORD_STATUS.MISSING, storedDate: null }
+  }
+
+  const parsed = safeParseJson(raw)
+  if (parsed === undefined || parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return { value: fallback(), status: RECORD_STATUS.CORRUPT, storedDate: null }
+  }
+
+  const storedDate = isISODateString(parsed.date) ? parsed.date : null
+
+  const sanitized = sanitize(parsed)
+  if (sanitized === undefined) {
+    return { value: fallback(), status: RECORD_STATUS.CORRUPT, storedDate }
+  }
+
+  // A record with no usable date cannot be shown to belong to today, and
+  // showing yesterday's progress as today's is the failure this module exists
+  // to prevent. Treat it as a rollover.
+  if (storedDate === null || storedDate !== today) {
+    return {
+      value: rollForward(sanitized),
+      status: RECORD_STATUS.ROLLED_OVER,
+      storedDate,
+    }
+  }
+
+  return { value: sanitized, status: RECORD_STATUS.CURRENT, storedDate }
+}
+
+/**
+ * Writes a day-scoped record, stamping it with the day resolved *now* rather
+ * than one captured at mount.
+ *
+ * @param {string} key
+ * @param {object} payload merged into the stored record
+ * @param {{ today?: string, storage?: Storage|null }} [options]
+ * @returns {boolean} whether the write landed
+ */
+export function writeDailyRecord(key, payload, { today = getTodayISO(), storage = defaultStorage() } = {}) {
+  if (!storage) return false
+
+  try {
+    storage.setItem(key, JSON.stringify({ ...payload, date: today }))
+    return true
+  } catch {
+    // Quota exceeded, or storage disabled mid-session. A tracker losing its
+    // local state is not worth throwing out of a click handler.
+    return false
+  }
+}
+
+/**
+ * True when a stored record belongs to a day other than `today`.
+ *
+ * @param {{ storedDate: string|null }} record from {@link readDailyRecord}
+ * @param {string} today
+ * @returns {boolean}
+ */
+export function isStale(record, today) {
+  return !record || record.storedDate === null || record.storedDate !== today
+}

--- a/lib/useDailyReset.js
+++ b/lib/useDailyReset.js
@@ -1,0 +1,106 @@
+'use client'
+
+/**
+ * useDailyReset — tells a component when the user's calendar day has changed.
+ *
+ * Everything about *what* a day-scoped record looks like lives in
+ * `./daily-storage.js`, which is pure and separately tested. This hook only
+ * decides *when* to ask.
+ *
+ * ## Why a timer alone is not enough
+ *
+ * The self-care trackers resolved "today" once, in a mount effect, and never
+ * again — so a tab left open across midnight kept showing yesterday's progress
+ * and then wrote it under today's date. A midnight timer fixes the obvious
+ * case, but not the three that actually happen more often:
+ *
+ *  - **A backgrounded tab.** Browsers throttle timers in hidden tabs to once a
+ *    minute or worse, and a suspended tab may not fire them at all. Coming back
+ *    to the tab has to re-check, which is what `visibilitychange` is for.
+ *  - **A laptop that was asleep.** The machine wakes hours later with the timer
+ *    long overdue; `focus` catches this even where the timer did not fire.
+ *  - **Another tab.** Two self-care tabs are perfectly ordinary. When one rolls
+ *    over and writes, the other has to notice, which is what `storage` is for.
+ *
+ * The day is re-read from the clock on every one of those signals and compared
+ * with the last one seen, so a spurious wake-up costs a string comparison and
+ * nothing else.
+ */
+
+import { useEffect, useRef } from 'react'
+import { getTodayISO } from './date-utils.js'
+import { msUntilNextLocalMidnight } from './daily-storage.js'
+
+/**
+ * Calls `onRollover(newDay)` whenever the local calendar day changes while the
+ * component is mounted.
+ *
+ * @param {(day: string) => void} onRollover
+ * @param {{ watchKeys?: string[] }} [options] storage keys that should also
+ *   trigger a re-check when another tab writes them
+ */
+export default function useDailyReset(onRollover, { watchKeys = [] } = {}) {
+  // Held in refs so changing the callback or the key list does not tear down
+  // and re-arm the midnight timer.
+  const callbackRef = useRef(onRollover)
+  const keysRef = useRef(watchKeys)
+  const lastDayRef = useRef(null)
+
+  callbackRef.current = onRollover
+  keysRef.current = watchKeys
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined
+
+    let timeoutId = null
+    let cancelled = false
+
+    if (lastDayRef.current === null) {
+      lastDayRef.current = getTodayISO()
+    }
+
+    const checkDay = () => {
+      if (cancelled) return
+
+      const today = getTodayISO()
+      if (today === lastDayRef.current) return
+
+      lastDayRef.current = today
+      callbackRef.current?.(today)
+    }
+
+    const scheduleMidnight = () => {
+      if (cancelled) return
+
+      timeoutId = window.setTimeout(() => {
+        checkDay()
+        // Re-arm from the new "now" rather than adding a fixed 24 hours, so a
+        // DST change does not drift the boundary for every following day.
+        scheduleMidnight()
+      }, msUntilNextLocalMidnight())
+    }
+
+    const handleVisibility = () => {
+      if (document.visibilityState === 'visible') checkDay()
+    }
+
+    const handleStorage = (event) => {
+      // A null key means the whole store was cleared, which is worth a re-check
+      // whatever the component is watching.
+      if (event.key === null || keysRef.current.includes(event.key)) checkDay()
+    }
+
+    scheduleMidnight()
+    document.addEventListener('visibilitychange', handleVisibility)
+    window.addEventListener('focus', checkDay)
+    window.addEventListener('storage', handleStorage)
+
+    return () => {
+      cancelled = true
+      if (timeoutId !== null) window.clearTimeout(timeoutId)
+      document.removeEventListener('visibilitychange', handleVisibility)
+      window.removeEventListener('focus', checkDay)
+      window.removeEventListener('storage', handleStorage)
+    }
+  }, [])
+}

--- a/scripts/test-daily-storage.js
+++ b/scripts/test-daily-storage.js
@@ -1,0 +1,299 @@
+/**
+ * Regression suite for lib/daily-storage.js.
+ *
+ * The bug this is part of fixing: `HydrationTracker` and `SelfCareChecklist`
+ * both store a `{ date, ... }` record, and both resolved "today" exactly once,
+ * inside a mount effect.
+ *
+ *     useEffect(() => {
+ *       setSettings(loadSettings())
+ *       setCount(loadCount())
+ *       setMounted(true)
+ *     }, [])
+ *
+ * The self-care page is a dashboard people leave open. Past midnight the ring
+ * still showed yesterday's glasses and the checklist still showed yesterday's
+ * ticks, so the new day began already "complete" -- and the next interaction
+ * called the save path, which stamps *today's* date onto yesterday's numbers
+ * and makes the stale state permanent. `NotificationPreferences` reads
+ * `hercycle_water_intake` directly to decide whether to nudge, so it saw a full
+ * glass count for a day in which the user had drunk nothing.
+ *
+ * The second half is validation on read. The hydration settings modal clamps
+ * carefully on save, and the reload path threw that away:
+ *
+ *     if (raw) return { ...DEFAULT_SETTINGS, ...JSON.parse(raw) }
+ *
+ * A stored `cupCapacity: 0` reached `Math.round(dailyGoal / cupCapacity)`; a
+ * stored `dailyGoal: 0` made the ring's `strokeDashoffset` NaN, which renders
+ * as no ring at all.
+ *
+ *   node scripts/test-daily-storage.js
+ */
+
+import {
+  RECORD_STATUS,
+  clampNumber,
+  isStale,
+  msUntilNextLocalMidnight,
+  readDailyRecord,
+  safeParseJson,
+  writeDailyRecord,
+} from '../lib/daily-storage.js'
+
+let passed = 0
+let failed = 0
+
+function check(actual, expected, label) {
+  if (Object.is(actual, expected)) {
+    passed += 1
+    return
+  }
+  failed += 1
+  console.error(`  ${label}`)
+  console.error(`       expected: ${JSON.stringify(expected)}`)
+  console.error(`       actual:   ${JSON.stringify(actual)}`)
+}
+
+function checkDeep(actual, expected, label) {
+  const a = JSON.stringify(actual)
+  const b = JSON.stringify(expected)
+  if (a === b) {
+    passed += 1
+    return
+  }
+  failed += 1
+  console.error(`  ${label}`)
+  console.error(`       expected: ${b}`)
+  console.error(`       actual:   ${a}`)
+}
+
+function checkTruthy(value, label) {
+  check(Boolean(value), true, label)
+}
+
+/** An in-memory stand-in for `localStorage`, with an optional failure mode. */
+function fakeStorage(initial = {}, { throwOn = null } = {}) {
+  const data = { ...initial }
+  return {
+    getItem(key) {
+      if (throwOn === 'get') throw new Error('storage blocked')
+      return Object.prototype.hasOwnProperty.call(data, key) ? data[key] : null
+    },
+    setItem(key, value) {
+      if (throwOn === 'set') throw new Error('quota exceeded')
+      data[key] = String(value)
+    },
+    raw: data,
+  }
+}
+
+const TODAY = '2026-08-27'
+const YESTERDAY = '2026-08-26'
+const KEY = 'hercycle_water_intake'
+
+const countOptions = (storage, today = TODAY) => ({
+  storage,
+  today,
+  sanitize: (stored) => clampNumber(stored.count, { min: 0, max: 16, fallback: 0, integer: true }),
+  fallback: () => 0,
+  onNewDay: () => 0,
+})
+
+// ---------------------------------------------------------------------------
+// The rollover
+// ---------------------------------------------------------------------------
+
+console.log('\nyesterday\'s progress never shows as today\'s')
+
+const sameDay = readDailyRecord(KEY, countOptions(fakeStorage({ [KEY]: JSON.stringify({ date: TODAY, count: 5 }) })))
+check(sameDay.value, 5, 'a record from today is restored as-is')
+check(sameDay.status, RECORD_STATUS.CURRENT, 'and reported as current')
+
+const priorDay = readDailyRecord(
+  KEY,
+  countOptions(fakeStorage({ [KEY]: JSON.stringify({ date: YESTERDAY, count: 8 }) }))
+)
+check(priorDay.value, 0, "yesterday's glasses do not carry into today")
+check(priorDay.status, RECORD_STATUS.ROLLED_OVER, 'and the rollover is reported, not silent')
+check(priorDay.storedDate, YESTERDAY, 'the day it came from is still available to the caller')
+
+const undatedRecord = readDailyRecord(KEY, countOptions(fakeStorage({ [KEY]: JSON.stringify({ count: 8 }) })))
+check(undatedRecord.value, 0, 'a record with no date cannot claim to be today')
+check(undatedRecord.status, RECORD_STATUS.ROLLED_OVER, 'and is treated as a rollover')
+
+const nonsenseDate = readDailyRecord(
+  KEY,
+  countOptions(fakeStorage({ [KEY]: JSON.stringify({ date: 'yesterday', count: 8 }) }))
+)
+check(nonsenseDate.value, 0, 'so is a record whose date is not a calendar day')
+
+const impossibleDate = readDailyRecord(
+  KEY,
+  countOptions(fakeStorage({ [KEY]: JSON.stringify({ date: '2026-02-31', count: 8 }) }))
+)
+check(impossibleDate.value, 0, 'and one whose date does not exist')
+
+// A checklist rolls forward differently: it keeps the tasks and clears the ticks.
+const tasksKey = 'hercycle_selfcare_checklist'
+const storedTasks = [
+  { id: 'default-drink-water', isDefault: true, labelKey: 'k1', completed: true },
+  { id: 'custom-1', label: 'Journal', isDefault: false, completed: true },
+]
+
+const rolledTasks = readDailyRecord(tasksKey, {
+  storage: fakeStorage({ [tasksKey]: JSON.stringify({ date: YESTERDAY, tasks: storedTasks }) }),
+  today: TODAY,
+  sanitize: (stored) => stored.tasks,
+  fallback: () => [],
+  onNewDay: (tasks) => tasks.map((t) => ({ ...t, completed: false })),
+})
+
+check(rolledTasks.value.length, 2, 'a new day keeps the tasks')
+check(rolledTasks.value.every((t) => t.completed === false), true, 'but clears every tick')
+check(
+  rolledTasks.value.find((t) => t.id === 'custom-1').label,
+  'Journal',
+  'including a custom task the user added'
+)
+
+// ---------------------------------------------------------------------------
+// Corrupt and missing state
+// ---------------------------------------------------------------------------
+
+console.log('\ncorrupt state degrades to a usable default')
+
+check(readDailyRecord(KEY, countOptions(fakeStorage())).status, RECORD_STATUS.MISSING,
+  'nothing stored is reported as missing')
+check(readDailyRecord(KEY, countOptions(fakeStorage())).value, 0, 'and falls back')
+
+check(readDailyRecord(KEY, countOptions(fakeStorage({ [KEY]: 'not json' }))).status, RECORD_STATUS.CORRUPT,
+  'unparseable JSON is reported as corrupt')
+check(readDailyRecord(KEY, countOptions(fakeStorage({ [KEY]: '[]' }))).status, RECORD_STATUS.CORRUPT,
+  'an array where an object belongs is corrupt')
+check(readDailyRecord(KEY, countOptions(fakeStorage({ [KEY]: 'null' }))).status, RECORD_STATUS.CORRUPT,
+  'a stored null is corrupt')
+check(readDailyRecord(KEY, countOptions(fakeStorage({ [KEY]: '"five"' }))).status, RECORD_STATUS.CORRUPT,
+  'a stored scalar is corrupt')
+
+check(
+  readDailyRecord(KEY, {
+    ...countOptions(fakeStorage({ [KEY]: JSON.stringify({ date: TODAY, count: 3 }) })),
+    sanitize: () => undefined,
+  }).status,
+  RECORD_STATUS.CORRUPT,
+  'a sanitiser returning undefined rejects the record'
+)
+
+check(
+  readDailyRecord(KEY, countOptions(fakeStorage({}, { throwOn: 'get' }))).value,
+  0,
+  'storage that throws on read -- a browser blocking site data -- still yields a usable value'
+)
+check(readDailyRecord(KEY, countOptions(null)).value, 0, 'so does having no storage at all')
+
+check(safeParseJson('not json'), undefined, 'safeParseJson does not throw on garbage')
+check(safeParseJson(''), undefined, 'nor on an empty string')
+check(safeParseJson(null), undefined, 'nor on null')
+checkDeep(safeParseJson('{"a":1}'), { a: 1 }, 'and still parses valid JSON')
+
+// ---------------------------------------------------------------------------
+// Value clamping
+// ---------------------------------------------------------------------------
+
+console.log('\nstored values are clamped on read, not only on save')
+
+const goal = { min: 500, max: 5000, fallback: 2000, integer: true }
+const capacity = { min: 50, max: 1000, fallback: 250, integer: true }
+
+check(clampNumber(2500, goal), 2500, 'a value inside the range is kept')
+check(clampNumber('2500', goal), 2500, 'a numeric string is coerced')
+check(clampNumber(99999, goal), 5000, 'a value above the range is clamped')
+check(clampNumber(10, goal), 500, 'a value below the range is clamped')
+
+check(clampNumber(0, capacity), 50, 'a zero capacity is clamped -- this is the division by zero')
+checkTruthy(Number.isFinite(2000 / clampNumber(0, capacity)), 'so the glass count stays finite')
+check(clampNumber(0, goal), 500, 'a zero goal is clamped')
+checkTruthy(Number.isFinite(500 / clampNumber(0, goal)), 'so the percentage stays finite')
+
+check(clampNumber(null, goal), 2000, 'null falls back rather than coercing to 0')
+check(clampNumber('', goal), 2000, 'an empty string falls back')
+check(clampNumber([], goal), 2000, 'an empty array falls back')
+check(clampNumber(true, goal), 2000, 'a boolean falls back')
+check(clampNumber(undefined, goal), 2000, 'undefined falls back')
+check(clampNumber(Number.NaN, goal), 2000, 'NaN falls back')
+check(clampNumber(Number.POSITIVE_INFINITY, goal), 2000, 'Infinity falls back')
+check(clampNumber(250.6, capacity), 251, 'an integer field is rounded')
+check(clampNumber(250.6, { ...capacity, integer: false }), 250.6, 'a non-integer field is not')
+
+// ---------------------------------------------------------------------------
+// Writes
+// ---------------------------------------------------------------------------
+
+console.log('\nwrites stamp the day resolved now, not one captured at mount')
+
+const writeStore = fakeStorage()
+check(writeDailyRecord(KEY, { count: 4 }, { today: TODAY, storage: writeStore }), true, 'a write reports success')
+checkDeep(JSON.parse(writeStore.raw[KEY]), { count: 4, date: TODAY }, 'and stamps the current day')
+
+check(
+  writeDailyRecord(KEY, { count: 4, date: YESTERDAY }, { today: TODAY, storage: writeStore }),
+  true,
+  'a payload carrying its own date is accepted'
+)
+check(JSON.parse(writeStore.raw[KEY]).date, TODAY, 'but the resolved day wins over it')
+
+check(
+  writeDailyRecord(KEY, { count: 4 }, { today: TODAY, storage: fakeStorage({}, { throwOn: 'set' }) }),
+  false,
+  'a quota failure is reported rather than thrown out of a click handler'
+)
+check(writeDailyRecord(KEY, { count: 4 }, { today: TODAY, storage: null }), false,
+  'and so is having no storage')
+
+const roundTrip = fakeStorage()
+writeDailyRecord(KEY, { count: 6 }, { today: TODAY, storage: roundTrip })
+check(readDailyRecord(KEY, countOptions(roundTrip)).value, 6, 'a write round-trips through a read')
+check(readDailyRecord(KEY, countOptions(roundTrip, '2026-08-28')).value, 0,
+  'and the same record read on the next day rolls over')
+
+check(isStale({ storedDate: YESTERDAY }, TODAY), true, 'a record from another day is stale')
+check(isStale({ storedDate: TODAY }, TODAY), false, "today's record is not")
+check(isStale({ storedDate: null }, TODAY), true, 'an undated record is stale')
+check(isStale(null, TODAY), true, 'so is a missing one')
+
+// ---------------------------------------------------------------------------
+// Midnight scheduling
+// ---------------------------------------------------------------------------
+
+console.log('\nthe midnight timer targets local midnight')
+
+const noon = new Date(2026, 7, 27, 12, 0, 0)
+check(msUntilNextLocalMidnight(noon), 12 * 60 * 60 * 1000, 'noon is twelve hours from midnight')
+
+const lateNight = new Date(2026, 7, 27, 23, 59, 30)
+check(msUntilNextLocalMidnight(lateNight), 30 * 1000, 'half a minute before midnight is thirty seconds')
+
+const justAfter = new Date(2026, 7, 27, 0, 0, 1)
+check(
+  msUntilNextLocalMidnight(justAfter),
+  24 * 60 * 60 * 1000 - 1000,
+  'just after midnight is almost a full day away'
+)
+
+checkTruthy(msUntilNextLocalMidnight(new Date(2026, 7, 27, 0, 0, 0)) > 0,
+  'exactly midnight still schedules a positive delay rather than spinning')
+checkTruthy(msUntilNextLocalMidnight(new Date()) <= 24 * 60 * 60 * 1000,
+  'the delay never exceeds a day, whatever the clock says')
+checkTruthy(msUntilNextLocalMidnight(new Date()) > 0, 'and is always positive')
+
+// The delay is computed against a constructed local midnight rather than as
+// "24h minus elapsed", so a 23- or 25-hour DST day does not drift the boundary.
+const dstDay = new Date(2026, 2, 29, 12, 0, 0)
+const expected = new Date(2026, 2, 30, 0, 0, 0, 0).getTime() - dstDay.getTime()
+check(msUntilNextLocalMidnight(dstDay), expected, 'a DST transition day targets the real local midnight')
+
+// ---------------------------------------------------------------------------
+
+console.log(`\n${failed === 0 ? 'PASS' : 'FAIL'} ${passed} passed, ${failed} failed`)
+process.exit(failed === 0 ? 0 : 1)


### PR DESCRIPTION
## Linked Issue
Fixes #738

## Description

`HydrationTracker` and `SelfCareChecklist` both store a `{ date, ... }` record, and both resolved "today" exactly once — inside a mount effect:

```js
useEffect(() => {
  setSettings(loadSettings())
  setCount(loadCount())   // reads getTodayISO() exactly once
  setMounted(true)
}, [])
```

### 1. The daily rollover never fired while the page was open

The self-care page is a dashboard people leave open. Past midnight:

- the hydration ring still showed yesterday's glasses, so the new day began already "complete";
- the checklist still showed yesterday's ticks;
- **the next interaction made it permanent** — `saveCount()` / `saveTasks()` stamp *today's* date onto yesterday's numbers;
- `NotificationPreferences` reads `hercycle_water_intake` directly to decide whether to nudge, so it saw a full glass count for a day in which the user had drunk nothing.

Nothing recovered from this: not a tab switch, not returning from a background tab, not another tab writing the same key.

### 2. Restored `localStorage` was trusted unconditionally

```js
function loadSettings() {
  const raw = localStorage.getItem(SETTINGS_KEY);
  if (raw) return { ...DEFAULT_SETTINGS, ...JSON.parse(raw) };   // no validation
}
```

The settings **modal** validates carefully (`clamp(Number(draft.dailyGoal) || …, 500, 5000)`) — and the reload path spreads the stored object straight over the defaults and throws that work away. A stored `cupCapacity: 0` reaches `Math.round(dailyGoal / cupCapacity)`; a stored `dailyGoal: 0` makes `percentage` `NaN` and `strokeDashoffset` `NaN`, which React emits as an invalid SVG attribute — the progress ring simply disappears.

`loadTasks()` had the mirror problem: `saved.tasks` was accepted as long as it was an array, so an entry with no `id` produced duplicate React keys **and a row that could never be deleted** — `deleteTask` filters on `id`, and `undefined === undefined` matches every such row at once.

### The fix

**`lib/daily-storage.js` (new)** owns both halves, because they are the same mistake made twice: validate on **read**, not only on save, and make the day a value resolved per read rather than captured once. `storage` and `today` are injectable, so every branch is testable in plain Node.

**`lib/useDailyReset.js` (new)** supplies the timing, and deliberately does **not** rely on a midnight timer alone — a timer fixes the obvious case but not the three that happen more often:

- **A backgrounded tab.** Browsers throttle timers in hidden tabs to once a minute or worse, and a suspended tab may not fire them at all → `visibilitychange`.
- **A laptop that was asleep.** It wakes hours later with the timer long overdue → `focus`.
- **A second tab.** Two self-care tabs are ordinary; when one rolls over and writes, the other must notice → `storage`.

The day is re-read from the clock on each signal and compared with the last one seen, so a spurious wake-up costs a string comparison. The delay is computed against a *constructed* local midnight rather than "24h minus elapsed", so a 23- or 25-hour DST day does not drift the boundary for every following day.

**Also fixed along the way:** the custom task list is capped, and a new task's id is no longer `custom-${Date.now()}`, which collides for two tasks added inside the same millisecond — producing exactly the duplicate-key/undeletable-row failure described above. `NotificationPreferences` now reads the water count through the same helper, so a corrupted `count` no longer propagates into the nudge arithmetic.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (clean code updates, no behavior modifications)
- [ ] Documentation update
- [ ] Performance optimization
- [ ] Security patch

## Files Modified

| File | Change |
|------|--------|
| `lib/daily-storage.js` | **New.** Day-scoped read/write, rollover, read-time validation, clamping, DST-safe midnight delay |
| `lib/useDailyReset.js` | **New.** Midnight timer + `visibilitychange` / `focus` / `storage` re-checks |
| `components/self-care/HydrationTracker.jsx` | Validated settings + count on read; rolls over while open |
| `components/self-care/SelfCareChecklist.jsx` | Validated task list, id de-duplication, task cap, collision-free ids; rolls over while open |
| `components/settings/NotificationPreferences.jsx` | Reads the water count through the same helper |
| `scripts/test-daily-storage.js` | **New.** 61 assertions |

## Testing

```bash
node scripts/test-daily-storage.js
# PASS 61 passed, 0 failed
```

Covers the rollover boundary (including a record with no date, an unparseable date and `2026-02-31`, all of which must count as stale rather than as today), corrupt-payload recovery (unparseable JSON, an array where an object belongs, a storage object that throws on read — which is what a browser blocking site data does), the clamping that stops the division by zero, quota-exceeded writes, and the DST-safe midnight delay.

Manual:

1. Open **Self-care**, log a few glasses and tick some checklist items.
2. Set the OS clock forward past midnight (or leave the tab open overnight) and return to the tab — the ring reads 0 and the ticks are cleared, without a reload.
3. Open the page in two tabs, roll over in one — the other follows.
4. `localStorage.setItem('hercycle_hydration_settings', '{"dailyGoal":0,"cupCapacity":0}')` and reload — the ring renders normally at the default goal (previously blank).

## Screenshots (if UI changes are made)
No intentional visual change — the trackers render exactly as before, on the correct day's data. The one visible difference is the **Add** button disabling once the task cap is reached.

## Checklist
- [x] This PR is submitted under ECSOC.
- [x] Added the required **ECSoc26** label to this Pull Request.
- [x] Linked issue using `Fixes #738`.
- [x] Tested locally.
- [x] No breaking changes introduced.
- [x] Documentation updated if required.
