### PR TITLE
[ECSoC26] API: Repair the /api/chat error handler, intent matcher and reply envelope

### DIFF
--- a/app/[locale]/chat/page.js
+++ b/app/[locale]/chat/page.js
@@ -9,6 +9,7 @@ import { useTranslations, useLocale } from 'next-intl'
 import { useRouter } from 'next/navigation'
 import { useOffline } from '@/lib/OfflineContext'
 import fetchWithTimeout from '@/lib/fetch-with-timeout'
+import { readChatResponse } from '@/lib/chat-fallback'
 
 export default function ChatPage() {
   const t = useTranslations('pages.chat')
@@ -57,9 +58,16 @@ export default function ChatPage() {
       })
       const data = await res.json()
       setIsTyping(false)
-      if (data.success) {
-        setChatMessages(prev => [...prev, { role: 'ai', text: data.response }])
-      }
+
+      // Read through `readChatResponse`, not `data.response`. The route was
+      // moved to the standard `jsonSuccess` envelope, which nests the reply
+      // under `data`, and this caller was never updated -- so `data.response`
+      // was `undefined` and every assistant turn rendered as an empty bubble.
+      const reply = readChatResponse(data)
+      setChatMessages(prev => [...prev, {
+        role: 'ai',
+        text: reply.text || tChat('error'),
+      }])
     } catch {
       setIsTyping(false)
       setChatMessages(prev => [...prev, {

--- a/app/[locale]/page.js
+++ b/app/[locale]/page.js
@@ -37,6 +37,7 @@ import FeaturesSection from '@/components/dashboard/FeaturesSection'
 import PCOSMythFactCard from '@/components/dashboard/PCOSMythFactCard'
 import { isEncryptionFailure } from '@/lib/encryption-policy'
 import { getTodayISO, eachDayISO, addDaysISO } from '@/lib/date-utils'
+import { readChatResponse } from '@/lib/chat-fallback'
 
 const MONTH_NAMES = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December']
 
@@ -310,14 +311,14 @@ const HerCycleApp = () => {
       const data = await response.json()
       setIsTyping(false)
 
-      if (data?.response) {
-        setChatMessages(prev => [...prev, { role: 'ai', text: data.response }])
-      } else {
-        setChatMessages(prev => [...prev, {
-          role: 'ai',
-          text: tChat('error')
-        }])
-      }
+      // `data.response` sits under `data.data` since the API envelope was
+      // standardised, so this check read `undefined` and swapped in the generic
+      // error string for replies that had actually succeeded.
+      const reply = readChatResponse(data)
+      setChatMessages(prev => [...prev, {
+        role: 'ai',
+        text: reply.text || tChat('error')
+      }])
     } catch (error) {
       setIsTyping(false)
       setChatMessages(prev => [...prev, {

--- a/app/api/chat/route.js
+++ b/app/api/chat/route.js
@@ -7,6 +7,13 @@ import { getSupabaseAdmin } from '@/lib/supabase-admin'
 import { z } from 'zod'
 import { pruneMessageHistory } from '@/lib/chat-utils';
 import { jsonSuccess, jsonError } from '@/lib/api-helpers'
+import {
+  MAX_HISTORY_TURNS,
+  SOURCE_FALLBACK,
+  SOURCE_MODEL,
+  buildFallbackReply,
+  normaliseChatHistory,
+} from '@/lib/chat-fallback'
 
 const TIMEOUT_MS = 6000; // 6 seconds timeout per AI attempt to keep chat snappy
 
@@ -14,7 +21,12 @@ const chatPayloadSchema = z.object({
   language: z.string().max(20).optional(),
   message: z.string().min(1).max(2000),
   context: z.any().optional(),
-  history: z.array(z.any()).optional()
+  // Capped here rather than relying on `pruneMessageHistory` downstream: the
+  // pruner runs *after* the whole array has been parsed and mapped, so an
+  // unbounded history was already fully materialised — and one `null` element
+  // threw inside that map, which was charged as a provider failure and spent
+  // the Groq retry before the local fallback was reached.
+  history: z.array(z.any()).max(MAX_HISTORY_TURNS).optional()
 }).passthrough()
 
 const withTimeout = async (fn, ms) => {
@@ -26,50 +38,6 @@ const withTimeout = async (fn, ms) => {
     clearTimeout(timeoutId);
   }
 };
-
-function getSmartLocalResponse(message, language = 'en', context = {}) {
-  const query = (message || '').toLowerCase();
-  const isHindi = language === 'hi' || language === 'हि';
-
-  if (query.includes('eat') || query.includes('food') || query.includes('nutrition') || query.includes('diet') || query.includes('snack')) {
-    return isHindi
-      ? 'माहवारी के दौरान आयरन युक्त भोजन (जैसे पालक, दालें, मेवे), डार्क चॉकलेट और गर्म हर्बल चाय लें। प्रोसेस्ड और अत्यधिक नमकीन खाने से बचें।'
-      : 'During your period, focus on iron-rich foods (spinach, lentils, pumpkin seeds), magnesium (dark chocolate), and warm herbal teas like ginger or chamomile. Stay hydrated and limit excess salt/sugar to minimize bloating! 🥗🍫';
-  }
-
-  if (query.includes('cramp') || query.includes('pain') || query.includes('ache') || query.includes('hurt')) {
-    return isHindi
-      ? 'माहवारी के दर्द (क्रैम्प्स) में गर्म पानी की थैली (हीटिंग पैड) से सिकाई करें, पर्याप्त पानी पिएं और हल्के खिंचाव (स्ट्रेचिंग) करें। यदि दर्द अत्यधिक हो तो डॉक्टर से परामर्श लें।'
-      : 'For cramp relief, try a warm heating pad on your lower abdomen, gentle stretching/yoga, drinking warm chamomile or ginger tea, and staying hydrated. If severe, consult your doctor! 🌸';
-  }
-
-  if (query.includes('pcos') || query.includes('pcod')) {
-    return isHindi
-      ? 'PCOD/PCOS एक हार्मोनल स्थिति है। संतुलित आहार, नियमित व्यायाम और तनाव प्रबंधन इसे नियंत्रित करने में सहायक होते हैं।'
-      : 'PCOD/PCOS is a common hormonal condition. It can be managed effectively with a low-glycemic balanced diet, regular exercise, consistent sleep, and medical guidance. 🩺';
-  }
-
-  if (query.includes('next period') || query.includes('predicted') || query.includes('when')) {
-    if (context?.nextPeriodDate) {
-      return isHindi
-        ? `आपकी अगली माहवारी की अनुमानित तारीख ${context.nextPeriodDate} है।`
-        : `Based on your cycle history, your next period is predicted around ${context.nextPeriodDate}. 💕`;
-    }
-    return isHindi
-      ? 'नियमित रूप से अपनी माहवारी लॉग करें ताकि हम सटीक अनुमान लगा सकें।'
-      : 'Keep tracking your daily cycle data so we can generate accurate predictions for your next period! 📅';
-  }
-
-  if (query.includes('hello') || query.includes('hi') || query.includes('hey') || query.includes('hie')) {
-    return isHindi
-      ? 'नमस्ते! मैं आपकी स्वास्थ्य सहायक हूँ। आप मुझसे अपनी माहवारी, पोषण या स्वास्थ्य के बारे में कुछ भी पूछ सकती हैं। 💕'
-      : 'Hello! I am your HerCycle health assistant. Ask me anything about your cycle, nutrition, symptoms, or wellness tips! 💕';
-  }
-
-  return isHindi
-    ? 'मैं आपके स्वास्थ्य और माहवारी से जुड़े प्रश्नों में मदद के लिए यहाँ हूँ। अपनी माहवारी के लक्षण या सुझाव के बारे बारे में पूछें। 💕'
-    : 'I am here to support you with menstrual health, cycle tracking tips, nutrition, and symptom care. How can I help you today? 💕';
-}
 
 /**
  * Primary AI Call: Google Gemini API
@@ -152,6 +120,15 @@ async function callGroq(message, systemPrompt, history = [], signal) {
 
 export async function POST(request) {
   validateEnv();
+
+  // Hoisted above the try/catch that reads them.
+  //
+  // These lived *inside* the `try`, and the `catch` at the bottom read
+  // `json?.message`. `let` is block-scoped and optional chaining does not
+  // rescue an undeclared binding, so every trip through that handler threw
+  // `ReferenceError: json is not defined` — the fallback written to keep the
+  // assistant answering was the one thing guaranteeing it could not.
+  let requestBody = null;
   let language = 'en';
 
   // ============ RATE LIMITING ============
@@ -170,22 +147,23 @@ export async function POST(request) {
       return jsonError('Unauthorized', 401)
     }
 
-    let json;
     try {
-      json = await request.json();
+      requestBody = await request.json();
     } catch (parseError) {
       logger.warn(`Malformed JSON payload in AI Chat API: ${parseError.message}`);
       return jsonError('Bad Request: Invalid JSON payload', 400)
     }
 
-    const result = chatPayloadSchema.safeParse(json)
+    const result = chatPayloadSchema.safeParse(requestBody)
     if (!result.success) {
       logger.warn(`Invalid request payload on AI Chat API: ${result.error.message}`);
       return jsonError('Bad Request', 400, null, result.error.errors)
     }
 
-    const { message, context, history = [] } = result.data
+    const { message, context } = result.data
     language = result.data.language || 'en'
+    // Unusable turns are dropped before an adapter can throw on them.
+    const history = normaliseChatHistory(result.data.history)
 
     if (!message || message.trim().length === 0) {
       return jsonError("Message content cannot be empty", 400)
@@ -205,7 +183,7 @@ export async function POST(request) {
     }
 
     if (userProfile && userProfile.allow_ai_analysis === false) {
-      return jsonSuccess({ response: 'Privacy mode enabled' })
+      return jsonSuccess({ response: 'Privacy mode enabled', source: SOURCE_FALLBACK, intent: 'privacy' })
     }
 
     let systemPrompt = `You are a helpful menstrual health assistant. Provide empathetic, accurate health guidance.`;
@@ -237,8 +215,11 @@ export async function POST(request) {
 
     systemPrompt += `\n\nImportant: Keep responses under 100 words. Be supportive and conversational.`;
 
-    // Try Gemini -> Groq -> Local smart response
+    // Try Gemini -> Groq -> local canned reply.
     let responseText = null;
+    let source = SOURCE_MODEL;
+    let intent = null;
+
     try {
       responseText = await withTimeout((sig) => callGemini(message, systemPrompt, history, sig), TIMEOUT_MS);
     } catch (geminiErr) {
@@ -246,16 +227,35 @@ export async function POST(request) {
       try {
         responseText = await withTimeout((sig) => callGroq(message, systemPrompt, history, sig), TIMEOUT_MS);
       } catch (groqErr) {
-        logger.warn(`Groq call failed: ${groqErr.message}. Using intelligent health fallback...`);
-        responseText = getSmartLocalResponse(message, language, context);
+        logger.warn(`Groq call failed: ${groqErr.message}. Using the local health fallback...`);
+        const fallback = buildFallbackReply(message, language, context);
+        responseText = fallback.text;
+        source = SOURCE_FALLBACK;
+        intent = fallback.intent;
       }
     }
 
-    logger.info(`Successful chat assistant response generated for user ${userId}`);
-    return jsonSuccess({ response: responseText })
+    // `source` lets the caller say so. A canned paragraph about heating pads
+    // was previously returned with the same shape and the same 200 as a
+    // generated answer, so neither the UI nor the user could tell that no
+    // model had read the question.
+    logger.info(`Chat response for user ${userId} (source: ${source}${intent ? `, intent: ${intent}` : ''})`);
+    return jsonSuccess({ response: responseText, source, ...(intent ? { intent } : {}) })
   } catch (error) {
     logger.error('AI Chat Route Error:', error);
-    const fallback = getSmartLocalResponse(json?.message || '', language, json?.context);
-    return jsonSuccess({ response: fallback })
+
+    // `requestBody` is hoisted, so this handler can actually run. It is still
+    // whatever the client sent — unvalidated, possibly null — which is why
+    // every accessor below tolerates that.
+    const fallback = buildFallbackReply(requestBody?.message, language, requestBody?.context);
+
+    // A server fault is reported as one. Returning 200 here made an outage
+    // indistinguishable from advice; the reply is still carried so the chat UI
+    // has something to show rather than an empty bubble.
+    return jsonError('The assistant is temporarily unavailable.', 503, 'ASSISTANT_UNAVAILABLE', {
+      response: fallback.text,
+      source: SOURCE_FALLBACK,
+      intent: fallback.intent,
+    })
   }
 }

--- a/components/layout/ChatFAB.jsx
+++ b/components/layout/ChatFAB.jsx
@@ -7,6 +7,7 @@ import { MessageCircle, X } from 'lucide-react'
 import ChatAssistant from '@/components/dashboard/ChatAssistant'
 import { useOffline } from '@/lib/OfflineContext'
 import fetchWithTimeout from '@/lib/fetch-with-timeout'
+import { readChatResponse } from '@/lib/chat-fallback'
 
 export default function ChatFAB() {
   const pathname = usePathname()
@@ -103,9 +104,16 @@ export default function ChatFAB() {
       })
       const data = await res.json()
       setIsTyping(false)
-      if (data.success) {
-        setChatMessages(prev => [...prev, { role: 'ai', text: data.response }])
-      }
+
+      // Read through `readChatResponse`, not `data.response`. The route was
+      // moved to the standard `jsonSuccess` envelope, which nests the reply
+      // under `data`, and this caller was never updated -- so `data.response`
+      // was `undefined` and every assistant turn rendered as an empty bubble.
+      const reply = readChatResponse(data)
+      setChatMessages(prev => [...prev, {
+        role: 'ai',
+        text: reply.text || tChat('error'),
+      }])
     } catch {
       setIsTyping(false)
       setChatMessages(prev => [...prev, {

--- a/lib/chat-fallback.js
+++ b/lib/chat-fallback.js
@@ -1,0 +1,387 @@
+/**
+ * chat-fallback.js — what the assistant says when no model answers.
+ *
+ * ## The bug this exists to prevent
+ *
+ * `app/api/chat/route.js` ended with a `catch` that read a variable declared
+ * inside the `try` it was catching for:
+ *
+ *     try {
+ *       ...
+ *       let json;                                    // <- block-scoped, in the try
+ *       try { json = await request.json(); } catch { ... }
+ *       ...
+ *     } catch (error) {
+ *       const fallback = getSmartLocalResponse(json?.message || '', language, json?.context);
+ *       //                                     ^^^^ ReferenceError
+ *     }
+ *
+ * `let` is block-scoped, and optional chaining does not rescue an undeclared
+ * binding — `json?.message` on one is a `ReferenceError`, not `undefined`. The
+ * handler written to keep the assistant answering when something went wrong was
+ * the one thing guaranteeing it could not: every trip through that `catch`
+ * threw, replacing the intended graceful reply with an unhandled rejection and
+ * a bare framework 500 that the chat page renders as nothing at all.
+ *
+ * The path is ordinary, not exotic. `getAuthUserId()` throws when Clerk cannot
+ * resolve a session — a rotated key, a clock-skewed JWT, a preview deployment
+ * missing `CLERK_SECRET_KEY` — and `getSupabaseAdmin()` throws without a
+ * service key. Both are precisely the situations the fallback exists for.
+ *
+ * ## What lives here
+ *
+ * The fallback's actual decisions: which intent a message expresses, which
+ * language to answer in, and which reply that pair selects. It was a
+ * module-private function inside a route handler, so the keyword matching that
+ * decides what a user in distress is told had no test coverage at all.
+ *
+ * ## Why matching is on word boundaries
+ *
+ * The original matcher used `String.prototype.includes`:
+ *
+ *     if (query.includes('hello') || query.includes('hi') || query.includes('hey') ...)
+ *
+ * `includes('hi')` is a substring test. "I have been feeling this way for a
+ * while", "my thighs ache", "which foods help", "is this normal" all contain
+ * `hi`. Those branches sit last, so they only fired when nothing earlier
+ * matched — but that residual case is the common one: any question that does
+ * not happen to name a symptom was answered "Hello! I am your HerCycle health
+ * assistant." rather than with health guidance.
+ *
+ * Boundaries here are Unicode-aware lookarounds rather than `\b`, because `\b`
+ * is defined over `[A-Za-z0-9_]` and would never sit correctly against
+ * Devanagari. That also lets the Hindi terms below participate in matching at
+ * all — under the old English-only keyword list, a question typed in Hindi
+ * could never match anything and always received the general reply.
+ *
+ * No imports, so this is usable from Route Handlers, Server Components, Client
+ * Components and plain Node scripts alike.
+ */
+
+/** The reply came from a model. */
+export const SOURCE_MODEL = 'model'
+
+/** The reply is canned — no model answered. */
+export const SOURCE_FALLBACK = 'fallback'
+
+/**
+ * Longest message the fallback matcher will scan.
+ *
+ * The route caps `message` at 2000 characters, so this is belt-and-braces for
+ * callers that reach this module directly (the error path can be entered with
+ * a body the schema never validated).
+ */
+export const MAX_FALLBACK_SCAN = 2000
+
+/** Most history turns forwarded to a provider. */
+export const MAX_HISTORY_TURNS = 20
+
+/** Longest single history turn kept, in characters. */
+export const MAX_HISTORY_TURN_CHARS = 2000
+
+/**
+ * Intents, in priority order.
+ *
+ * Order is explicit and data-driven rather than being the order a chain of
+ * `if`s happens to be written in — that ordering was load-bearing and
+ * invisible, which is how the greeting branch came to absorb every unmatched
+ * question.
+ *
+ * `greeting` sits last on purpose: a message that names a symptom *and* opens
+ * with "hi" is a symptom question.
+ */
+export const CHAT_INTENTS = Object.freeze([
+  {
+    key: 'nutrition',
+    terms: ['eat', 'eating', 'food', 'foods', 'nutrition', 'diet', 'snack', 'snacks', 'meal', 'meals',
+      'खाना', 'भोजन', 'आहार', 'पोषण'],
+  },
+  {
+    key: 'pain',
+    terms: ['cramp', 'cramps', 'cramping', 'pain', 'painful', 'ache', 'aches', 'aching', 'hurt', 'hurts', 'hurting',
+      'दर्द', 'ऐंठन'],
+  },
+  {
+    key: 'pcod',
+    terms: ['pcod', 'pcos', 'polycystic'],
+  },
+  {
+    key: 'prediction',
+    terms: ['next period', 'predicted', 'prediction', 'predict', 'due', 'when',
+      'कब', 'अगली'],
+  },
+  {
+    key: 'greeting',
+    terms: ['hello', 'hi', 'hey', 'hie', 'hiya', 'namaste',
+      'नमस्ते', 'हैलो'],
+  },
+])
+
+/** The intent used when nothing matches. */
+export const DEFAULT_INTENT = 'general'
+
+/**
+ * Reply table. English and Hindi are held side by side so a missing
+ * translation is visible at a glance rather than discovered at runtime.
+ *
+ * The strings are carried over verbatim from the route's private
+ * `getSmartLocalResponse`, so this change alters *when* a reply is chosen, not
+ * what it says.
+ */
+const REPLIES = Object.freeze({
+  nutrition: {
+    en: 'During your period, focus on iron-rich foods (spinach, lentils, pumpkin seeds), magnesium (dark chocolate), and warm herbal teas like ginger or chamomile. Stay hydrated and limit excess salt/sugar to minimize bloating! 🥗🍫',
+    hi: 'माहवारी के दौरान आयरन युक्त भोजन (जैसे पालक, दालें, मेवे), डार्क चॉकलेट और गर्म हर्बल चाय लें। प्रोसेस्ड और अत्यधिक नमकीन खाने से बचें।',
+  },
+  pain: {
+    en: 'For cramp relief, try a warm heating pad on your lower abdomen, gentle stretching/yoga, drinking warm chamomile or ginger tea, and staying hydrated. If severe, consult your doctor! 🌸',
+    hi: 'माहवारी के दर्द (क्रैम्प्स) में गर्म पानी की थैली (हीटिंग पैड) से सिकाई करें, पर्याप्त पानी पिएं और हल्के खिंचाव (स्ट्रेचिंग) करें। यदि दर्द अत्यधिक हो तो डॉक्टर से परामर्श लें।',
+  },
+  pcod: {
+    en: 'PCOD/PCOS is a common hormonal condition. It can be managed effectively with a low-glycemic balanced diet, regular exercise, consistent sleep, and medical guidance. 🩺',
+    hi: 'PCOD/PCOS एक हार्मोनल स्थिति है। संतुलित आहार, नियमित व्यायाम और तनाव प्रबंधन इसे नियंत्रित करने में सहायक होते हैं।',
+  },
+  greeting: {
+    en: 'Hello! I am your HerCycle health assistant. Ask me anything about your cycle, nutrition, symptoms, or wellness tips! 💕',
+    hi: 'नमस्ते! मैं आपकी स्वास्थ्य सहायक हूँ। आप मुझसे अपनी माहवारी, पोषण या स्वास्थ्य के बारे में कुछ भी पूछ सकती हैं। 💕',
+  },
+  general: {
+    en: 'I am here to support you with menstrual health, cycle tracking tips, nutrition, and symptom care. How can I help you today? 💕',
+    hi: 'मैं आपके स्वास्थ्य और माहवारी से जुड़े प्रश्नों में मदद के लिए यहाँ हूँ। अपनी माहवारी के लक्षण या सुझाव के बारे में पूछें। 💕',
+  },
+  /** `prediction` is context-dependent; see `predictionReply`. */
+  predictionKnown: {
+    en: (date) => `Based on your cycle history, your next period is predicted around ${date}. 💕`,
+    hi: (date) => `आपकी अगली माहवारी की अनुमानित तारीख ${date} है।`,
+  },
+  predictionUnknown: {
+    en: 'Keep tracking your daily cycle data so we can generate accurate predictions for your next period! 📅',
+    hi: 'नियमित रूप से अपनी माहवारी लॉग करें ताकि हम सटीक अनुमान लगा सकें।',
+  },
+})
+
+/** Escapes a literal term for embedding in a regular expression. */
+function escapeRegExp(term) {
+  return String(term).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+/**
+ * Builds a Unicode-aware whole-word matcher for a term list.
+ *
+ * `(?<![\p{L}\p{N}])` / `(?![\p{L}\p{N}])` rather than `\b`: `\b` is defined
+ * over `[A-Za-z0-9_]`, so it sits in the wrong places against Devanagari and
+ * would make every Hindi term either always or never match. The lookarounds
+ * are correct for both scripts, and they are what stops `thigh` reading as
+ * `hi` and `update` reading as `date`.
+ *
+ * Terms containing a space (`next period`) work unchanged — the boundary is
+ * only required at the two ends of the phrase.
+ */
+function buildTermMatcher(terms) {
+  const alternation = terms
+    .slice()
+    // Longest first, so `cramps` is preferred over `cramp` and the matched
+    // span is the full word rather than a prefix of it.
+    .sort((a, b) => b.length - a.length)
+    .map(escapeRegExp)
+    .join('|')
+
+  return new RegExp(`(?<![\\p{L}\\p{N}])(?:${alternation})(?![\\p{L}\\p{N}])`, 'iu')
+}
+
+/** Compiled once at module load, not per request. */
+const COMPILED_INTENTS = CHAT_INTENTS.map((intent) => ({
+  key: intent.key,
+  matcher: buildTermMatcher(intent.terms),
+}))
+
+/**
+ * Normalises the requested language to one this module can answer in.
+ *
+ * The route compared against both `'hi'` and the literal string `'हि'`, which
+ * is what the language switcher stores. Both are accepted here, along with
+ * region-tagged forms like `hi-IN`, and anything unrecognised falls back to
+ * English rather than producing an undefined reply.
+ *
+ * @param {unknown} raw
+ * @returns {'en'|'hi'}
+ */
+export function normaliseChatLanguage(raw) {
+  if (typeof raw !== 'string') return 'en'
+  const lowered = raw.trim().toLowerCase()
+  if (lowered === 'hi' || lowered === 'हि' || lowered === 'हिंदी' || lowered.startsWith('hi-')) return 'hi'
+  return 'en'
+}
+
+/**
+ * Classifies a message into one of `CHAT_INTENTS`, or `DEFAULT_INTENT`.
+ *
+ * Never throws: a non-string, an empty string and a message of any length all
+ * resolve to an intent, because this is the path taken when everything else
+ * has already failed.
+ *
+ * @param {unknown} message
+ * @returns {string} an intent key
+ */
+export function classifyChatIntent(message) {
+  if (typeof message !== 'string') return DEFAULT_INTENT
+
+  const scanned = message.slice(0, MAX_FALLBACK_SCAN)
+  if (scanned.trim() === '') return DEFAULT_INTENT
+
+  for (const intent of COMPILED_INTENTS) {
+    if (intent.matcher.test(scanned)) return intent.key
+  }
+
+  return DEFAULT_INTENT
+}
+
+/**
+ * The prediction reply, which is the one intent whose answer depends on
+ * context rather than on the message alone.
+ *
+ * @param {'en'|'hi'} language
+ * @param {object} context
+ * @returns {string}
+ */
+function predictionReply(language, context) {
+  const date = context?.nextPeriodDate
+  if (typeof date === 'string' && date.trim()) {
+    return REPLIES.predictionKnown[language](date.trim())
+  }
+  return REPLIES.predictionUnknown[language]
+}
+
+/**
+ * Selects the canned reply for a message.
+ *
+ * Returns the intent alongside the text so the caller can log which branch
+ * answered — previously unknowable, because the selection happened inside a
+ * chain of `if`s in a route handler.
+ *
+ * @param {unknown} message
+ * @param {unknown} rawLanguage
+ * @param {object} [context]
+ * @returns {{ text: string, intent: string, language: 'en'|'hi' }}
+ */
+export function buildFallbackReply(message, rawLanguage, context = {}) {
+  const language = normaliseChatLanguage(rawLanguage)
+  const intent = classifyChatIntent(message)
+
+  if (intent === 'prediction') {
+    return { text: predictionReply(language, context), intent, language }
+  }
+
+  const entry = REPLIES[intent] || REPLIES[DEFAULT_INTENT]
+  return { text: entry[language] || entry.en, intent, language }
+}
+
+/**
+ * Cleans a conversation history before it reaches a provider adapter.
+ *
+ * The route declared `history: z.array(z.any()).optional()` with no length cap
+ * and then mapped over it:
+ *
+ *     history.map(msg => ({ role: ..., parts: [{ text: msg.text || msg.content || '' }] }))
+ *
+ * A `null` element throws inside that map. The throw was caught, but it was
+ * caught by the *provider* handler — so a malformed history was charged as a
+ * Gemini failure, spent the Groq retry as well, and only then fell back. And
+ * because there was no cap, the whole array was parsed and mapped before
+ * `pruneMessageHistory` ever saw it.
+ *
+ * Unusable turns are dropped rather than rejected: a client that sends one bad
+ * turn should lose that turn, not the conversation.
+ *
+ * @param {unknown} history
+ * @returns {Array<{ role: string, text: string }>}
+ */
+export function normaliseChatHistory(history) {
+  if (!Array.isArray(history)) return []
+
+  const cleaned = []
+
+  for (const turn of history) {
+    if (!turn || typeof turn !== 'object') continue
+
+    const rawText = typeof turn.text === 'string'
+      ? turn.text
+      : typeof turn.content === 'string'
+        ? turn.content
+        : ''
+
+    const text = rawText.trim()
+    if (!text) continue
+
+    // Anything that is not explicitly the assistant is treated as the user.
+    // The two providers spell the assistant differently ('model' vs
+    // 'assistant'), so both are recognised and a single canonical value is
+    // emitted for the adapters to translate.
+    const role = turn.role === 'ai' || turn.role === 'model' || turn.role === 'assistant'
+      ? 'assistant'
+      : 'user'
+
+    cleaned.push({ role, text: text.slice(0, MAX_HISTORY_TURN_CHARS) })
+  }
+
+  // Keep the most recent turns: a conversation is truncated from the front,
+  // because the newest turns are the ones a follow-up question refers to.
+  return cleaned.slice(-MAX_HISTORY_TURNS)
+}
+
+/**
+ * Reads an assistant reply out of a `/api/chat` response body.
+ *
+ * ## Why this is needed
+ *
+ * Commit "api: Standardize JSON error and success envelope across all API
+ * routes" moved the route from
+ *
+ *     { response: '…' }
+ *
+ * to `jsonSuccess({ response })`, which nests it:
+ *
+ *     { success: true, data: { response: '…' } }
+ *
+ * None of the three callers were updated. `app/[locale]/chat/page.js` and
+ * `components/layout/ChatFAB.jsx` both do
+ *
+ *     if (data.success) setChatMessages(prev => [...prev, { role: 'ai', text: data.response }])
+ *
+ * and `app/[locale]/page.js` checks `data?.response`. In every case
+ * `data.response` is `undefined`: the first two append a message whose `text`
+ * is `undefined` — `ChatAssistant` renders `{msg.text}`, so the reply arrives
+ * as an **empty bubble** — and the third silently swaps in the generic error
+ * string for a reply that actually succeeded.
+ *
+ * Reading the payload in one place, tolerant of all three shapes, is what stops
+ * a fourth caller from making the same mistake.
+ *
+ * @param {unknown} payload the parsed response body
+ * @returns {{ ok: boolean, text: string|null, source: string|null, intent: string|null }}
+ */
+export function readChatResponse(payload) {
+  if (!payload || typeof payload !== 'object') {
+    return { ok: false, text: null, source: null, intent: null }
+  }
+
+  // A 503 carries the canned reply under `details`, so the UI has something to
+  // show rather than an empty bubble — but `ok` stays false, because no model
+  // read the question.
+  const envelope = payload.success === false ? payload.details : payload.data
+
+  // The bare `response` fallback covers a payload from before the envelope
+  // change, which an in-flight client or a cached response can still hold.
+  const text = typeof envelope?.response === 'string'
+    ? envelope.response
+    : typeof payload.response === 'string'
+      ? payload.response
+      : null
+
+  return {
+    ok: payload.success === true && typeof text === 'string' && text.length > 0,
+    text,
+    source: typeof envelope?.source === 'string' ? envelope.source : null,
+    intent: typeof envelope?.intent === 'string' ? envelope.intent : null,
+  }
+}

--- a/scripts/test-chat-fallback.js
+++ b/scripts/test-chat-fallback.js
@@ -1,0 +1,386 @@
+/**
+ * Regression suite for lib/chat-fallback.js.
+ *
+ * Three bugs are covered here, all in the same response path.
+ *
+ * 1. `app/api/chat/route.js` closed with a `catch` that read `json?.message`,
+ *    where `json` was declared with `let` *inside* the `try` it was catching
+ *    for. Optional chaining does not rescue an undeclared binding, so every
+ *    trip through that handler threw `ReferenceError: json is not defined` and
+ *    the fallback could never run.
+ *
+ * 2. The intent matcher used `String.prototype.includes`, so `includes('hi')`
+ *    matched "thigh", "which" and "this" -- any question that did not happen to
+ *    name a symptom was answered with the greeting.
+ *
+ * 3. The route was migrated to the standard `jsonSuccess` envelope, which
+ *    nests the reply under `data`, and none of the three callers were updated.
+ *    `data.response` was `undefined`, so `ChatAssistant` rendered `{msg.text}`
+ *    as an **empty bubble** on every assistant turn.
+ *
+ *   node scripts/test-chat-fallback.js
+ */
+
+import {
+  CHAT_INTENTS,
+  DEFAULT_INTENT,
+  MAX_HISTORY_TURNS,
+  MAX_HISTORY_TURN_CHARS,
+  SOURCE_FALLBACK,
+  SOURCE_MODEL,
+  buildFallbackReply,
+  classifyChatIntent,
+  normaliseChatHistory,
+  normaliseChatLanguage,
+  readChatResponse,
+} from '../lib/chat-fallback.js'
+
+let passed = 0
+let failed = 0
+
+function check(actual, expected, label) {
+  if (Object.is(actual, expected)) {
+    passed += 1
+    return
+  }
+  failed += 1
+  console.error(`FAIL ${label}\n  expected: ${JSON.stringify(expected)}\n  actual:   ${JSON.stringify(actual)}`)
+}
+
+function checkDeep(actual, expected, label) {
+  const a = JSON.stringify(actual)
+  const b = JSON.stringify(expected)
+  if (a === b) {
+    passed += 1
+    return
+  }
+  failed += 1
+  console.error(`FAIL ${label}\n  expected: ${b}\n  actual:   ${a}`)
+}
+
+// ---------------------------------------------------------------------------
+// normaliseChatLanguage
+// ---------------------------------------------------------------------------
+
+check(normaliseChatLanguage('hi'), 'hi', 'the ISO code selects Hindi')
+check(normaliseChatLanguage('हि'), 'hi', 'the Devanagari abbreviation the switcher stores selects Hindi')
+check(normaliseChatLanguage('हिंदी'), 'hi', 'the full Devanagari name selects Hindi')
+check(normaliseChatLanguage('hi-IN'), 'hi', 'a region-tagged code selects Hindi')
+check(normaliseChatLanguage('HI'), 'hi', 'language matching is case-insensitive')
+check(normaliseChatLanguage(' hi '), 'hi', 'surrounding whitespace is tolerated')
+check(normaliseChatLanguage('en'), 'en', 'English is English')
+check(normaliseChatLanguage('en-GB'), 'en', 'a region-tagged English code is English')
+check(normaliseChatLanguage('fr'), 'en', 'an unsupported language falls back to English')
+check(normaliseChatLanguage(''), 'en', 'an empty language falls back to English')
+check(normaliseChatLanguage(null), 'en', 'a null language falls back to English')
+check(normaliseChatLanguage(undefined), 'en', 'a missing language falls back to English')
+check(normaliseChatLanguage(42), 'en', 'a non-string language falls back to English')
+check(normaliseChatLanguage({}), 'en', 'an object language falls back to English')
+
+// ---------------------------------------------------------------------------
+// classifyChatIntent -- the substring false positives this rewrite exists for
+//
+// Every one of these was answered "Hello! I am your HerCycle health
+// assistant." by the old `query.includes('hi')` branch.
+// ---------------------------------------------------------------------------
+
+check(classifyChatIntent('is this normal'), 'general', '"this" is not a greeting')
+check(classifyChatIntent('my thighs ache'), 'pain', '"thighs" is not a greeting -- and "ache" is pain')
+check(classifyChatIntent('which vitamins should I take'), 'general', '"which" is not a greeting')
+check(classifyChatIntent('I have felt this way for a while'), 'general', '"while" is not a greeting')
+check(classifyChatIntent('should I take a shower'), 'general', '"shower" is not a greeting')
+check(classifyChatIntent('my chin is breaking out'), 'general', '"chin" is not a greeting')
+check(classifyChatIntent('anything else I should watch for'), 'general', '"thing" is not a greeting')
+
+// The greeting still works when it is actually a greeting.
+check(classifyChatIntent('hi'), 'greeting', 'a bare "hi" is a greeting')
+check(classifyChatIntent('Hi there!'), 'greeting', 'a greeting with punctuation is a greeting')
+check(classifyChatIntent('hello'), 'greeting', '"hello" is a greeting')
+check(classifyChatIntent('hey'), 'greeting', '"hey" is a greeting')
+check(classifyChatIntent('HEY'), 'greeting', 'greeting matching is case-insensitive')
+check(classifyChatIntent('namaste'), 'greeting', '"namaste" is a greeting')
+
+// Priority: a greeting that also names a symptom is a symptom question. Under
+// the old chain this happened to work, but only because of the order the `if`s
+// were written in -- ordering that was load-bearing and undocumented.
+check(classifyChatIntent('hi, I have terrible cramps'), 'pain', 'a symptom outranks an opening greeting')
+check(classifyChatIntent('hello! what should I eat'), 'nutrition', 'nutrition outranks an opening greeting')
+check(classifyChatIntent('hey, do I have pcod?'), 'pcod', 'pcod outranks an opening greeting')
+
+// Each intent, matched on its own terms.
+check(classifyChatIntent('what should I eat today'), 'nutrition', '"eat" is nutrition')
+check(classifyChatIntent('any good snacks?'), 'nutrition', '"snacks" is nutrition')
+check(classifyChatIntent('diet advice please'), 'nutrition', '"diet" is nutrition')
+check(classifyChatIntent('my cramps are unbearable'), 'pain', '"cramps" is pain')
+check(classifyChatIntent('everything hurts'), 'pain', '"hurts" is pain')
+check(classifyChatIntent('lower back pain'), 'pain', '"pain" is pain')
+check(classifyChatIntent('could this be PCOS?'), 'pcod', '"PCOS" is pcod')
+check(classifyChatIntent('polycystic ovaries'), 'pcod', '"polycystic" is pcod')
+check(classifyChatIntent('when is my next period'), 'prediction', '"next period" is prediction')
+check(classifyChatIntent('when will it start'), 'prediction', '"when" is prediction')
+
+// Substring-only occurrences must not match. `update` contains `date`;
+// `predicted` must not be reached through `dict`; `eaten` is not `eat`.
+check(classifyChatIntent('should I update the app'), 'general', '"update" does not match a prediction term')
+check(classifyChatIntent('I have not eaten anything'), 'general', '"eaten" is not the term "eat"')
+check(classifyChatIntent('my back is achy'), 'general', '"achy" is not the term "ache"')
+check(classifyChatIntent('champagne'), 'general', '"champagne" does not match "pain"')
+check(classifyChatIntent('spain'), 'general', '"spain" does not match "pain"')
+check(classifyChatIntent('hurtful comments'), 'general', '"hurtful" is not the term "hurt"')
+
+// Degenerate input. This path runs when everything else has already failed, so
+// it must never throw.
+check(classifyChatIntent(''), DEFAULT_INTENT, 'an empty message is the general intent')
+check(classifyChatIntent('   '), DEFAULT_INTENT, 'a whitespace message is the general intent')
+check(classifyChatIntent(null), DEFAULT_INTENT, 'a null message is the general intent')
+check(classifyChatIntent(undefined), DEFAULT_INTENT, 'an undefined message is the general intent')
+check(classifyChatIntent(12345), DEFAULT_INTENT, 'a numeric message is the general intent')
+check(classifyChatIntent({}), DEFAULT_INTENT, 'an object message is the general intent')
+check(classifyChatIntent([]), DEFAULT_INTENT, 'an array message is the general intent')
+check(classifyChatIntent('x'.repeat(50000)), DEFAULT_INTENT, 'an enormous message does not throw')
+check(
+  classifyChatIntent(`${'x'.repeat(5000)} cramps`),
+  DEFAULT_INTENT,
+  'matching stops at the scan cap rather than walking an unbounded string'
+)
+
+// Hindi. Under the English-only keyword list none of these could match, so a
+// user typing in Hindi always received the general reply.
+check(classifyChatIntent('मुझे बहुत दर्द हो रहा है'), 'pain', 'the Hindi word for pain is matched')
+check(classifyChatIntent('मुझे क्या खाना चाहिए'), 'nutrition', 'the Hindi word for food is matched')
+check(classifyChatIntent('नमस्ते'), 'greeting', 'the Hindi greeting is matched')
+check(classifyChatIntent('अगली माहवारी कब है'), 'prediction', 'the Hindi prediction question is matched')
+
+// ---------------------------------------------------------------------------
+// buildFallbackReply
+// ---------------------------------------------------------------------------
+
+const pain = buildFallbackReply('my cramps are bad', 'en')
+check(pain.intent, 'pain', 'the reply reports which intent answered')
+check(pain.language, 'en', 'the reply reports which language answered')
+check(pain.text.includes('heating pad'), true, 'the English pain reply is the cramp-relief text')
+
+const painHi = buildFallbackReply('my cramps are bad', 'hi')
+check(painHi.language, 'hi', 'the Hindi language is honoured')
+check(painHi.text.includes('हीटिंग पैड'), true, 'the Hindi pain reply is the Hindi cramp-relief text')
+check(painHi.text !== pain.text, true, 'the two languages produce different text')
+
+check(
+  buildFallbackReply('what should I eat', 'en').text.includes('iron-rich'),
+  true,
+  'the nutrition reply is the iron-rich text'
+)
+check(
+  buildFallbackReply('do I have pcod', 'en').text.includes('hormonal condition'),
+  true,
+  'the pcod reply is the hormonal-condition text'
+)
+check(
+  buildFallbackReply('anything at all', 'en').text.includes('menstrual health'),
+  true,
+  'the general reply is the support text'
+)
+
+// Prediction is the one context-dependent intent.
+const known = buildFallbackReply('when is my next period', 'en', { nextPeriodDate: 'Aug 14, 2026' })
+check(known.text.includes('Aug 14, 2026'), true, 'a known prediction date is quoted back')
+check(known.intent, 'prediction', 'a known prediction is still the prediction intent')
+
+const unknown = buildFallbackReply('when is my next period', 'en', {})
+check(unknown.text.includes('Keep tracking'), true, 'an unknown prediction asks the user to keep tracking')
+check(
+  buildFallbackReply('when is my next period', 'en', { nextPeriodDate: '   ' }).text.includes('Keep tracking'),
+  true,
+  'a blank prediction date counts as unknown'
+)
+check(
+  buildFallbackReply('when is my next period', 'en', { nextPeriodDate: 42 }).text.includes('Keep tracking'),
+  true,
+  'a non-string prediction date counts as unknown'
+)
+check(
+  buildFallbackReply('when is my next period', 'en', null).text.includes('Keep tracking'),
+  true,
+  'a null context counts as unknown'
+)
+check(
+  buildFallbackReply('when is my next period', 'hi', { nextPeriodDate: 'Aug 14, 2026' }).text.includes('Aug 14, 2026'),
+  true,
+  'the Hindi prediction reply also quotes the date'
+)
+
+// This is the exact call the repaired catch block makes, with the body the
+// route may never have parsed. It must not throw and must produce text.
+const fromBrokenRequest = buildFallbackReply(undefined, undefined, undefined)
+check(typeof fromBrokenRequest.text, 'string', 'the catch-path call produces text')
+check(fromBrokenRequest.text.length > 0, true, 'the catch-path reply is not empty')
+check(fromBrokenRequest.intent, DEFAULT_INTENT, 'the catch-path reply is the general intent')
+
+// Every intent must have text in both languages -- a missing translation would
+// otherwise surface at runtime as `undefined` in a chat bubble.
+for (const intent of [...CHAT_INTENTS.map((i) => i.key), DEFAULT_INTENT]) {
+  const sample = { nutrition: 'food', pain: 'cramps', pcod: 'pcod', prediction: 'when', greeting: 'hello', general: 'zzz' }[intent]
+  for (const lang of ['en', 'hi']) {
+    const reply = buildFallbackReply(sample, lang)
+    check(typeof reply.text === 'string' && reply.text.length > 0, true, `${intent}/${lang} has a reply`)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// normaliseChatHistory
+// ---------------------------------------------------------------------------
+
+checkDeep(normaliseChatHistory(undefined), [], 'a missing history is empty')
+checkDeep(normaliseChatHistory(null), [], 'a null history is empty')
+checkDeep(normaliseChatHistory('nope'), [], 'a non-array history is empty')
+checkDeep(normaliseChatHistory({}), [], 'an object history is empty')
+checkDeep(normaliseChatHistory([]), [], 'an empty history stays empty')
+
+// The element that used to throw inside the provider adapter's map -- and be
+// charged as a Gemini failure, spending the Groq retry before the local
+// fallback was reached.
+checkDeep(normaliseChatHistory([null]), [], 'a null turn is dropped, not thrown on')
+checkDeep(normaliseChatHistory([undefined]), [], 'an undefined turn is dropped')
+checkDeep(normaliseChatHistory(['just a string']), [], 'a bare string turn is dropped')
+checkDeep(normaliseChatHistory([{ role: 'user' }]), [], 'a turn with no text is dropped')
+checkDeep(normaliseChatHistory([{ role: 'user', text: '   ' }]), [], 'a whitespace-only turn is dropped')
+checkDeep(normaliseChatHistory([{ role: 'user', text: 42 }]), [], 'a non-string text is dropped')
+
+checkDeep(
+  normaliseChatHistory([{ role: 'user', text: 'hello' }]),
+  [{ role: 'user', text: 'hello' }],
+  'a user turn survives'
+)
+checkDeep(
+  normaliseChatHistory([{ role: 'user', content: 'hello' }]),
+  [{ role: 'user', text: 'hello' }],
+  'the Groq-style `content` key is read'
+)
+checkDeep(
+  normaliseChatHistory([{ role: 'ai', text: 'reply' }]),
+  [{ role: 'assistant', text: 'reply' }],
+  'the app-side role "ai" is canonicalised'
+)
+checkDeep(
+  normaliseChatHistory([{ role: 'model', text: 'reply' }]),
+  [{ role: 'assistant', text: 'reply' }],
+  'the Gemini-side role "model" is canonicalised'
+)
+checkDeep(
+  normaliseChatHistory([{ role: 'assistant', text: 'reply' }]),
+  [{ role: 'assistant', text: 'reply' }],
+  'the Groq-side role "assistant" is preserved'
+)
+checkDeep(
+  normaliseChatHistory([{ role: 'system', text: 'injected' }]),
+  [{ role: 'user', text: 'injected' }],
+  'an unexpected role is treated as the user, never as the assistant'
+)
+checkDeep(
+  normaliseChatHistory([{ text: ' padded ' }]),
+  [{ role: 'user', text: 'padded' }],
+  'turn text is trimmed'
+)
+
+const longTurn = normaliseChatHistory([{ role: 'user', text: 'x'.repeat(9999) }])
+check(longTurn[0].text.length, MAX_HISTORY_TURN_CHARS, 'an over-long turn is truncated')
+
+const manyTurns = normaliseChatHistory(
+  Array.from({ length: 60 }, (_, i) => ({ role: 'user', text: `turn ${i}` }))
+)
+check(manyTurns.length, MAX_HISTORY_TURNS, 'the history is capped')
+check(manyTurns[manyTurns.length - 1].text, 'turn 59', 'the cap keeps the most recent turns')
+check(
+  manyTurns[0].text,
+  `turn ${60 - MAX_HISTORY_TURNS}`,
+  'the cap truncates from the front, because a follow-up refers to recent turns'
+)
+
+const mixed = normaliseChatHistory([
+  { role: 'user', text: 'first' },
+  null,
+  { role: 'ai', text: 'second' },
+  { role: 'user', text: '' },
+  { role: 'user', content: 'third' },
+])
+checkDeep(
+  mixed,
+  [{ role: 'user', text: 'first' }, { role: 'assistant', text: 'second' }, { role: 'user', text: 'third' }],
+  'a mixed history keeps the usable turns in order and drops the rest'
+)
+
+// ---------------------------------------------------------------------------
+// readChatResponse -- the empty-bubble bug
+// ---------------------------------------------------------------------------
+
+checkDeep(
+  readChatResponse({ success: true, data: { response: 'here you go', source: SOURCE_MODEL } }),
+  { ok: true, text: 'here you go', source: SOURCE_MODEL, intent: null },
+  'a model reply is read out of the standard envelope'
+)
+checkDeep(
+  readChatResponse({ success: true, data: { response: 'canned', source: SOURCE_FALLBACK, intent: 'pain' } }),
+  { ok: true, text: 'canned', source: SOURCE_FALLBACK, intent: 'pain' },
+  'a canned reply is read, and reports itself as canned'
+)
+
+// The exact payload the callers were reading `data.response` from. Before this
+// helper, `text` here was `undefined` and the bubble rendered blank.
+check(
+  readChatResponse({ success: true, data: { response: 'nested' } }).text,
+  'nested',
+  'the nested reply is found -- this is the value the callers were missing'
+)
+
+// A payload from before the envelope change, which an in-flight client or a
+// cached response can still hold.
+check(
+  readChatResponse({ response: 'legacy shape' }).text,
+  'legacy shape',
+  'a pre-envelope payload is still readable'
+)
+
+// The 503 the repaired catch block returns: the reply is carried so the UI has
+// something to show, but `ok` stays false because no model read the question.
+const unavailable = readChatResponse({
+  success: false,
+  error: 'The assistant is temporarily unavailable.',
+  code: 'ASSISTANT_UNAVAILABLE',
+  details: { response: 'still here for you', source: SOURCE_FALLBACK, intent: 'general' },
+})
+check(unavailable.ok, false, 'a 503 is not reported as ok')
+check(unavailable.text, 'still here for you', 'a 503 still carries a reply for the UI')
+check(unavailable.source, SOURCE_FALLBACK, 'a 503 reports its reply as canned')
+
+checkDeep(
+  readChatResponse({ success: false, error: 'Unauthorized' }),
+  { ok: false, text: null, source: null, intent: null },
+  'an error with no reply yields no text'
+)
+checkDeep(
+  readChatResponse(null),
+  { ok: false, text: null, source: null, intent: null },
+  'a null payload is handled'
+)
+checkDeep(
+  readChatResponse(undefined),
+  { ok: false, text: null, source: null, intent: null },
+  'an undefined payload is handled'
+)
+checkDeep(
+  readChatResponse('not json'),
+  { ok: false, text: null, source: null, intent: null },
+  'a string payload is handled'
+)
+check(readChatResponse({ success: true, data: {} }).ok, false, 'a success with no reply is not ok')
+check(readChatResponse({ success: true, data: { response: '' } }).ok, false, 'an empty reply is not ok')
+check(
+  readChatResponse({ success: true, data: { response: 42 } }).text,
+  null,
+  'a non-string reply is refused rather than rendered'
+)
+
+// ---------------------------------------------------------------------------
+
+console.log(`${failed === 0 ? 'PASS' : 'FAIL'} ${passed} passed, ${failed} failed`)
+process.exit(failed === 0 ? 0 : 1)


### PR DESCRIPTION
## Linked Issue
Fixes #747

## Description

`app/api/chat/route.js` closed with a `catch` that read a variable declared inside the `try` it was catching for:

```js
try {
  ...
  let json;                                    // block-scoped, inside the try
  try { json = await request.json(); } catch { ... }
  ...
} catch (error) {
  const fallback = getSmartLocalResponse(json?.message || '', language, json?.context);
  //                                     ^^^^ ReferenceError
}
```

`let` is block-scoped, and optional chaining does not rescue an undeclared binding — `json?.message` on one is a `ReferenceError`, not `undefined`. The handler written to keep the assistant answering when something went wrong was the one thing guaranteeing it could not: every trip through it threw, replacing the intended graceful reply with an unhandled rejection and a bare framework 500.

```
node -e "function f(){ try { let json; throw new Error('x') } catch(e){ try { return json?.message } catch(err){ return 'ReferenceError: '+err.message } } }; console.log(f())"
ReferenceError: json is not defined
```

The path is ordinary, not exotic — `getAuthUserId()` throws when Clerk cannot resolve a session (a rotated key, a clock-skewed JWT, a preview deployment missing `CLERK_SECRET_KEY`), and `getSupabaseAdmin()` throws without a service key. Both are precisely the situations the fallback exists for.

### Also fixed: every assistant reply was rendering as an empty bubble

While tracing the response path I found a second, live defect in the same contract. Commit `0ec2edc` ("api: Standardize JSON error and success envelope across all API routes") moved this route from `{ response }` to `jsonSuccess({ response })`, which nests it:

```js
{ success: true, data: { response: '…' } }
```

None of the three callers were updated:

| Caller | Reads | Result |
|---|---|---|
| `app/[locale]/chat/page.js` | `if (data.success) … text: data.response` | appends a message whose `text` is `undefined` |
| `components/layout/ChatFAB.jsx` | same | same |
| `app/[locale]/page.js` | `if (data?.response)` | falls to the `else`, showing the generic error string for a reply that succeeded |

`ChatAssistant` renders `{msg.text}`, so on the chat page and in the floating widget **every assistant turn arrives as a blank bubble**, and on the home page every successful reply is replaced by "something went wrong". This is the visible symptom users would actually report, and it is the same root cause: the route's response contract had drifted away from its callers with nothing checking.

### The intent matcher answered ordinary questions with a greeting

```js
if (query.includes('hello') || query.includes('hi') || query.includes('hey') ...)
```

`includes('hi')` is a substring test. "is **thi**s normal", "my **thi**ghs ache", "**whi**ch foods help", "I have felt this way for a **whi**le" all contain `hi`. That branch sits last, so it only fired when nothing earlier matched — but that residual case is the common one: any question not happening to name a symptom was answered "Hello! I am your HerCycle health assistant." `update` likewise contains `date`.

### The fix

**`lib/chat-fallback.js` (new)** owns the fallback's actual decisions — intent, language, reply — which had been a module-private function inside a route handler, so the keyword matching that decides what a user in distress is told had no coverage at all. The reply strings are carried over verbatim: this changes *when* a reply is chosen, not what it says.

Matching is on **Unicode-aware lookarounds** (`(?<![\p{L}\p{N}])…(?![\p{L}\p{N}])`) rather than `\b`, because `\b` is defined over `[A-Za-z0-9_]` and sits in the wrong places against Devanagari. That is also what lets the Hindi terms participate at all — under the English-only keyword list a question typed in Hindi could never match anything and always received the general reply. Intent order is now explicit data rather than the order a chain of `if`s happens to be written in; that ordering was load-bearing and invisible.

**`readChatResponse`** reads the reply out of the standard envelope, the 503 envelope, and the pre-envelope shape an in-flight client can still hold — in one place, so a fourth caller cannot make the same mistake. All three callers now go through it.

**A provider outage answers 503, not 200.** Both fallback paths previously returned `jsonSuccess`, so a canned paragraph about heating pads was indistinguishable from a generated answer — the caller could not label it and the user could not know. The reply is still carried under `details` so the UI has something to show, and `source: 'model' | 'fallback'` says which is which.

**`history` is capped in the schema and normalised before dispatch.** It was `z.array(z.any()).optional()` with no limit; `pruneMessageHistory` trimmed it, but only after the whole array had been parsed and mapped — and a single `null` element threw inside `history.map(msg => msg.text || msg.content)`. That throw was caught by the *provider* handler, so a malformed history was charged as a Gemini failure, spent the Groq retry too, and only then fell back.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (clean code updates, no behavior modifications)
- [ ] Documentation update
- [ ] Performance optimization
- [ ] Security patch

## Files Modified

| File | Change |
|------|--------|
| `lib/chat-fallback.js` | **New.** Intent classification, reply table, language normalisation, history normalisation, `readChatResponse` |
| `app/api/chat/route.js` | Body hoisted above the catch that reads it; 503 for a genuine fault; `source`/`intent` on the reply; history capped and normalised |
| `app/[locale]/chat/page.js` | Reads the reply through `readChatResponse` (was rendering an empty bubble) |
| `components/layout/ChatFAB.jsx` | Same |
| `app/[locale]/page.js` | Same (was showing the error string for successful replies) |
| `scripts/test-chat-fallback.js` | **New.** 127 assertions |

## Testing

```bash
node scripts/test-chat-fallback.js
# PASS 127 passed, 0 failed

node scripts/test-chat-pruning.js
# ✅ All chat history pruning and token optimization tests passed successfully!

npx next build --webpack
# ✓ Compiled successfully in 11.3s
```

The suite pins every substring false positive by name — `this`, `thighs`, `which`, `while`, `shower`, `chin`, `anything`, `update`, `eaten`, `achy`, `champagne`, `spain`, `hurtful` — and asserts the greeting still matches when it is actually a greeting, and that a message opening with "hi" but naming a symptom resolves to the symptom. It covers both languages for every intent (so a missing translation cannot surface as `undefined` in a chat bubble), the context-dependent prediction branch, the exact `buildFallbackReply(undefined, undefined, undefined)` call the repaired catch makes, history normalisation including the `null` turn that used to throw inside the provider adapter, and `readChatResponse` against all three payload shapes — including the exact `{ success: true, data: { response } }` the callers were reading `data.response` from.

Manual:

1. Ask anything on **/chat** — the reply appears (previously an empty bubble).
2. Ask a question from the home page hero — the reply appears (previously "something went wrong").
3. With no `GEMINI_API_KEY` or `GROQ_API_KEY`, ask "is this normal" → the general health reply, not the greeting.
4. Ask in Hindi with no provider keys → the Hindi reply for the matching intent, not the general one.
5. Point `CLERK_SECRET_KEY` at a rotated value and post to `/api/chat` → `503` with a readable reply (previously an unhandled `ReferenceError` and a bare 500).

## Screenshots (if UI changes are made)
The visible change is that assistant replies now have text in them. No layout, styling or copy changes.

## Checklist
- [x] This PR is submitted under ECSOC.
- [x] Added the required **ECSoc26** label to this Pull Request.
- [x] Linked issue using `Fixes #747`.
- [x] Tested locally.
- [x] `npm run build` completes successfully.
- [x] No breaking changes introduced.
- [x] Documentation updated if required.
