### PR TITLE
[ECSoC26] API: Repair GET /api/cycles and stop it wiping the offline mirror

### DIFF
--- a/app/api/cycles/route.js
+++ b/app/api/cycles/route.js
@@ -6,7 +6,13 @@ import { z } from 'zod'
 import { eventBus } from '@/lib/events'
 import { pcodRiskCache } from '@/lib/cache'
 import { endsOnOrAfterStart, isoCalendarDate, optionalIsoCalendarDate } from '@/lib/date-schemas'
-import { jsonSuccess, jsonError, getPaginationParams, formatPaginatedResponse } from '@/lib/api-helpers'
+import { jsonSuccess, jsonError } from '@/lib/api-helpers'
+import {
+  buildCycleCursorFilter,
+  buildCyclePage,
+  emptyCyclePage,
+  parseCycleQuery,
+} from '@/lib/cycle-page'
 
 /**
  * Physiologically valid cycle length: 15–90 days covers all clinical edge cases
@@ -81,11 +87,15 @@ export async function GET(request) {
     await ensureUserExists(userId)
 
     const url = new URL(request.url)
-    const { limit, cursor } = getPaginationParams(url.searchParams, 12, 100)
+    // Both halves of the cursor are validated before they can reach a filter
+    // string -- an unusable cursor decodes to `null`, which serves the first
+    // page. See lib/cycle-page.js.
+    const { limit, cursor } = parseCycleQuery(url.searchParams)
 
     const supabaseAdmin = getSupabaseAdmin()
 
-    // Query total count for metadata tracking
+    // Total count is metadata, not the page. A failure here must not fail the
+    // read, so it is logged and the count is reported as unknown.
     const { count: totalCount, error: countError } = await supabaseAdmin
       .from('cycles')
       .select('*', { count: 'exact', head: true })
@@ -100,35 +110,35 @@ export async function GET(request) {
       .select('*')
       .eq('user_id', userId)
       .order('start_date', { ascending: false })
+      // `start_date` is not unique -- a duplicate write or a correction can
+      // share one -- so the id tie-break is what makes paging stable.
       .order('id', { ascending: false })
-      .limit(limit)
+      // One row more than asked for: its presence answers `hasMore` without a
+      // second scan of the same range.
+      .limit(limit + 1)
 
     if (cursor) {
-      // Decode cursor assuming format: `${start_date}_${id}` or similar composite cursor
-      const [cursorDate, cursorId] = cursor.split('_')
-      if (cursorDate && cursorId) {
-        query = query.or(`start_date.lt.${cursorDate},and(start_date.eq.${cursorDate},id.lt.${cursorId})`)
-      }
+      query = query.or(buildCycleCursorFilter(cursor))
     }
 
     const { data: cycles, error } = await query
 
     if (error && error.code !== 'PGRST116') {
       logger.error(`Error querying cycles for user ${userId}:`, error.message);
-      return jsonSuccess({ cycles: [], nextPeriodDate: null, confidence: null, averageCycleLength: 28 })
+      // Same envelope as the success path. The client reads
+      // `data.data.cycles` on every branch, and the two branches of this
+      // handler previously disagreed about whether that key existed.
+      return jsonSuccess(emptyCyclePage())
     }
 
     const rows = cycles || []
-    logger.info(`Successfully fetched ${rows.length} cycles for user ${userId}`);
+    const page = buildCyclePage(rows, limit, typeof totalCount === 'number' ? totalCount : null)
+    logger.info(`Successfully fetched ${page.cycles.length} cycles for user ${userId}`);
 
-    const paginatedResult = formatPaginatedResponse(
-      rows,
-      limit,
-      totalCount || rows.length,
-      (item) => `${item.start_date}_${item.id}`
-    )
-
-    return NextResponse.json(paginatedResult, { status: 200 })
+    // Through `jsonSuccess`, not a bare `NextResponse`: reaching past the
+    // shared helper is how this handler came to reference an identifier the
+    // file never imported, and how its shape drifted from the client's.
+    return jsonSuccess(page)
   } catch (error) {
     logger.error('Error fetching cycles:', error.message || error);
     return jsonError(`Failed to fetch cycles: ${error.message || error}`, 500)

--- a/lib/OfflineContext.jsx
+++ b/lib/OfflineContext.jsx
@@ -14,6 +14,7 @@ import {
   planNextAttempt,
 } from './sync-queue'
 import fetchWithTimeout, { TimeoutError } from './fetch-with-timeout'
+import { hasUsableCyclePayload } from './cycle-page'
 import {
   RISK_UNAVAILABLE_REASONS,
   normaliseRiskResult,
@@ -406,7 +407,14 @@ export function OfflineProvider({ children }) {
         try {
           const res = await fetchWithTimeout('/api/cycles');
           const data = await res.json();
-          if (data.success) {
+          // `hasUsableCyclePayload` and not a bare `data.success`, because
+          // `cacheRecords` calls `replaceAll`, which clears the store before it
+          // writes. A response whose shape does not carry `data.cycles` --
+          // exactly what a server-side envelope change produces -- turns into
+          // `[]` inside `decryptRecords` and would therefore *delete* the
+          // user's local cycle history. The mirror is only replaced when the
+          // server actually sent an array of cycles. See lib/cycle-page.js.
+          if (hasUsableCyclePayload(data)) {
             // Decrypt everything FIRST. Awaiting inside a readwrite transaction
             // auto-commits it, after which every remaining put throws
             // TransactionInactiveError — which used to leave the store cleared
@@ -427,6 +435,16 @@ export function OfflineProvider({ children }) {
               }
             };
           }
+
+          // A 200 whose body does not carry cycles is a server-side fault, not
+          // an empty account. It used to fall through in silence, leaving the
+          // user with a stale mirror -- or, on a fresh device, an empty
+          // dashboard indistinguishable from a new account. Log it, then use
+          // the mirror deliberately rather than by accident.
+          logNetworkFallback(
+            new Error('The cycles response did not contain a cycle list'),
+            'Fetch cycles'
+          );
         } catch (e) {
           logNetworkFallback(e, 'Fetch cycles');
         }

--- a/lib/cycle-page.js
+++ b/lib/cycle-page.js
@@ -1,0 +1,309 @@
+/**
+ * cycle-page.js — the read contract for `GET /api/cycles`.
+ *
+ * ## The bug this exists to prevent
+ *
+ * The cycles read handler ended with
+ *
+ *     return NextResponse.json(paginatedResult, { status: 200 })
+ *
+ * in a file that never imported `NextResponse`. Every read of the cycle list —
+ * the record the dashboard, the calendar, the prediction and the PCOD risk
+ * view all hang off — threw `ReferenceError: NextResponse is not defined`, was
+ * swallowed by the outer `catch`, and came back as a 500.
+ *
+ * The client did not surface that. `OfflineContext.fetchCycles` reads
+ * `data.success`, finds `false`, skips the refresh block without throwing, and
+ * falls through to the IndexedDB mirror — so a user with a warm cache saw stale
+ * cycles indefinitely and a user on a new device saw an empty account.
+ *
+ * And the one-line fix — importing `NextResponse` — would have made it worse.
+ * The handler had been migrated to `formatPaginatedResponse`, which produces
+ *
+ *     { success, data: [ ...rows ], pagination: { … } }
+ *
+ * while the client reads `data.data.cycles`. With the import in place
+ * `data.success` becomes `true`, `data.data.cycles` is `undefined`,
+ * `decryptRecords(undefined)` returns `[]` by design, and that `[]` reaches
+ * `cacheRecords('cycles', [])` → `replaceAll` → **the offline mirror is
+ * cleared**. A stale-cache bug would have become a cache-wipe on every load.
+ *
+ * The two branches of the same handler also disagreed about the shape: the
+ * database-error path returned `{ cycles, nextPeriodDate, confidence,
+ * averageCycleLength }` nested under `data`, the success path returned a bare
+ * array. Whichever was right, they could not both be.
+ *
+ * ## What lives here
+ *
+ * The parts of that read which are decisions about untrusted input and about
+ * response shape, rather than I/O: cursor encoding, cursor validation, and the
+ * envelope both branches must produce. The route applies them; this module
+ * decides them, and `scripts/test-cycle-page.js` exercises them without a
+ * database.
+ *
+ * ## Why the cursor is validated rather than interpolated
+ *
+ * The previous cursor was the raw string `${start_date}_${id}`, split on `_`
+ * and dropped straight into a PostgREST filter:
+ *
+ *     query.or(`start_date.lt.${cursorDate},and(start_date.eq.${cursorDate},id.lt.${cursorId})`)
+ *
+ * `,`, `(`, `)` and `.` are all filter syntax. A cursor containing any of them
+ * produced a malformed filter, PostgREST answered 400, and the route's
+ * `error && error.code !== 'PGRST116'` branch returned **200 with an empty
+ * list** — a hand-edited or stale cursor told the user she had no cycles.
+ *
+ * `lib/forum-query.js` already refuses to allow that shape on the forum side.
+ * This is the same discipline applied to the other paged endpoint: decode,
+ * validate both halves against what they are (a real calendar day, a UUID),
+ * and treat anything unusable as "start from the beginning" rather than as an
+ * empty result.
+ *
+ * No imports beyond `date-utils`, so this is usable from Route Handlers,
+ * Server Components and plain Node scripts alike.
+ */
+
+import { isISODateString } from './date-utils.js'
+
+/** Page size when the caller does not ask for one. */
+export const DEFAULT_CYCLE_PAGE_SIZE = 12
+
+/**
+ * Hard ceiling on page size.
+ *
+ * Cycles carry `encrypted_data`, so a row is not small. Without a ceiling,
+ * `?limit=100000` is a way to make the server serialise — and the client
+ * decrypt — an entire history on every request.
+ */
+export const MAX_CYCLE_PAGE_SIZE = 100
+
+/** Separator inside the decoded cursor. Neither half can contain it. */
+const CURSOR_SEPARATOR = '|'
+
+/**
+ * A canonical UUID. `cycles.id` is `uuid`, so anything else is either a typo or
+ * an attempt to reach the filter string, and Postgres would raise 22P02 for it
+ * either way.
+ */
+const UUID_RE = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/
+
+/**
+ * True when `value` is a usable `cycles.id`.
+ *
+ * @param {unknown} value
+ * @returns {boolean}
+ */
+export function isCycleId(value) {
+  return typeof value === 'string' && UUID_RE.test(value)
+}
+
+/**
+ * Base64-encodes a string in whichever runtime this is called from.
+ *
+ * `btoa` is byte-oriented and throws on anything outside Latin-1, so the
+ * payload is percent-encoded first. Node gets `Buffer`. The encoding is not a
+ * security boundary — it exists so the value reads as an opaque token rather
+ * than as an invitation to hand-edit a timestamp in the address bar — and the
+ * decoder validates the contents regardless.
+ *
+ * @param {string} raw
+ * @returns {string}
+ */
+function toBase64(raw) {
+  if (typeof btoa === 'function') return btoa(encodeURIComponent(raw))
+  return Buffer.from(raw, 'utf8').toString('base64')
+}
+
+/**
+ * The inverse of `toBase64`. Returns `null` rather than throwing on malformed
+ * input, because the caller's response to "this cursor is broken" is to start
+ * from the beginning, not to fail the request.
+ *
+ * @param {string} encoded
+ * @returns {string|null}
+ */
+function fromBase64(encoded) {
+  try {
+    if (typeof atob === 'function') return decodeURIComponent(atob(encoded))
+    return Buffer.from(encoded, 'base64').toString('utf8')
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Encodes a keyset cursor from the last row of a page.
+ *
+ * `(start_date, id)` rather than `start_date` alone: two cycles can share a
+ * start date (a duplicate write, a correction, a seeded account), and a cursor
+ * on the date alone would either skip the second row or repeat the first
+ * across a page boundary.
+ *
+ * @param {{ start_date?: string, id?: string }} row
+ * @returns {string|null} `null` when the row cannot anchor a cursor
+ */
+export function encodeCycleCursor(row) {
+  if (!row) return null
+  if (!isISODateString(row.start_date)) return null
+  if (!isCycleId(row.id)) return null
+
+  return toBase64(`${row.start_date}${CURSOR_SEPARATOR}${row.id}`)
+}
+
+/**
+ * Decodes and validates a keyset cursor.
+ *
+ * Every failure mode — malformed base64, a missing separator, a date that is
+ * not a real calendar day, an id that is not a UUID — returns `null`. The
+ * route reads `null` as "no cursor", which serves the first page. That is the
+ * right degradation: a stale bookmark should show the newest cycles, not an
+ * empty history and not a 500.
+ *
+ * @param {unknown} cursor
+ * @returns {{ startDate: string, id: string }|null}
+ */
+export function decodeCycleCursor(cursor) {
+  if (typeof cursor !== 'string' || cursor === '') return null
+
+  const decoded = fromBase64(cursor)
+  if (decoded === null) return null
+
+  // Split on the first separator. A `YYYY-MM-DD` date can never contain `|`
+  // and neither can a UUID, so a second one means the token is malformed.
+  const at = decoded.indexOf(CURSOR_SEPARATOR)
+  if (at <= 0 || at === decoded.length - 1) return null
+
+  const startDate = decoded.slice(0, at)
+  const id = decoded.slice(at + 1)
+
+  // Both halves are validated for what they *are*, not merely for being
+  // non-empty. This is the check whose absence let filter syntax through.
+  if (!isISODateString(startDate)) return null
+  if (!isCycleId(id)) return null
+
+  return { startDate, id }
+}
+
+/**
+ * Clamps a requested page size.
+ *
+ * @param {unknown} raw
+ * @returns {number}
+ */
+export function normaliseCycleLimit(raw) {
+  if (raw === undefined || raw === null || raw === '') return DEFAULT_CYCLE_PAGE_SIZE
+  const parsed = Number(raw)
+  if (!Number.isFinite(parsed)) return DEFAULT_CYCLE_PAGE_SIZE
+  return Math.min(MAX_CYCLE_PAGE_SIZE, Math.max(1, Math.floor(parsed)))
+}
+
+/**
+ * Turns raw request parameters into a validated query description.
+ *
+ * @param {URLSearchParams|Record<string, unknown>} params
+ * @returns {{ limit: number, cursor: {startDate: string, id: string}|null }}
+ */
+export function parseCycleQuery(params) {
+  const read = (key) => (typeof params?.get === 'function' ? params.get(key) : params?.[key])
+
+  return {
+    limit: normaliseCycleLimit(read('limit')),
+    cursor: decodeCycleCursor(read('cursor')),
+  }
+}
+
+/**
+ * Builds the keyset predicate for the row *after* the cursor, newest first.
+ *
+ * The condition is a tuple comparison — "an earlier start date, or the same
+ * date with a smaller id" — which a single `.lt()` cannot express:
+ *
+ *     (start_date, id) < (cursor.startDate, cursor.id)
+ *
+ * Both values are quoted so PostgREST reads them as literals, and both have
+ * already been validated by `decodeCycleCursor`, so nothing that could be read
+ * as filter syntax can reach this string. The quoting is defence in depth, not
+ * the primary control.
+ *
+ * @param {{startDate: string, id: string}} cursor
+ * @returns {string}
+ */
+export function buildCycleCursorFilter(cursor) {
+  const { startDate, id } = cursor
+  return `start_date.lt."${startDate}",and(start_date.eq."${startDate}",id.lt."${id}")`
+}
+
+/**
+ * Builds the payload for a page of cycles.
+ *
+ * ## Why the shape is `{ cycles, pagination }` and not a bare array
+ *
+ * `OfflineContext.fetchCycles` reads `data.data.cycles`, and the handler's own
+ * error branch already returned `{ cycles, … }` nested under `data`. Keeping
+ * the array under a named key means the success path and the fallback path
+ * agree, and means a future field (a prediction, a count) can be added without
+ * changing the type of `data` out from under the client again.
+ *
+ * The route asks the database for `limit + 1` rows: the extra row is how
+ * "is there more?" is answered without a second `count(*)`, which on a table
+ * indexed for `(user_id, start_date)` costs a second scan of the same range.
+ * The extra row is trimmed here before it reaches the client.
+ *
+ * @param {object[]} rows up to `limit + 1` rows, newest first
+ * @param {number} limit the page size that was requested
+ * @param {number|null} [totalCount] total cycles for this user, when known
+ * @returns {{ cycles: object[], pagination: { limit: number, hasMore: boolean, nextCursor: string|null, totalCount: number|null } }}
+ */
+export function buildCyclePage(rows, limit, totalCount = null) {
+  const safeRows = Array.isArray(rows) ? rows.filter(Boolean) : []
+  const hasMore = safeRows.length > limit
+  const cycles = hasMore ? safeRows.slice(0, limit) : safeRows
+
+  return {
+    cycles,
+    pagination: {
+      limit,
+      hasMore,
+      // No next cursor on the last page: handing one back would make the
+      // client issue a request guaranteed to return nothing.
+      nextCursor: hasMore ? encodeCycleCursor(cycles[cycles.length - 1]) : null,
+      totalCount: Number.isFinite(totalCount) ? totalCount : null,
+    },
+  }
+}
+
+/**
+ * The payload served when the cycle list cannot be read.
+ *
+ * Returned with a 200 deliberately: an empty history and an unreadable history
+ * look the same to the dashboard, and the offline mirror is the fallback for
+ * both. What matters is that the *shape* matches `buildCyclePage`, so the
+ * client's `data.data.cycles` access is valid on every branch — the invariant
+ * whose absence is the second half of this bug.
+ *
+ * @returns {ReturnType<typeof buildCyclePage>}
+ */
+export function emptyCyclePage() {
+  return buildCyclePage([], DEFAULT_CYCLE_PAGE_SIZE, 0)
+}
+
+/**
+ * True when a payload can safely refresh the offline mirror.
+ *
+ * `cacheRecords` calls `replaceAll`, which clears the store before it writes.
+ * Handing it the result of a shape mismatch — `undefined`, which
+ * `decryptRecords` turns into `[]` — therefore *deletes* the user's local
+ * cycle history rather than leaving it alone. This is the guard that makes
+ * that impossible: the mirror is only replaced when the server actually sent
+ * an array of cycles.
+ *
+ * A genuinely empty array is still a valid refresh — an account with no cycles
+ * should not keep showing rows from a previous sign-in — so the check is on
+ * the presence of the array, not on its length.
+ *
+ * @param {unknown} payload the parsed `{ success, data }` response body
+ * @returns {boolean}
+ */
+export function hasUsableCyclePayload(payload) {
+  return Boolean(payload?.success) && Array.isArray(payload?.data?.cycles)
+}

--- a/scripts/test-cycle-page.js
+++ b/scripts/test-cycle-page.js
@@ -1,0 +1,416 @@
+/**
+ * Regression suite for lib/cycle-page.js.
+ *
+ * The bug this is part of fixing: `GET /api/cycles` ended with
+ *
+ *     return NextResponse.json(paginatedResult, { status: 200 })
+ *
+ * in a file that never imported `NextResponse`. Every read of the cycle list
+ * threw `ReferenceError: NextResponse is not defined`, was swallowed by the
+ * outer catch, and came back as a 500 -- which the client read as
+ * `data.success === false` and skipped without a word, falling through to the
+ * IndexedDB mirror.
+ *
+ * The import alone was not the fix. The handler had been migrated to
+ * `formatPaginatedResponse`, whose `{ success, data: [...] }` does not carry
+ * the `data.cycles` key the client reads; with the import in place,
+ * `decryptRecords(undefined)` returns `[]`, and `cacheRecords('cycles', [])`
+ * calls `replaceAll`, which *clears the store*. The naive fix would have
+ * turned a stale-cache bug into a cache wipe on every dashboard load.
+ *
+ * And the cursor was the raw `${start_date}_${id}`, split on `_` and
+ * interpolated into a PostgREST `or` filter, so a cursor containing filter
+ * syntax produced a 400 that the route reported to the user as an empty
+ * history.
+ *
+ *   node scripts/test-cycle-page.js
+ */
+
+import {
+  DEFAULT_CYCLE_PAGE_SIZE,
+  MAX_CYCLE_PAGE_SIZE,
+  buildCycleCursorFilter,
+  buildCyclePage,
+  decodeCycleCursor,
+  emptyCyclePage,
+  encodeCycleCursor,
+  hasUsableCyclePayload,
+  isCycleId,
+  normaliseCycleLimit,
+  parseCycleQuery,
+} from '../lib/cycle-page.js'
+
+let passed = 0
+let failed = 0
+
+function check(actual, expected, label) {
+  if (Object.is(actual, expected)) {
+    passed += 1
+    return
+  }
+  failed += 1
+  console.error(`FAIL ${label}\n  expected: ${JSON.stringify(expected)}\n  actual:   ${JSON.stringify(actual)}`)
+}
+
+function checkDeep(actual, expected, label) {
+  const a = JSON.stringify(actual)
+  const b = JSON.stringify(expected)
+  if (a === b) {
+    passed += 1
+    return
+  }
+  failed += 1
+  console.error(`FAIL ${label}\n  expected: ${b}\n  actual:   ${a}`)
+}
+
+const UUID_A = '3f2a1b4c-5d6e-4f70-8901-a2b3c4d5e6f7'
+const UUID_B = '9e8d7c6b-5a49-4382-9170-6f5e4d3c2b1a'
+const UUID_UPPER = '3F2A1B4C-5D6E-4F70-8901-A2B3C4D5E6F7'
+
+function cycle(startDate, id, extra = {}) {
+  return { id, start_date: startDate, end_date: null, cycle_length: 28, ...extra }
+}
+
+// ---------------------------------------------------------------------------
+// isCycleId
+// ---------------------------------------------------------------------------
+
+check(isCycleId(UUID_A), true, 'isCycleId accepts a canonical uuid')
+check(isCycleId(UUID_UPPER), true, 'isCycleId accepts an uppercase uuid')
+check(isCycleId(''), false, 'isCycleId rejects the empty string')
+check(isCycleId(null), false, 'isCycleId rejects null')
+check(isCycleId(undefined), false, 'isCycleId rejects undefined')
+check(isCycleId(42), false, 'isCycleId rejects a number')
+check(isCycleId('not-a-uuid'), false, 'isCycleId rejects a plain word')
+check(isCycleId(UUID_A.slice(0, -1)), false, 'isCycleId rejects a truncated uuid')
+check(isCycleId(`${UUID_A}0`), false, 'isCycleId rejects an over-long uuid')
+check(isCycleId(UUID_A.replace('-', '')), false, 'isCycleId rejects a uuid missing a hyphen')
+check(isCycleId(`${UUID_A},user_id.neq.x`), false, 'isCycleId rejects filter syntax appended to a uuid')
+check(isCycleId('3f2a1b4c-5d6e-4f70-8901-a2b3c4d5e6g7'), false, 'isCycleId rejects a non-hex character')
+
+// ---------------------------------------------------------------------------
+// Cursor round trip
+// ---------------------------------------------------------------------------
+
+const cursor = encodeCycleCursor(cycle('2026-07-21', UUID_A))
+check(typeof cursor, 'string', 'encodeCycleCursor returns a string for a valid row')
+check(cursor.includes('2026-07-21'), false, 'the encoded cursor does not read as a date in the address bar')
+checkDeep(
+  decodeCycleCursor(cursor),
+  { startDate: '2026-07-21', id: UUID_A },
+  'a cursor round-trips losslessly'
+)
+
+check(
+  encodeCycleCursor(cycle('2026-01-01', UUID_A)) !== encodeCycleCursor(cycle('2026-01-01', UUID_B)),
+  true,
+  'two rows sharing a start date produce different cursors'
+)
+
+// The id tie-break is the whole reason the cursor is a pair. Two cycles can
+// share a start date -- a duplicate write, a correction, a seeded account --
+// and a cursor on the date alone would skip one or repeat the other.
+checkDeep(
+  decodeCycleCursor(encodeCycleCursor(cycle('2026-01-01', UUID_B))),
+  { startDate: '2026-01-01', id: UUID_B },
+  'the id half survives the round trip when the dates collide'
+)
+
+// ---------------------------------------------------------------------------
+// encodeCycleCursor: rows that cannot anchor a page
+// ---------------------------------------------------------------------------
+
+check(encodeCycleCursor(null), null, 'encodeCycleCursor rejects null')
+check(encodeCycleCursor(undefined), null, 'encodeCycleCursor rejects undefined')
+check(encodeCycleCursor({}), null, 'encodeCycleCursor rejects an empty object')
+check(encodeCycleCursor(cycle(null, UUID_A)), null, 'encodeCycleCursor rejects a null start_date')
+check(encodeCycleCursor(cycle('2026-07-21', null)), null, 'encodeCycleCursor rejects a null id')
+check(encodeCycleCursor(cycle('21-07-2026', UUID_A)), null, 'encodeCycleCursor rejects a non-ISO start_date')
+check(encodeCycleCursor(cycle('2026-02-31', UUID_A)), null, 'encodeCycleCursor rejects a date that is not a real day')
+check(encodeCycleCursor(cycle('2026-13-01', UUID_A)), null, 'encodeCycleCursor rejects month 13')
+check(encodeCycleCursor(cycle('2026-07-21T00:00:00Z', UUID_A)), null, 'encodeCycleCursor rejects a timestamp')
+check(encodeCycleCursor(cycle('2026-07-21', 'abc')), null, 'encodeCycleCursor rejects a non-uuid id')
+
+// ---------------------------------------------------------------------------
+// decodeCycleCursor: every way an unusable cursor must degrade
+//
+// Each of these must return null -- read by the route as "no cursor", which
+// serves the first page. That is the correct degradation: a stale bookmark
+// shows the newest cycles. The old code's answer was a 200 with an empty list,
+// which told the user she had no cycles at all.
+// ---------------------------------------------------------------------------
+
+check(decodeCycleCursor(null), null, 'decodeCycleCursor rejects null')
+check(decodeCycleCursor(undefined), null, 'decodeCycleCursor rejects undefined')
+check(decodeCycleCursor(''), null, 'decodeCycleCursor rejects the empty string')
+check(decodeCycleCursor(12345), null, 'decodeCycleCursor rejects a number')
+check(decodeCycleCursor({}), null, 'decodeCycleCursor rejects an object')
+check(decodeCycleCursor('!!!not base64!!!'), null, 'decodeCycleCursor rejects malformed base64')
+
+const encode = (raw) => Buffer.from(raw, 'utf8').toString('base64')
+
+check(decodeCycleCursor(encode('2026-07-21')), null, 'decodeCycleCursor rejects a cursor with no separator')
+check(decodeCycleCursor(encode('|' + UUID_A)), null, 'decodeCycleCursor rejects a leading separator')
+check(decodeCycleCursor(encode('2026-07-21|')), null, 'decodeCycleCursor rejects a trailing separator')
+check(decodeCycleCursor(encode('2026-02-31|' + UUID_A)), null, 'decodeCycleCursor rejects a date that is not a real day')
+check(decodeCycleCursor(encode('2026-07-21|abc')), null, 'decodeCycleCursor rejects a non-uuid id')
+check(decodeCycleCursor(encode('2026-07-21|')), null, 'decodeCycleCursor rejects an empty id')
+
+// The filter-syntax cases. Under the old `cursor.split('_')` these reached the
+// PostgREST `or` string verbatim.
+check(
+  decodeCycleCursor(encode(`2026-07-21|${UUID_A},user_id.neq.someone-else`)),
+  null,
+  'decodeCycleCursor rejects a comma-injected id'
+)
+check(
+  decodeCycleCursor(encode('2026-07-21,and(cycle_length.gt.0)|' + UUID_A)),
+  null,
+  'decodeCycleCursor rejects a comma-injected date'
+)
+check(
+  decodeCycleCursor(encode(`2026-07-21|${UUID_A})`)),
+  null,
+  'decodeCycleCursor rejects an id carrying a closing parenthesis'
+)
+check(
+  decodeCycleCursor(encode(`2026-07-21|${UUID_A}|extra`)),
+  null,
+  'decodeCycleCursor rejects a cursor with a second separator'
+)
+
+// The literal shape of the old cursor must not be honoured either -- an
+// in-flight client holding one degrades to the first page rather than to an
+// empty history.
+check(
+  decodeCycleCursor(`2026-07-21_${UUID_A}`),
+  null,
+  'decodeCycleCursor rejects the previous raw `date_id` cursor form'
+)
+
+// ---------------------------------------------------------------------------
+// normaliseCycleLimit
+// ---------------------------------------------------------------------------
+
+check(normaliseCycleLimit(undefined), DEFAULT_CYCLE_PAGE_SIZE, 'a missing limit uses the default')
+check(normaliseCycleLimit(null), DEFAULT_CYCLE_PAGE_SIZE, 'a null limit uses the default')
+check(normaliseCycleLimit(''), DEFAULT_CYCLE_PAGE_SIZE, 'an empty limit uses the default')
+check(normaliseCycleLimit('abc'), DEFAULT_CYCLE_PAGE_SIZE, 'a non-numeric limit uses the default')
+check(normaliseCycleLimit('NaN'), DEFAULT_CYCLE_PAGE_SIZE, 'the string NaN uses the default')
+check(normaliseCycleLimit(Infinity), DEFAULT_CYCLE_PAGE_SIZE, 'Infinity uses the default')
+check(normaliseCycleLimit('20'), 20, 'a numeric string is accepted')
+check(normaliseCycleLimit(20), 20, 'a number is accepted')
+check(normaliseCycleLimit('20.9'), 20, 'a fractional limit is floored')
+check(normaliseCycleLimit(0), 1, 'zero is raised to one')
+check(normaliseCycleLimit(-5), 1, 'a negative limit is raised to one')
+check(normaliseCycleLimit(1e9), MAX_CYCLE_PAGE_SIZE, 'an enormous limit is clamped to the ceiling')
+check(normaliseCycleLimit(MAX_CYCLE_PAGE_SIZE), MAX_CYCLE_PAGE_SIZE, 'the ceiling itself is accepted')
+
+// ---------------------------------------------------------------------------
+// parseCycleQuery
+// ---------------------------------------------------------------------------
+
+const validCursor = encodeCycleCursor(cycle('2026-06-01', UUID_B))
+
+checkDeep(
+  parseCycleQuery(new URLSearchParams('')),
+  { limit: DEFAULT_CYCLE_PAGE_SIZE, cursor: null },
+  'an empty query yields the default page and no cursor'
+)
+checkDeep(
+  parseCycleQuery(new URLSearchParams(`limit=5&cursor=${encodeURIComponent(validCursor)}`)),
+  { limit: 5, cursor: { startDate: '2026-06-01', id: UUID_B } },
+  'a limit and a cursor are both read'
+)
+checkDeep(
+  parseCycleQuery(new URLSearchParams('cursor=garbage')),
+  { limit: DEFAULT_CYCLE_PAGE_SIZE, cursor: null },
+  'an unusable cursor degrades to the first page rather than to an error'
+)
+checkDeep(
+  parseCycleQuery({ limit: '3', cursor: validCursor }),
+  { limit: 3, cursor: { startDate: '2026-06-01', id: UUID_B } },
+  'parseCycleQuery also accepts a plain object, for tests and server components'
+)
+checkDeep(
+  parseCycleQuery(undefined),
+  { limit: DEFAULT_CYCLE_PAGE_SIZE, cursor: null },
+  'parseCycleQuery survives being handed nothing at all'
+)
+
+// ---------------------------------------------------------------------------
+// buildCycleCursorFilter
+// ---------------------------------------------------------------------------
+
+const filter = buildCycleCursorFilter({ startDate: '2026-07-21', id: UUID_A })
+check(
+  filter,
+  `start_date.lt."2026-07-21",and(start_date.eq."2026-07-21",id.lt."${UUID_A}")`,
+  'the keyset filter expresses the tuple comparison'
+)
+check(filter.includes('start_date.lt'), true, 'the filter pages strictly backwards')
+check(filter.includes('id.lt'), true, 'the filter carries the id tie-break')
+
+// ---------------------------------------------------------------------------
+// buildCyclePage
+// ---------------------------------------------------------------------------
+
+const rows = [
+  cycle('2026-07-21', UUID_A),
+  cycle('2026-06-20', UUID_B),
+  cycle('2026-05-19', '11111111-2222-4333-8444-555555555555'),
+]
+
+const fullPage = buildCyclePage(rows, 3, 3)
+check(fullPage.cycles.length, 3, 'a page exactly the size of the limit keeps every row')
+check(fullPage.pagination.hasMore, false, 'a page exactly the size of the limit is the last page')
+check(fullPage.pagination.nextCursor, null, 'the last page carries no next cursor')
+check(fullPage.pagination.totalCount, 3, 'the total count is passed through')
+check(fullPage.pagination.limit, 3, 'the requested limit is echoed back')
+
+const trimmedPage = buildCyclePage(rows, 2, 9)
+check(trimmedPage.cycles.length, 2, 'the extra look-ahead row is trimmed off')
+check(trimmedPage.pagination.hasMore, true, 'the extra row is what answers hasMore')
+check(trimmedPage.cycles[1].id, UUID_B, 'the trimmed page ends on the last row the client asked for')
+checkDeep(
+  decodeCycleCursor(trimmedPage.pagination.nextCursor),
+  { startDate: '2026-06-20', id: UUID_B },
+  'the next cursor anchors on the last returned row, not on the look-ahead row'
+)
+
+// The look-ahead row must never be visible to the client -- it is the row that
+// would otherwise be served twice, once as the tail of this page and once as
+// the head of the next.
+check(
+  trimmedPage.cycles.some((row) => row.id === '11111111-2222-4333-8444-555555555555'),
+  false,
+  'the look-ahead row does not reach the client'
+)
+
+checkDeep(buildCyclePage([], 12, 0).cycles, [], 'an empty result is an empty array, not null')
+check(buildCyclePage([], 12, 0).pagination.hasMore, false, 'an empty result has no more pages')
+check(buildCyclePage(null, 12, 0).cycles.length, 0, 'a null row set does not throw')
+check(buildCyclePage(undefined, 12, 0).cycles.length, 0, 'an undefined row set does not throw')
+check(buildCyclePage([null, undefined], 12, 0).cycles.length, 0, 'null rows are filtered out')
+check(buildCyclePage(rows, 2, null).pagination.totalCount, null, 'an unknown total count is reported as null')
+check(buildCyclePage(rows, 2, undefined).pagination.totalCount, null, 'an undefined total count is reported as null')
+
+// A last row that cannot anchor a cursor must not produce a broken one. The
+// client would page forever against a cursor the decoder then rejects.
+const unanchorable = buildCyclePage(
+  [cycle('2026-07-21', UUID_A), cycle('2026-06-20', 'not-a-uuid'), cycle('2026-05-19', UUID_B)],
+  2,
+  9
+)
+check(unanchorable.pagination.hasMore, true, 'hasMore is still reported when the last row cannot anchor')
+check(unanchorable.pagination.nextCursor, null, 'an unanchorable last row yields no cursor rather than a broken one')
+
+// ---------------------------------------------------------------------------
+// emptyCyclePage -- the shape invariant that is the second half of this bug
+// ---------------------------------------------------------------------------
+
+const empty = emptyCyclePage()
+checkDeep(Object.keys(empty).sort(), ['cycles', 'pagination'], 'the fallback page has the same top-level keys as a real one')
+checkDeep(
+  Object.keys(empty.pagination).sort(),
+  Object.keys(fullPage.pagination).sort(),
+  'the fallback pagination block has the same keys as a real one'
+)
+check(Array.isArray(empty.cycles), true, 'the fallback page carries an array under `cycles`')
+check(empty.cycles.length, 0, 'the fallback page is empty')
+check(empty.pagination.hasMore, false, 'the fallback page reports no further pages')
+
+// ---------------------------------------------------------------------------
+// hasUsableCyclePayload -- the guard that stops the offline mirror being wiped
+// ---------------------------------------------------------------------------
+
+check(
+  hasUsableCyclePayload({ success: true, data: { cycles: [], pagination: {} } }),
+  true,
+  'an empty cycle array is a usable refresh -- a cleared account must clear the mirror'
+)
+check(
+  hasUsableCyclePayload({ success: true, data: { cycles: rows, pagination: {} } }),
+  true,
+  'a populated cycle array is a usable refresh'
+)
+
+// This is the exact payload `formatPaginatedResponse` produced, and the exact
+// reason the naive one-line fix would have wiped the mirror.
+check(
+  hasUsableCyclePayload({ success: true, data: rows, pagination: {} }),
+  false,
+  'a bare array under `data` is refused -- the shape that would have cleared the store'
+)
+check(
+  hasUsableCyclePayload({ success: false, error: 'Failed to fetch cycles: NextResponse is not defined' }),
+  false,
+  'the 500 this bug produced is refused'
+)
+check(hasUsableCyclePayload({ success: true, data: null }), false, 'a null data block is refused')
+check(hasUsableCyclePayload({ success: true }), false, 'a missing data block is refused')
+check(hasUsableCyclePayload({ success: true, data: {} }), false, 'a data block with no cycles key is refused')
+check(
+  hasUsableCyclePayload({ success: true, data: { cycles: null } }),
+  false,
+  'a null cycles key is refused'
+)
+check(
+  hasUsableCyclePayload({ success: true, data: { cycles: 'many' } }),
+  false,
+  'a non-array cycles key is refused'
+)
+check(hasUsableCyclePayload(null), false, 'a null payload is refused')
+check(hasUsableCyclePayload(undefined), false, 'an undefined payload is refused')
+check(hasUsableCyclePayload('nope'), false, 'a string payload is refused')
+
+// ---------------------------------------------------------------------------
+// End-to-end: walking a history one page at a time
+//
+// The property that matters is that paging visits every row exactly once. The
+// old cursor could not guarantee it -- two rows sharing a start date were
+// either skipped or repeated, because the cursor did not carry the id.
+// ---------------------------------------------------------------------------
+
+const history = [
+  cycle('2026-07-21', 'aaaaaaaa-0000-4000-8000-000000000001'),
+  cycle('2026-07-21', 'aaaaaaaa-0000-4000-8000-000000000000'), // same day, lower id
+  cycle('2026-06-20', 'bbbbbbbb-0000-4000-8000-000000000001'),
+  cycle('2026-05-19', 'cccccccc-0000-4000-8000-000000000001'),
+  cycle('2026-04-18', 'dddddddd-0000-4000-8000-000000000001'),
+]
+
+/** Applies the keyset predicate the filter expresses, in memory. */
+function rowsAfter(all, anchor) {
+  if (!anchor) return all
+  return all.filter((row) =>
+    row.start_date < anchor.startDate ||
+    (row.start_date === anchor.startDate && row.id < anchor.id)
+  )
+}
+
+const seen = []
+let anchor = null
+let guard = 0
+
+for (;;) {
+  guard += 1
+  if (guard > 20) break // a runaway loop is itself a failure
+
+  const available = rowsAfter(history, anchor)
+  const page = buildCyclePage(available.slice(0, 2 + 1), 2, history.length)
+  for (const row of page.cycles) seen.push(row.id)
+
+  if (!page.pagination.hasMore) break
+  anchor = decodeCycleCursor(page.pagination.nextCursor)
+  check(anchor !== null, true, 'each next cursor decodes back to a usable anchor')
+}
+
+check(seen.length, history.length, 'paging visits every cycle')
+check(new Set(seen).size, history.length, 'paging visits no cycle twice')
+checkDeep(seen, history.map((row) => row.id), 'paging preserves the newest-first ordering, id-tie-broken')
+
+// ---------------------------------------------------------------------------
+
+console.log(`${failed === 0 ? 'PASS' : 'FAIL'} ${passed} passed, ${failed} failed`)
+process.exit(failed === 0 ? 0 : 1)


### PR DESCRIPTION
## Linked Issue
Fixes #746

## Description

`GET /api/cycles` ended with

```js
return NextResponse.json(paginatedResult, { status: 200 })
```

in a file that never imported `NextResponse`. The identifier does not exist in that module, so every read of the cycle list threw `ReferenceError: NextResponse is not defined`, was caught by the handler's own outer `catch`, and came back as

```json
{ "success": false, "error": "Failed to fetch cycles: NextResponse is not defined" }
```

`POST` and `PATCH` were unaffected — they return through `jsonSuccess`/`jsonError`, which import `NextResponse` themselves. Only `GET` reached past the shared helper, and only on its success path, which is why this survived: the error branch a few lines above goes through `jsonSuccess` and looks fine in a smoke test.

### Why nobody saw a crash

`lib/OfflineContext.jsx` read `data.success`, found `false`, skipped the refresh block **without throwing**, and fell through to the IndexedDB mirror. Nothing was logged. A user with a warm cache saw stale cycles indefinitely; a user on a new device or a cleared browser had an empty mirror and saw an empty dashboard — indistinguishable from a genuinely new account.

### Why the one-line fix would have been worse

The handler had been migrated to `formatPaginatedResponse`, which produces `{ success, data: [ ...rows ], pagination }`. The client reads `data.data.cycles`. With `NextResponse` merely imported:

- `data.success` becomes `true`, so the refresh block now runs;
- `data.data.cycles` is `undefined`;
- `decryptRecords(undefined, …)` returns `[]` — by design, it guards its input;
- `cacheRecords('cycles', [])` calls `replaceAll`, which **clears the store and repopulates it with nothing**.

A stale-cache bug would have become a cache wipe on every dashboard load. The two branches of the same handler also disagreed about the shape — the database-error path returned `{ cycles, nextPeriodDate, confidence, averageCycleLength }` nested under `data`, the success path returned a bare array. Whichever was right, they could not both be.

### The fix

**`lib/cycle-page.js` (new)** owns the read contract: cursor encoding, cursor validation, and the envelope *both* branches produce. It has no I/O, so every branch is reachable from plain Node.

The route now returns through `jsonSuccess`, not a bare `NextResponse`. Reaching past the shared helper is precisely how this handler came to reference an identifier its file never imported, and how its shape drifted away from the client's.

**The cursor is no longer a filter fragment.** It was the raw `${start_date}_${id}`, split on `_` and interpolated into a PostgREST `or`:

```js
query.or(`start_date.lt.${cursorDate},and(start_date.eq.${cursorDate},id.lt.${cursorId})`)
```

`,`, `(`, `)` and `.` are all filter syntax, so `?cursor=a,b_c` produced a malformed filter, PostgREST answered 400, and the route's `error && error.code !== 'PGRST116'` branch returned **200 with an empty list** — a hand-edited or stale cursor told the user she had no cycles. It is now an opaque token whose halves are validated for what they *are* (a real calendar day; a UUID) before either can reach a filter string, and an unusable cursor decodes to `null`, which serves the first page. This is the same discipline `lib/forum-query.js` already applies on the forum side.

The page also asks for `limit + 1` rows and trims the extra one, so `hasMore` is answered without a second `count(*)` over the same range — and the id tie-break is kept, because `start_date` is not unique and a cursor on the date alone would skip or repeat rows that share one.

**`OfflineContext` no longer trusts a 200 to be well-shaped.** `hasUsableCyclePayload` gates the mirror refresh on the payload actually carrying an array of cycles, so no future envelope change can delete a user's local history. A 200 without cycles is now logged as the fault it is rather than falling through in silence. An empty array is still a valid refresh — a cleared account must clear the mirror — so the check is on the presence of the array, not its length.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (clean code updates, no behavior modifications)
- [ ] Documentation update
- [ ] Performance optimization
- [ ] Security patch

## Files Modified

| File | Change |
|------|--------|
| `lib/cycle-page.js` | **New.** Cursor encode/decode/validate, keyset filter, page envelope, payload guard |
| `app/api/cycles/route.js` | `GET` returns through `jsonSuccess`; validated cursor; `limit + 1` look-ahead; both branches share one shape |
| `lib/OfflineContext.jsx` | Mirror is refreshed only from a payload carrying a cycles array; a malformed 200 is logged |
| `scripts/test-cycle-page.js` | **New.** 106 assertions |

## Testing

```bash
node scripts/test-cycle-page.js
# PASS 106 passed, 0 failed

npx next build --webpack
# ✓ Compiled successfully
```

The suite covers the cursor round trip; every rejected cursor form (malformed base64, missing/leading/trailing separator, `2026-02-31`, a non-UUID id, comma- and parenthesis-injected halves, and the *previous* raw `date_id` form, so an in-flight client degrades to the first page rather than to an empty history); limit clamping; the look-ahead row never reaching the client; a last row that cannot anchor a cursor yielding `null` rather than a broken token; the fallback page having byte-identical keys to a real one; and `hasUsableCyclePayload` refusing the exact `{ success: true, data: [...] }` payload that would have wiped the mirror.

It also walks a five-cycle history — including two cycles sharing a start date — one page at a time and asserts that paging visits every row exactly once, in order. That is the property the old cursor could not hold, because it did not carry the id.

Manual:

1. `curl -i "$APP/api/cycles"` with a valid session → `200`, `{ success: true, data: { cycles: [...], pagination: {...} } }` (previously `500`).
2. Open the dashboard in a fresh browser profile → cycles load (previously an empty state).
3. `curl "$APP/api/cycles?cursor=x,y_z"` → the first page, not an empty list.
4. Page through a long history with `?cursor=` → no repeated or skipped cycles.

## Screenshots (if UI changes are made)
No visual change by design — the dashboard, calendar and prediction render exactly as intended; they simply receive the cycle list they were always asking for.

## Checklist
- [x] This PR is submitted under ECSOC.
- [x] Added the required **ECSoc26** label to this Pull Request.
- [x] Linked issue using `Fixes #746`.
- [x] Tested locally.
- [x] `npm run build` completes successfully.
- [x] No breaking changes introduced.
- [x] Documentation updated if required.
