### PR TITLE
[ECSoC26] Feat/compare this cycle

### DIFF
--- a/app/[locale]/insights/page.js
+++ b/app/[locale]/insights/page.js
@@ -16,6 +16,7 @@ import Footer from '@/components/layout/Footer'
 import { useOffline } from '@/lib/OfflineContext'
 import { useTranslations } from 'next-intl'
 import SymptomPhaseInsights from '@/components/dashboard/SymptomPhaseInsights'
+import CycleComparisonCard from '@/components/dashboard/CycleComparisonCard'
 import { formatDateForCSV } from '@/lib/utils'
 import { normaliseRiskResult } from '@/lib/pcod-risk-result'
 import { copyToClipboard } from '@/lib/clipboard'
@@ -627,6 +628,12 @@ const [cycleData, setCycleData] = useState(null)
             cycles={cycles}
             averageCycleLength={avgCycle}
             loading={loading}
+          />
+
+          {/* ── Compare This Cycle ── */}
+          <CycleComparisonCard
+            cycles={cycles}
+            dailyLogs={dailyLogs}
           />
 
           {/* ── Mood Distribution ── */}

--- a/components/dashboard/CycleComparisonCard.jsx
+++ b/components/dashboard/CycleComparisonCard.jsx
@@ -1,0 +1,216 @@
+'use client'
+
+/**
+ * CycleComparisonCard — "Compare This Cycle" insights card.
+ *
+ * Compares current cycle length and symptom activity against the user's
+ * previous 3 completed cycles.
+ */
+
+import { useMemo } from 'react'
+import { useTranslations } from 'next-intl'
+import { GitCompare, Calendar, Activity, Info } from 'lucide-react'
+import { compareCurrentCycle } from '@/lib/cycle-comparison'
+import SectionCard, { IconBadge } from '@/components/ui/SectionCard'
+import { THEME_COLORS, THEME_SURFACES, THEME_TEXT } from '@/lib/theme-constants'
+
+const PINK = THEME_COLORS.pink
+const MAUVE = THEME_COLORS.mauve
+const CARD_BG = THEME_SURFACES.cardBg
+const CARD_BORDER = THEME_SURFACES.cardBorder
+
+export default function CycleComparisonCard({ cycles = [], dailyLogs = [] }) {
+  const t = useTranslations('CycleComparison')
+
+  const comparison = useMemo(() => {
+    return compareCurrentCycle(cycles, dailyLogs)
+  }, [cycles, dailyLogs])
+
+  if (!comparison.hasEnoughData) {
+    return (
+      <SectionCard
+        title={t('title')}
+        subtitle={t('subtitle')}
+        icon={<GitCompare size={20} color={PINK} />}
+      >
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '0.75rem',
+            padding: '1.25rem',
+            background: 'rgba(255,255,255,0.04)',
+            border: '1px dashed rgba(255,255,255,0.15)',
+            borderRadius: 14,
+            color: 'var(--text-soft)',
+            fontSize: '0.9rem',
+          }}
+        >
+          <Info size={24} style={{ flexShrink: 0, color: PINK }} />
+          <span>{t('insufficientData')}</span>
+        </div>
+      </SectionCard>
+    )
+  }
+
+  const { currentCycle, previous3Avg, comparison: comp } = comparison
+
+  const getLengthBadge = () => {
+    if (comp.cycleLengthStatus === 'longer') {
+      return {
+        label: t('longerThanUsual', { diff: Math.abs(comp.cycleLengthDiff) }),
+        color: '#fbbf24',
+        bg: 'rgba(251,191,36,0.15)',
+        border: 'rgba(251,191,36,0.4)',
+      }
+    }
+    if (comp.cycleLengthStatus === 'shorter') {
+      return {
+        label: t('shorterThanUsual', { diff: Math.abs(comp.cycleLengthDiff) }),
+        color: '#6ee7b7',
+        bg: 'rgba(16,185,129,0.15)',
+        border: 'rgba(16,185,129,0.4)',
+      }
+    }
+    return {
+      label: t('sameAsUsual'),
+      color: 'rgba(255,255,255,0.85)',
+      bg: 'rgba(255,255,255,0.08)',
+      border: 'rgba(255,255,255,0.2)',
+    }
+  }
+
+  const getSymptomBadge = () => {
+    if (comp.symptomStatus === 'more') {
+      return {
+        label: t('moreSymptomsThanUsual', { diff: Math.abs(comp.symptomDiff) }),
+        color: '#f87171',
+        bg: 'rgba(248,113,113,0.15)',
+        border: 'rgba(248,113,113,0.4)',
+      }
+    }
+    if (comp.symptomStatus === 'fewer') {
+      return {
+        label: t('fewerSymptomsThanUsual', { diff: Math.abs(comp.symptomDiff) }),
+        color: '#34d399',
+        bg: 'rgba(52,211,153,0.15)',
+        border: 'rgba(52,211,153,0.4)',
+      }
+    }
+    return {
+      label: t('sameSymptomsAsUsual'),
+      color: 'rgba(255,255,255,0.85)',
+      bg: 'rgba(255,255,255,0.08)',
+      border: 'rgba(255,255,255,0.2)',
+    }
+  }
+
+  const lengthBadge = getLengthBadge()
+  const symptomBadge = getSymptomBadge()
+
+  return (
+    <SectionCard
+      title={t('title')}
+      subtitle={t('subtitle')}
+      icon={<GitCompare size={20} color={PINK} />}
+    >
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(260px, 1fr))',
+          gap: '1.25rem',
+        }}
+      >
+        {/* Metric 1: Cycle Length Comparison */}
+        <div
+          style={{
+            background: 'rgba(255,255,255,0.03)',
+            border: CARD_BORDER,
+            borderRadius: 14,
+            padding: '1.25rem',
+            display: 'flex',
+            flexDirection: 'column',
+            justify: 'space-between',
+          }}
+        >
+          <div>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
+              <IconBadge size="sm">
+                <Calendar size={14} color={PINK} />
+              </IconBadge>
+              <span style={{ fontSize: '0.85rem', fontWeight: 600, color: 'var(--text-soft)' }}>
+                {t('cycleLengthLabel')}
+              </span>
+            </div>
+            <div style={{ fontSize: '1.5rem', fontWeight: 700, color: THEME_TEXT.primary }}>
+              {t('currentDay', { day: currentCycle.cycleDay })}
+            </div>
+            <div style={{ fontSize: '0.8rem', color: 'rgba(255,255,255,0.6)', marginTop: 4 }}>
+              {t('prev3AvgDays', { avg: previous3Avg.cycleLength })}
+            </div>
+          </div>
+          <div
+            style={{
+              marginTop: '1rem',
+              padding: '6px 12px',
+              borderRadius: 20,
+              fontSize: '0.8rem',
+              fontWeight: 600,
+              color: lengthBadge.color,
+              background: lengthBadge.bg,
+              border: `1px solid ${lengthBadge.border}`,
+              width: 'fit-content',
+            }}
+          >
+            {lengthBadge.label}
+          </div>
+        </div>
+
+        {/* Metric 2: Symptom Activity Comparison */}
+        <div
+          style={{
+            background: 'rgba(255,255,255,0.03)',
+            border: CARD_BORDER,
+            borderRadius: 14,
+            padding: '1.25rem',
+            display: 'flex',
+            flexDirection: 'column',
+            justify: 'space-between',
+          }}
+        >
+          <div>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
+              <IconBadge size="sm">
+                <Activity size={14} color={MAUVE} />
+              </IconBadge>
+              <span style={{ fontSize: '0.85rem', fontWeight: 600, color: 'var(--text-soft)' }}>
+                {t('symptomActivityLabel')}
+              </span>
+            </div>
+            <div style={{ fontSize: '1.5rem', fontWeight: 700, color: THEME_TEXT.primary }}>
+              {t('currentSymptomsCount', { count: currentCycle.symptomCount })}
+            </div>
+            <div style={{ fontSize: '0.8rem', color: 'rgba(255,255,255,0.6)', marginTop: 4 }}>
+              {t('prev3AvgSymptoms', { avg: previous3Avg.symptomCount })}
+            </div>
+          </div>
+          <div
+            style={{
+              marginTop: '1rem',
+              padding: '6px 12px',
+              borderRadius: 20,
+              fontSize: '0.8rem',
+              fontWeight: 600,
+              color: symptomBadge.color,
+              background: symptomBadge.bg,
+              border: `1px solid ${symptomBadge.border}`,
+              width: 'fit-content',
+            }}
+          >
+            {symptomBadge.label}
+          </div>
+        </div>
+      </div>
+    </SectionCard>
+  )
+}

--- a/lib/cycle-comparison.js
+++ b/lib/cycle-comparison.js
@@ -1,0 +1,163 @@
+/**
+ * cycle-comparison.js — compares current active cycle against previous completed cycles.
+ *
+ * All functions here are pure and testable in plain Node without side effects.
+ */
+
+import { getTodayISO, isISODateString } from './date-utils.js'
+import { normalizeSymptomsList } from './symptom-correlation.js'
+
+function toLocalDay(dateVal) {
+  if (!dateVal) return null
+  const str = String(dateVal).slice(0, 10)
+  if (!isISODateString(str)) return null
+  const date = new Date(`${str}T00:00:00`)
+  if (Number.isNaN(date.getTime())) return null
+  date.setHours(0, 0, 0, 0)
+  return date
+}
+
+/**
+ * Calculates current cycle metrics and compares against previous 3 completed cycles.
+ *
+ * @param {Array<object>} cycles array of cycle records
+ * @param {Array<object>} dailyLogs array of daily log records
+ * @param {object} [options]
+ * @param {string} [options.today] YYYY-MM-DD date override for testing
+ * @returns {object} structured comparison object
+ */
+export function compareCurrentCycle(cycles, dailyLogs, options = {}) {
+  const todayISO = options.today || getTodayISO()
+  const todayDate = toLocalDay(todayISO)
+
+  if (!todayDate) {
+    return {
+      hasEnoughData: false,
+      completedCount: 0,
+      currentCycle: null,
+      previous3Avg: null,
+      comparison: null,
+    }
+  }
+
+  const safeCycles = Array.isArray(cycles)
+    ? cycles.filter((c) => c && toLocalDay(c.start_date || c.period_start))
+    : []
+
+  // Sort cycles descending by start date (newest first)
+  const sortedCycles = [...safeCycles].sort((a, b) => {
+    const aTime = toLocalDay(a.start_date || a.period_start).getTime()
+    const bTime = toLocalDay(b.start_date || b.period_start).getTime()
+    return bTime - aTime
+  })
+
+  // We need at least 1 current cycle + at least 3 completed previous cycles (total >= 4 cycles)
+  if (sortedCycles.length < 4) {
+    return {
+      hasEnoughData: false,
+      completedCount: Math.max(0, sortedCycles.length - 1),
+      currentCycle: null,
+      previous3Avg: null,
+      comparison: null,
+    }
+  }
+
+  const currentCycleObj = sortedCycles[0]
+  const currentStartDate = toLocalDay(currentCycleObj.start_date || currentCycleObj.period_start)
+
+  // Current cycle elapsed days (1-indexed)
+  const daysElapsed = Math.max(
+    1,
+    Math.floor((todayDate.getTime() - currentStartDate.getTime()) / (24 * 60 * 60 * 1000)) + 1
+  )
+
+  // Previous 3 completed cycles
+  const prev3Cycles = sortedCycles.slice(1, 4)
+
+  // Calculate average length of previous 3 completed cycles
+  const prev3Lengths = prev3Cycles.map((c, index) => {
+    if (
+      Number.isFinite(Number(c.cycle_length)) &&
+      Number(c.cycle_length) >= 15 &&
+      Number(c.cycle_length) <= 90
+    ) {
+      return Number(c.cycle_length)
+    }
+
+    const thisStart = toLocalDay(c.start_date || c.period_start)
+    const nextStart = toLocalDay(sortedCycles[index].start_date || sortedCycles[index].period_start)
+    if (thisStart && nextStart) {
+      const diffDays = Math.round((nextStart.getTime() - thisStart.getTime()) / (24 * 60 * 60 * 1000))
+      return Math.min(90, Math.max(15, diffDays))
+    }
+    return 28
+  })
+
+  const avgPrev3CycleLength =
+    Math.round((prev3Lengths.reduce((a, b) => a + b, 0) / prev3Lengths.length) * 10) / 10
+
+  // Calculate symptoms per cycle from daily logs
+  const safeLogs = Array.isArray(dailyLogs) ? dailyLogs.filter((l) => l && l.date) : []
+
+  // Count symptoms for current cycle
+  let currentSymptomCount = 0
+  safeLogs.forEach((log) => {
+    const logDate = toLocalDay(log.date)
+    if (!logDate) return
+    if (logDate.getTime() >= currentStartDate.getTime() && logDate.getTime() <= todayDate.getTime()) {
+      const symptoms = normalizeSymptomsList(log.symptoms)
+      currentSymptomCount += symptoms.length
+    }
+  })
+
+  // Count symptoms for each of the 3 previous completed cycles
+  const prev3SymptomCounts = prev3Cycles.map((c, idx) => {
+    const start = toLocalDay(c.start_date || c.period_start)
+    const end = toLocalDay(sortedCycles[idx].start_date || sortedCycles[idx].period_start)
+    let count = 0
+    safeLogs.forEach((log) => {
+      const logDate = toLocalDay(log.date)
+      if (!logDate) return
+      if (logDate.getTime() >= start.getTime() && logDate.getTime() < end.getTime()) {
+        const symptoms = normalizeSymptomsList(log.symptoms)
+        count += symptoms.length
+      }
+    })
+    return count
+  })
+
+  const avgPrev3SymptomCount =
+    Math.round((prev3SymptomCounts.reduce((a, b) => a + b, 0) / prev3SymptomCounts.length) * 10) / 10
+
+  // Comparisons
+  const cycleLengthDiff = Math.round((daysElapsed - avgPrev3CycleLength) * 10) / 10
+  let cycleLengthStatus = 'same'
+  if (cycleLengthDiff >= 2) cycleLengthStatus = 'longer'
+  else if (cycleLengthDiff <= -2) cycleLengthStatus = 'shorter'
+
+  const symptomDiff = Math.round((currentSymptomCount - avgPrev3SymptomCount) * 10) / 10
+  let symptomStatus = 'same'
+  if (symptomDiff >= 1) symptomStatus = 'more'
+  else if (symptomDiff <= -1) symptomStatus = 'fewer'
+
+  return {
+    hasEnoughData: true,
+    completedCount: sortedCycles.length - 1,
+    currentCycle: {
+      startDate: String(currentCycleObj.start_date || currentCycleObj.period_start).slice(0, 10),
+      cycleDay: daysElapsed,
+      symptomCount: currentSymptomCount,
+    },
+    previous3Avg: {
+      cycleLength: avgPrev3CycleLength,
+      symptomCount: avgPrev3SymptomCount,
+      completedCyclesCount: prev3Cycles.length,
+    },
+    comparison: {
+      cycleLengthDiff,
+      cycleLengthStatus,
+      symptomDiff,
+      symptomStatus,
+    },
+  }
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -734,5 +734,22 @@
     "confidence_moderate": "Some evidence",
     "confidence_low": "Early signal",
     "disclaimer": "These are patterns in what you logged, not a medical finding. Share them with a clinician rather than acting on them alone."
+  },
+  "CycleComparison": {
+    "title": "Compare This Cycle",
+    "subtitle": "How your current cycle compares against your previous 3 completed cycles.",
+    "insufficientData": "Log more cycles to see how your current cycle compares with your usual pattern.",
+    "cycleLengthLabel": "Cycle Length",
+    "symptomActivityLabel": "Symptom Activity",
+    "currentDay": "Day {day}",
+    "prev3AvgDays": "Previous 3-cycle avg: {avg} days",
+    "currentSymptomsCount": "{count} symptoms",
+    "prev3AvgSymptoms": "Previous 3-cycle avg: {avg} symptoms",
+    "longerThanUsual": "{diff} day(s) longer than usual",
+    "shorterThanUsual": "{diff} day(s) shorter than usual",
+    "sameAsUsual": "Approximately the same as usual",
+    "moreSymptomsThanUsual": "{diff} more symptoms than usual",
+    "fewerSymptomsThanUsual": "{diff} fewer symptoms than usual",
+    "sameSymptomsAsUsual": "Approximately the same symptom count"
   }
 }

--- a/messages/hi.json
+++ b/messages/hi.json
@@ -734,5 +734,22 @@
     "confidence_moderate": "कुछ प्रमाण",
     "confidence_low": "शुरुआती संकेत",
     "disclaimer": "ये आपके लॉग किए गए डेटा के पैटर्न हैं, कोई चिकित्सकीय निष्कर्ष नहीं। इन पर स्वयं कार्रवाई करने के बजाय इन्हें डॉक्टर के साथ साझा करें।"
+  },
+  "CycleComparison": {
+    "title": "इस चक्र की तुलना करें",
+    "subtitle": "आपका वर्तमान चक्र आपके पिछले 3 पूर्ण चक्रों की तुलना में कैसा है।",
+    "insufficientData": "यह देखने के लिए कि आपका वर्तमान चक्र आपके सामान्य पैटर्न से कैसे तुलना करता है, और अधिक चक्र दर्ज करें।",
+    "cycleLengthLabel": "चक्र अवधि",
+    "symptomActivityLabel": "लक्षण गतिविधि",
+    "currentDay": "दिन {day}",
+    "prev3AvgDays": "पिछले 3 चक्रों का औसत: {avg} दिन",
+    "currentSymptomsCount": "{count} लक्षण",
+    "prev3AvgSymptoms": "पिछले 3 चक्रों का औसत: {avg} लक्षण",
+    "longerThanUsual": "सामान्य से {diff} दिन लंबा",
+    "shorterThanUsual": "सामान्य से {diff} दिन छोटा",
+    "sameAsUsual": "सामान्य के लगभग समान",
+    "moreSymptomsThanUsual": "सामान्य से {diff} अधिक लक्षण",
+    "fewerSymptomsThanUsual": "सामान्य से {diff} कम लक्षण",
+    "sameSymptomsAsUsual": "सामान्य लक्षणों की संख्या के लगभग समान"
   }
 }

--- a/scripts/test-cycle-comparison.js
+++ b/scripts/test-cycle-comparison.js
@@ -1,0 +1,125 @@
+/**
+ * Unit test suite for lib/cycle-comparison.js
+ *
+ * Runs with:
+ *   node scripts/test-cycle-comparison.js
+ */
+
+import { compareCurrentCycle } from '../lib/cycle-comparison.js'
+
+let passed = 0
+let failed = 0
+
+function check(actual, expected, label) {
+  if (Object.is(actual, expected)) {
+    passed += 1
+    return
+  }
+  failed += 1
+  console.error(`  FAIL: ${label}`)
+  console.error(`       expected: ${JSON.stringify(expected)}`)
+  console.error(`       actual:   ${JSON.stringify(actual)}`)
+}
+
+console.log('\n--- Running Cycle Comparison Utility Tests ---')
+
+// 1. Insufficient data (< 4 total cycles)
+{
+  const cycles = [
+    { start_date: '2026-08-01', cycle_length: 28 },
+    { start_date: '2026-07-04', cycle_length: 28 },
+  ]
+  const res = compareCurrentCycle(cycles, [], { today: '2026-08-15' })
+  check(res.hasEnoughData, false, 'Insufficient data when only 2 cycles exist')
+  check(res.completedCount, 1, 'Completed count is 1')
+}
+
+// 2. Sufficient data with 4 cycles (1 active + 3 completed)
+{
+  const cycles = [
+    { start_date: '2026-08-01', cycle_length: 28 }, // Current cycle (Day 15 on Aug 15)
+    { start_date: '2026-07-04', cycle_length: 28 }, // Completed 1
+    { start_date: '2026-06-06', cycle_length: 28 }, // Completed 2
+    { start_date: '2026-05-09', cycle_length: 28 }, // Completed 3
+  ]
+
+  const dailyLogs = [
+    // Current cycle logs (Aug 1 to Aug 15): 4 symptoms
+    { date: '2026-08-02', symptoms: ['Cramps', 'Fatigue'] },
+    { date: '2026-08-10', symptoms: ['Headache', 'Bloating'] },
+
+    // Completed 1 logs (Jul 4 to Aug 1): 4 symptoms
+    { date: '2026-07-05', symptoms: ['Cramps', 'Fatigue'] },
+    { date: '2026-07-20', symptoms: ['Headache', 'Bloating'] },
+
+    // Completed 2 logs (Jun 6 to Jul 4): 4 symptoms
+    { date: '2026-06-07', symptoms: ['Cramps', 'Fatigue'] },
+    { date: '2026-06-22', symptoms: ['Headache', 'Bloating'] },
+
+    // Completed 3 logs (May 9 to Jun 6): 4 symptoms
+    { date: '2026-05-10', symptoms: ['Cramps', 'Fatigue'] },
+    { date: '2026-05-25', symptoms: ['Headache', 'Bloating'] },
+  ]
+
+  const res = compareCurrentCycle(cycles, dailyLogs, { today: '2026-08-15' })
+  check(res.hasEnoughData, true, 'Sufficient data with 4 cycles')
+  check(res.currentCycle.cycleDay, 15, 'Current cycle day is 15')
+  check(res.previous3Avg.cycleLength, 28, 'Previous 3 avg cycle length is 28')
+  check(res.currentCycle.symptomCount, 4, 'Current symptom count is 4')
+  check(res.previous3Avg.symptomCount, 4, 'Previous 3 avg symptom count is 4')
+  check(res.comparison.cycleLengthStatus, 'shorter', 'Day 15 vs 28 is shorter')
+  check(res.comparison.symptomStatus, 'same', '4 vs 4 symptoms is same')
+}
+
+// 3. Longer cycle length status test
+{
+  const cycles = [
+    { start_date: '2026-07-01', cycle_length: 28 }, // Day 35 on Aug 4
+    { start_date: '2026-06-03', cycle_length: 28 },
+    { start_date: '2026-05-06', cycle_length: 28 },
+    { start_date: '2026-04-08', cycle_length: 28 },
+  ]
+
+  const res = compareCurrentCycle(cycles, [], { today: '2026-08-04' })
+  check(res.hasEnoughData, true, 'Sufficient data')
+  check(res.currentCycle.cycleDay, 35, 'Day 35')
+  check(res.comparison.cycleLengthDiff, 7, 'Diff is +7 days')
+  check(res.comparison.cycleLengthStatus, 'longer', 'Cycle day 35 vs avg 28 is longer')
+}
+
+// 4. More symptoms & fewer symptoms test
+{
+  const cycles = [
+    { start_date: '2026-08-01', cycle_length: 28 },
+    { start_date: '2026-07-04', cycle_length: 28 },
+    { start_date: '2026-06-06', cycle_length: 28 },
+    { start_date: '2026-05-09', cycle_length: 28 },
+  ]
+
+  // Completed cycles had 2 symptoms each (avg = 2)
+  // Current cycle has 5 symptoms
+  const logsMore = [
+    { date: '2026-08-02', symptoms: ['Cramps', 'Fatigue', 'Acne', 'Bloating', 'Nausea'] },
+    { date: '2026-07-05', symptoms: ['Cramps', 'Fatigue'] },
+    { date: '2026-06-07', symptoms: ['Cramps', 'Fatigue'] },
+    { date: '2026-05-10', symptoms: ['Cramps', 'Fatigue'] },
+  ]
+
+  const resMore = compareCurrentCycle(cycles, logsMore, { today: '2026-08-15' })
+  check(resMore.comparison.symptomStatus, 'more', '5 symptoms vs avg 2 is more')
+
+  // Current cycle has 0 symptoms
+  const logsFewer = [
+    { date: '2026-07-05', symptoms: ['Cramps', 'Fatigue'] },
+    { date: '2026-06-07', symptoms: ['Cramps', 'Fatigue'] },
+    { date: '2026-05-10', symptoms: ['Cramps', 'Fatigue'] },
+  ]
+
+  const resFewer = compareCurrentCycle(cycles, logsFewer, { today: '2026-08-15' })
+  check(resFewer.comparison.symptomStatus, 'fewer', '0 symptoms vs avg 2 is fewer')
+}
+
+console.log(`\nResults: ${passed} passed, ${failed} failed.\n`)
+if (failed > 0) {
+  process.exit(1)
+}


### PR DESCRIPTION
## Summary

- Add a "Compare This Cycle" widget to the Insights page
- Compare current cycle length with the previous 3-cycle average
- Compare current symptom activity with the previous 3-cycle average
- Add graceful handling for insufficient cycle data
- Add a pure cycle comparison utility
- Add English and Hindi localization
- Add tests for the cycle comparison logic

## Issue

Fixes #769

## Testing

- Tested cycle comparison calculations
- Tested insufficient-data scenarios
- Tested current cycle and previous completed cycles
- Tested symptom activity comparison
- Verified English and Hindi translations
- Verified the application build

## Checklist

- [x] Changes are limited to Issue #769
- [x] `Fixes #769` included
- [x] Tests/build checked
- [ ] Add `ECSoc26` label