### PR TITLE
[ECSoC26] Calendar: honour the selected time zone and stop monthly recurrences skipping short months

### DIFF
--- a/app/api/events/route.js
+++ b/app/api/events/route.js
@@ -1,233 +1,278 @@
-import { NextResponse } from 'next/server';
 import { getAuthUserId } from '@/lib/clerk-server';
 import { getSupabaseAdmin } from '@/lib/supabase-admin';
 import { crudLimiter } from '@/lib/rateLimiter';
 import { logger } from '@/lib/logger';
+import { jsonSuccess, jsonError } from '@/lib/api-helpers';
+import {
+  MAX_EVENTS_RETURNED,
+  describeEventError,
+  isUuid,
+  readDeleteResult,
+  validateEventInput,
+} from '@/lib/event-schedule';
 
 export const dynamic = 'force-dynamic';
 
-export async function GET(req) {
+/** Columns the client is allowed to read back. */
+const EVENT_COLUMNS =
+  'id, title, description, start_time, end_time, recurrence_rule, category, time_zone, created_at';
+
+/**
+ * Rate-limits one request, returning a response when the caller is over budget.
+ *
+ * @param {Request} request
+ * @param {string} method for the log line
+ * @returns {Promise<Response|null>}
+ */
+async function checkRateLimit(request, method) {
+  try {
+    await crudLimiter.check(request);
+    return null;
+  } catch (rateLimitError) {
+    logger.warn(`[Rate Limit] Events ${method}: ${rateLimitError.message}`);
+    return jsonError('Too many requests, please slow down.', 429);
+  }
+}
+
+/**
+ * Turns a Supabase error into a client-safe response and logs the real one.
+ *
+ * Every branch of this route used to answer `500 Failed to <verb> event` for
+ * everything, including an `id` that was not a UUID and a row that simply did
+ * not exist. Both are client mistakes, and reporting them as server faults hid
+ * the difference from the calendar, which then had nothing useful to say.
+ *
+ * @param {object} error the Supabase error
+ * @param {string} context for the log line
+ * @param {string} userId
+ * @returns {Response}
+ */
+function respondToDatabaseError(error, context, userId) {
+  const described = describeEventError(error);
+  logger.error(
+    `[Events ${context}] ${described.code} for ${userId}: ${error?.message || 'unknown error'}`
+  );
+  return jsonError(described.message, described.status, described.code);
+}
+
+/**
+ * Lists the caller's events, newest first, bounded.
+ *
+ * The old handler had no `.limit()`, so an account with two years of daily
+ * reminders shipped its entire history on every page load to render one month.
+ */
+export async function GET(request) {
+  const limited = await checkRateLimit(request, 'GET');
+  if (limited) return limited;
+
   try {
     const userId = await getAuthUserId();
     if (!userId) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+      return jsonError('Unauthorized', 401);
     }
 
     const supabase = getSupabaseAdmin();
     const { data: events, error } = await supabase
       .from('events')
-      .select('*')
+      .select(EVENT_COLUMNS)
       .eq('user_id', userId)
-      .order('start_time', { ascending: true });
+      .order('start_time', { ascending: false })
+      .limit(MAX_EVENTS_RETURNED);
 
     if (error) {
-      logger.error(`[Events GET] Error fetching events for ${userId}: ${error.message}`);
-      return NextResponse.json({ error: 'Failed to fetch events' }, { status: 500 });
+      return respondToDatabaseError(error, 'GET', userId);
     }
 
-    return NextResponse.json({ success: true, events: events || [] });
+    const rows = events || [];
+    return jsonSuccess({
+      events: rows,
+      truncated: rows.length >= MAX_EVENTS_RETURNED,
+      limit: MAX_EVENTS_RETURNED,
+    });
   } catch (error) {
     logger.error(`[Events GET] Exception: ${error.message || error}`);
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+    return jsonError('Failed to load your calendar', 500);
   }
 }
 
-const ALLOWED_CATEGORIES = ['reminder', 'habit', 'donation', 'health'];
-const ALLOWED_RECURRENCE = ['none', 'daily', 'weekly', 'monthly', 'yearly'];
-
-function isValidDate(dateStr) {
-  if (!dateStr || typeof dateStr !== 'string') return false;
-  const time = new Date(dateStr).getTime();
-  return !Number.isNaN(time);
-}
-
-export async function POST(req) {
-  try {
-    await crudLimiter.check(req);
-  } catch (rateLimitError) {
-    return NextResponse.json({ error: 'Too many requests, please slow down.' }, { status: 429 });
-  }
+export async function POST(request) {
+  const limited = await checkRateLimit(request, 'POST');
+  if (limited) return limited;
 
   try {
     const userId = await getAuthUserId();
     if (!userId) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+      return jsonError('Unauthorized', 401);
     }
 
     let body;
     try {
-      body = await req.json();
-    } catch (parseErr) {
-      return NextResponse.json({ error: 'Invalid JSON payload' }, { status: 400 });
+      body = await request.json();
+    } catch (parseError) {
+      logger.warn(`Malformed JSON payload in events POST: ${parseError.message}`);
+      return jsonError('Bad Request: Invalid JSON payload', 400);
     }
 
-    const {
-      title,
-      description = '',
-      start_time,
-      end_time = null,
-      recurrence_rule = 'none',
-      category = 'reminder',
-      time_zone = 'UTC',
-    } = body;
-
-    if (!title || typeof title !== 'string' || !title.trim()) {
-      return NextResponse.json({ error: 'Event title is required' }, { status: 400 });
+    const parsed = validateEventInput(body);
+    if (!parsed.ok) {
+      return jsonError(parsed.error.message, parsed.error.status, 'INVALID_INPUT', {
+        field: parsed.error.field,
+      });
     }
-
-    if (!start_time || !isValidDate(start_time)) {
-      return NextResponse.json({ error: 'Valid event start time is required' }, { status: 400 });
-    }
-
-    if (end_time && !isValidDate(end_time)) {
-      return NextResponse.json({ error: 'Invalid event end time' }, { status: 400 });
-    }
-
-    const validCategory = ALLOWED_CATEGORIES.includes(category) ? category : 'reminder';
-    const validRecurrence = ALLOWED_RECURRENCE.includes(recurrence_rule) ? recurrence_rule : 'none';
 
     const supabase = getSupabaseAdmin();
     const { data: event, error } = await supabase
       .from('events')
-      .insert([
-        {
-          user_id: userId,
-          title: title.trim(),
-          description: typeof description === 'string' ? description.trim() : '',
-          start_time,
-          end_time: end_time || null,
-          recurrence_rule: validRecurrence,
-          category: validCategory,
-          time_zone: typeof time_zone === 'string' ? time_zone : 'UTC',
-          created_at: new Date().toISOString(),
-        },
-      ])
-      .select()
+      .insert([{ ...parsed.value, user_id: userId, created_at: new Date().toISOString() }])
+      .select(EVENT_COLUMNS)
       .single();
 
     if (error) {
-      logger.error(`[Events POST] Error creating event for ${userId}: ${error.message}`);
-      return NextResponse.json({ error: 'Failed to create event' }, { status: 500 });
+      return respondToDatabaseError(error, 'POST', userId);
     }
 
-    return NextResponse.json({ success: true, event }, { status: 201 });
+    return jsonSuccess({ event }, { status: 201 });
   } catch (error) {
     logger.error(`[Events POST] Exception: ${error.message || error}`);
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+    return jsonError('Failed to create the event', 500);
   }
 }
 
-export async function PUT(req) {
-  try {
-    await crudLimiter.check(req);
-  } catch (rateLimitError) {
-    return NextResponse.json({ error: 'Too many requests, please slow down.' }, { status: 429 });
-  }
+/**
+ * Applies a partial update.
+ *
+ * Two things changed beyond validation. The `id` is checked against the UUID
+ * shape before the query, because `events.id` is a `UUID` column and anything
+ * else makes Postgres raise `22P02` — previously reported as a 500. And the
+ * stored row is read first, so `end_time > start_time` can still be enforced
+ * when the payload only carries one of the two.
+ */
+export async function PUT(request) {
+  const limited = await checkRateLimit(request, 'PUT');
+  if (limited) return limited;
 
   try {
     const userId = await getAuthUserId();
     if (!userId) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+      return jsonError('Unauthorized', 401);
     }
 
     let body;
     try {
-      body = await req.json();
-    } catch (e) {
-      return NextResponse.json({ error: 'Invalid JSON payload' }, { status: 400 });
+      body = await request.json();
+    } catch (parseError) {
+      logger.warn(`Malformed JSON payload in events PUT: ${parseError.message}`);
+      return jsonError('Bad Request: Invalid JSON payload', 400);
     }
 
-    const { id, title, description, start_time, end_time, recurrence_rule, category, time_zone } = body;
-
+    const id = typeof body?.id === 'string' ? body.id.trim() : '';
     if (!id) {
-      return NextResponse.json({ error: 'Event ID is required' }, { status: 400 });
+      return jsonError('Event ID is required', 400, 'MISSING_EVENT_ID');
     }
-
-    if (start_time !== undefined && !isValidDate(start_time)) {
-      return NextResponse.json({ error: 'Invalid event start time' }, { status: 400 });
-    }
-
-    if (end_time !== undefined && end_time !== null && !isValidDate(end_time)) {
-      return NextResponse.json({ error: 'Invalid event end time' }, { status: 400 });
+    if (!isUuid(id)) {
+      return jsonError('Event ID is not a valid identifier', 400, 'INVALID_EVENT_ID');
     }
 
     const supabase = getSupabaseAdmin();
-    const updatePayload = {};
 
-    if (title !== undefined) updatePayload.title = typeof title === 'string' ? title.trim() : '';
-    if (description !== undefined) updatePayload.description = typeof description === 'string' ? description.trim() : '';
-    if (start_time !== undefined) updatePayload.start_time = start_time;
-    if (end_time !== undefined) updatePayload.end_time = end_time;
-    if (recurrence_rule !== undefined) {
-      updatePayload.recurrence_rule = ALLOWED_RECURRENCE.includes(recurrence_rule) ? recurrence_rule : 'none';
+    const { data: current, error: readError } = await supabase
+      .from('events')
+      .select('start_time, end_time')
+      .eq('id', id)
+      .eq('user_id', userId)
+      .maybeSingle();
+
+    if (readError) {
+      return respondToDatabaseError(readError, 'PUT', userId);
     }
-    if (category !== undefined) {
-      updatePayload.category = ALLOWED_CATEGORIES.includes(category) ? category : 'reminder';
+    if (!current) {
+      // `.eq('user_id', ...)` already scopes the lookup, so "no row" covers both
+      // "deleted" and "someone else's" without telling the caller which.
+      return jsonError('Event not found', 404, 'EVENT_NOT_FOUND');
     }
-    if (time_zone !== undefined) updatePayload.time_zone = typeof time_zone === 'string' ? time_zone : 'UTC';
+
+    const parsed = validateEventInput(
+      { ...body, __currentStartTime: current.start_time, __currentEndTime: current.end_time },
+      { partial: true }
+    );
+    if (!parsed.ok) {
+      return jsonError(parsed.error.message, parsed.error.status, 'INVALID_INPUT', {
+        field: parsed.error.field,
+      });
+    }
 
     const { data: updated, error } = await supabase
       .from('events')
-      .update(updatePayload)
+      .update(parsed.value)
       .eq('id', id)
       .eq('user_id', userId)
-      .select()
+      .select(EVENT_COLUMNS)
       .single();
 
     if (error) {
-      logger.error(`[Events PUT] Error updating event ${id} for ${userId}: ${error.message}`);
-      return NextResponse.json({ error: 'Failed to update event' }, { status: 500 });
+      return respondToDatabaseError(error, 'PUT', userId);
     }
 
-    return NextResponse.json({ success: true, event: updated });
+    return jsonSuccess({ event: updated });
   } catch (error) {
     logger.error(`[Events PUT] Exception: ${error.message || error}`);
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+    return jsonError('Failed to update the event', 500);
   }
 }
 
-export async function DELETE(req) {
-  try {
-    await crudLimiter.check(req);
-  } catch (rateLimitError) {
-    return NextResponse.json({ error: 'Too many requests, please slow down.' }, { status: 429 });
-  }
+export async function DELETE(request) {
+  const limited = await checkRateLimit(request, 'DELETE');
+  if (limited) return limited;
 
   try {
     const userId = await getAuthUserId();
     if (!userId) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+      return jsonError('Unauthorized', 401);
     }
 
-    const { searchParams } = new URL(req.url);
+    const { searchParams } = new URL(request.url);
     let id = searchParams.get('id');
 
     if (!id) {
       try {
-        const body = await req.json();
-        id = body?.id;
-      } catch (e) {}
+        const body = await request.json();
+        id = typeof body?.id === 'string' ? body.id : '';
+      } catch {
+        // A DELETE with no body is the normal case; the query string is the
+        // documented way to pass the id.
+      }
     }
 
+    id = typeof id === 'string' ? id.trim() : '';
     if (!id) {
-      return NextResponse.json({ error: 'Event ID is required' }, { status: 400 });
+      return jsonError('Event ID is required', 400, 'MISSING_EVENT_ID');
+    }
+    if (!isUuid(id)) {
+      return jsonError('Event ID is not a valid identifier', 400, 'INVALID_EVENT_ID');
     }
 
     const supabase = getSupabaseAdmin();
-    const { error } = await supabase
+    const { error, count } = await supabase
       .from('events')
-      .delete()
+      .delete({ count: 'exact' })
       .eq('id', id)
       .eq('user_id', userId);
 
     if (error) {
-      logger.error(`[Events DELETE] Error deleting event ${id} for ${userId}: ${error.message}`);
-      return NextResponse.json({ error: 'Failed to delete event' }, { status: 500 });
+      return respondToDatabaseError(error, 'DELETE', userId);
     }
 
-    return NextResponse.json({ success: true, message: 'Event deleted successfully' });
+    // Without the count this reported success for a row it had not touched, so
+    // deleting an already-deleted event refetched into an unchanged calendar
+    // under a green toast.
+    const { deleted } = readDeleteResult({ count });
+    if (!deleted) {
+      return jsonError('Event not found', 404, 'EVENT_NOT_FOUND');
+    }
+
+    return jsonSuccess({ id }, 'Event deleted');
   } catch (error) {
     logger.error(`[Events DELETE] Exception: ${error.message || error}`);
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+    return jsonError('Failed to delete the event', 500);
   }
 }

--- a/components/calendar/MultiLangCalendar.jsx
+++ b/components/calendar/MultiLangCalendar.jsx
@@ -1,7 +1,7 @@
 'use client';
 
-import React, { useState, useEffect } from 'react';
-import { format, parseISO, isSameDay } from 'date-fns';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { format, isSameDay, parseISO } from 'date-fns';
 import { enUS, hi } from 'date-fns/locale';
 import {
   Calendar as CalendarIcon,
@@ -23,6 +23,17 @@ import {
 } from 'lucide-react';
 import fetchWithTimeout from '@/lib/fetch-with-timeout';
 import toast from 'react-hot-toast';
+import {
+  MAX_DESCRIPTION_LENGTH,
+  MAX_TITLE_LENGTH,
+  buildOccurrenceIndex,
+  composeStartTime,
+  dayKeyOf,
+  monthDayKeys,
+  parseWallTime,
+  resolveTimeZone,
+  zonedFields,
+} from '@/lib/event-schedule';
 
 const TIMEZONES = [
   { label: 'India Standard Time (IST)', value: 'Asia/Kolkata' },
@@ -58,27 +69,42 @@ export default function MultiLangCalendar({ locale = 'en' }) {
   const [formCategory, setFormCategory] = useState('reminder');
   const [formRecurrence, setFormRecurrence] = useState('none');
   const [formTime, setFormTime] = useState('09:00');
+  // The modal used to have no date field at all: both the create and the edit
+  // path rebuilt `start_time` from `selectedDate`, so renaming an event while a
+  // different day was highlighted silently moved it to that day.
+  const [formDate, setFormDate] = useState(() => dayKeyOf(zonedFields(Date.now(), 'Asia/Kolkata')));
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  useEffect(() => {
-    fetchEvents();
-  }, []);
+  // Every read and every write goes through this one value. `time_zone` was
+  // previously written on insert and read by nothing, so the picker changed
+  // what the cards said without changing what was stored.
+  const activeTimeZone = resolveTimeZone(selectedTimeZone, 'Asia/Kolkata');
 
-  const fetchEvents = async () => {
+  const fetchEvents = useCallback(async () => {
     setIsLoadingEvents(true);
     try {
       const res = await fetchWithTimeout('/api/events');
       const json = await res.json();
-      if (json.success) {
-        setEvents(json.events || []);
+      if (!res.ok || !json?.success) {
+        // A failed load used to leave the grid empty and silent, which is
+        // indistinguishable from an account that has no events yet.
+        throw new Error(json?.error || 'Failed to load events');
+      }
+      setEvents(json.data?.events || []);
+      if (json.data?.truncated) {
+        toast('Showing your most recent events only.', { icon: '\u2139\ufe0f' });
       }
     } catch (err) {
       console.error('Failed to fetch calendar events:', err);
-      toast.error('Failed to load events');
+      toast.error(err.message || 'Failed to load events');
     } finally {
       setIsLoadingEvents(false);
     }
-  };
+  }, []);
+
+  useEffect(() => {
+    fetchEvents();
+  }, [fetchEvents]);
 
   // Month Navigation
   const prevMonth = () => {
@@ -101,6 +127,11 @@ export default function MultiLangCalendar({ locale = 'en' }) {
     setFormCategory('reminder');
     setFormRecurrence('none');
     setFormTime('09:00');
+    setFormDate(dayKeyOf({
+      year: selectedDate.getFullYear(),
+      month: selectedDate.getMonth() + 1,
+      day: selectedDate.getDate(),
+    }));
     setShowEventModal(true);
   };
 
@@ -110,13 +141,21 @@ export default function MultiLangCalendar({ locale = 'en' }) {
     setFormDescription(event.description || '');
     setFormCategory(event.category || 'reminder');
     setFormRecurrence(event.recurrence_rule || 'none');
-    if (event.start_time) {
-      try {
-        const dateObj = parseISO(event.start_time);
-        setFormTime(format(dateObj, 'HH:mm'));
-      } catch (e) {
-        setFormTime('09:00');
-      }
+
+    // Read the stored instant back through the *selected* zone, so the day and
+    // time shown for editing are the ones the card displays.
+    const startMs = event.start_time ? Date.parse(event.start_time) : NaN;
+    const fields = Number.isFinite(startMs) ? zonedFields(startMs, activeTimeZone) : null;
+    if (fields) {
+      setFormDate(dayKeyOf(fields));
+      setFormTime(`${String(fields.hour).padStart(2, '0')}:${String(fields.minute).padStart(2, '0')}`);
+    } else {
+      setFormDate(dayKeyOf({
+        year: selectedDate.getFullYear(),
+        month: selectedDate.getMonth() + 1,
+        day: selectedDate.getDate(),
+      }));
+      setFormTime('09:00');
     }
     setShowEventModal(true);
   };
@@ -128,22 +167,36 @@ export default function MultiLangCalendar({ locale = 'en' }) {
       return;
     }
 
+    if (formTitle.trim().length > MAX_TITLE_LENGTH) {
+      toast.error(`Please keep the title under ${MAX_TITLE_LENGTH} characters`);
+      return;
+    }
+    if (!parseWallTime(formTime)) {
+      toast.error('Please choose a valid time');
+      return;
+    }
+
+    // `setHours()` resolves against the browser's zone, which is the one zone
+    // the user did not pick: choosing Tokyo and typing 09:00 in IST stored
+    // 03:30 UTC and then displayed it back as 12:30 PM. `composeStartTime`
+    // reads the wall clock in `activeTimeZone` instead.
+    const startTime = composeStartTime(formDate, formTime, activeTimeZone);
+    if (!startTime) {
+      toast.error('Please choose a valid date and time');
+      return;
+    }
+
     setIsSubmitting(true);
     const toastId = toast.loading(editingEventId ? 'Updating event...' : 'Creating event...');
 
     try {
-      // Build ISO Start Time string combining selectedDate and formTime
-      const [hours, minutes] = formTime.split(':').map(Number);
-      const combinedDate = new Date(selectedDate);
-      combinedDate.setHours(hours || 9, minutes || 0, 0, 0);
-
       const payload = {
         title: formTitle.trim(),
         description: formDescription.trim(),
         category: formCategory,
         recurrence_rule: formRecurrence,
-        start_time: combinedDate.toISOString(),
-        time_zone: selectedTimeZone,
+        start_time: startTime,
+        time_zone: activeTimeZone,
       };
 
       let res;
@@ -162,7 +215,7 @@ export default function MultiLangCalendar({ locale = 'en' }) {
       }
 
       const json = await res.json();
-      if (!res.ok) throw new Error(json.error || 'Failed to save event');
+      if (!res.ok || !json?.success) throw new Error(json?.error || 'Failed to save event');
 
       toast.success(editingEventId ? 'Event updated!' : 'Event created!', { id: toastId });
       setShowEventModal(false);
@@ -180,9 +233,9 @@ export default function MultiLangCalendar({ locale = 'en' }) {
 
     const toastId = toast.loading('Deleting event...');
     try {
-      const res = await fetchWithTimeout(`/api/events?id=${eventId}`, { method: 'DELETE' });
+      const res = await fetchWithTimeout(`/api/events?id=${encodeURIComponent(eventId)}`, { method: 'DELETE' });
       const json = await res.json();
-      if (!res.ok) throw new Error(json.error || 'Failed to delete');
+      if (!res.ok || !json?.success) throw new Error(json?.error || 'Failed to delete');
 
       toast.success('Event deleted', { id: toastId });
       fetchEvents();
@@ -205,40 +258,41 @@ export default function MultiLangCalendar({ locale = 'en' }) {
     calendarDays.push(new Date(year, month, d));
   }
 
-  // Filter events for selected day (including recurring logic)
-  const getEventsForDate = (date) => {
-    if (!date) return [];
-    return events.filter((evt) => {
-      if (!evt.start_time) return false;
-      const evtDate = parseISO(evt.start_time);
+  // One pass over the event list per render instead of one per cell.
+  //
+  // `getEventsForDate` was called 42 times for the grid plus once for the side
+  // panel, and each call re-parsed every event's `start_time`. The modal's form
+  // state lives in this component, so every keystroke in the title field paid
+  // for all 43 passes.
+  //
+  // The expansion itself also moved: `date.getDate() === evtDate.getDate()`
+  // meant a monthly reminder anchored on the 31st did not exist in February,
+  // April, June, September or November, and a 29 February anniversary appeared
+  // once every four years.
+  const occurrences = useMemo(() => {
+    const keys = [
+      ...monthDayKeys(year, month + 1),
+      dayKeyOf({
+        year: selectedDate.getFullYear(),
+        month: selectedDate.getMonth() + 1,
+        day: selectedDate.getDate(),
+      }),
+    ];
+    return buildOccurrenceIndex(events, keys, activeTimeZone);
+  }, [events, year, month, selectedDate, activeTimeZone]);
 
-      if (isSameDay(evtDate, date)) return true;
-
-      // Recurrence Check
-      if (evt.recurrence_rule === 'daily' && date >= evtDate) return true;
-      if (
-        evt.recurrence_rule === 'weekly' &&
-        date >= evtDate &&
-        date.getDay() === evtDate.getDay()
-      )
-        return true;
-      if (
-        evt.recurrence_rule === 'monthly' &&
-        date >= evtDate &&
-        date.getDate() === evtDate.getDate()
-      )
-        return true;
-      if (
-        evt.recurrence_rule === 'yearly' &&
-        date >= evtDate &&
-        date.getMonth() === evtDate.getMonth() &&
-        date.getDate() === evtDate.getDate()
-      )
-        return true;
-
-      return false;
-    });
-  };
+  const getEventsForDate = useCallback(
+    (date) => {
+      if (!date) return [];
+      const key = dayKeyOf({
+        year: date.getFullYear(),
+        month: date.getMonth() + 1,
+        day: date.getDate(),
+      });
+      return occurrences.get(key) || [];
+    },
+    [occurrences]
+  );
 
   const selectedDateEvents = getEventsForDate(selectedDate);
 
@@ -455,13 +509,14 @@ export default function MultiLangCalendar({ locale = 'en' }) {
                   let formattedTime = '';
                   if (evt.start_time) {
                     try {
-                      const d = new Date(evt.start_time);
+                      // `activeTimeZone` is already validated, so this cannot
+                      // throw on a zone the database happened to hold.
                       formattedTime = new Intl.DateTimeFormat(locale === 'hi' ? 'hi-IN' : 'en-US', {
-                        timeZone: selectedTimeZone,
+                        timeZone: activeTimeZone,
                         hour: 'numeric',
                         minute: '2-digit',
                         hour12: true,
-                      }).format(d);
+                      }).format(new Date(evt.start_time));
                     } catch (e) {
                       formattedTime = format(parseISO(evt.start_time), 'hh:mm a');
                     }
@@ -543,6 +598,7 @@ export default function MultiLangCalendar({ locale = 'en' }) {
                   type="text"
                   value={formTitle}
                   onChange={(e) => setFormTitle(e.target.value)}
+                  maxLength={MAX_TITLE_LENGTH}
                   placeholder="e.g. Habit Reminder / Donation Cycle"
                   className="w-full bg-slate-800 border border-slate-700 rounded-xl p-2.5 text-white focus:outline-none focus:ring-2 focus:ring-pink-500"
                   required
@@ -556,6 +612,7 @@ export default function MultiLangCalendar({ locale = 'en' }) {
                 <textarea
                   value={formDescription}
                   onChange={(e) => setFormDescription(e.target.value)}
+                  maxLength={MAX_DESCRIPTION_LENGTH}
                   placeholder="Add notes or reminders..."
                   className="w-full bg-slate-800 border border-slate-700 rounded-xl p-2.5 text-white focus:outline-none focus:ring-2 focus:ring-pink-500 min-h-[60px]"
                 />
@@ -597,17 +654,45 @@ export default function MultiLangCalendar({ locale = 'en' }) {
                 </div>
               </div>
 
-              <div>
-                <label className="block text-xs font-semibold text-slate-400 uppercase tracking-wider mb-1">
-                  Time
-                </label>
-                <input
-                  type="time"
-                  value={formTime}
-                  onChange={(e) => setFormTime(e.target.value)}
-                  className="w-full bg-slate-800 border border-slate-700 rounded-xl p-2.5 text-white focus:outline-none"
-                />
+              <div className="grid grid-cols-2 gap-3">
+                <div>
+                  <label
+                    htmlFor="event-date"
+                    className="block text-xs font-semibold text-slate-400 uppercase tracking-wider mb-1"
+                  >
+                    Date
+                  </label>
+                  <input
+                    id="event-date"
+                    type="date"
+                    value={formDate}
+                    onChange={(e) => setFormDate(e.target.value)}
+                    required
+                    className="w-full bg-slate-800 border border-slate-700 rounded-xl p-2.5 text-white focus:outline-none"
+                  />
+                </div>
+
+                <div>
+                  <label
+                    htmlFor="event-time"
+                    className="block text-xs font-semibold text-slate-400 uppercase tracking-wider mb-1"
+                  >
+                    Time
+                  </label>
+                  <input
+                    id="event-time"
+                    type="time"
+                    value={formTime}
+                    onChange={(e) => setFormTime(e.target.value)}
+                    required
+                    className="w-full bg-slate-800 border border-slate-700 rounded-xl p-2.5 text-white focus:outline-none"
+                  />
+                </div>
               </div>
+
+              <p className="text-[11px] text-slate-500">
+                Saved in <span className="font-semibold text-slate-400">{activeTimeZone}</span>.
+              </p>
 
               <div className="flex justify-end gap-3 pt-3 border-t border-slate-800">
                 <button

--- a/lib/event-schedule.js
+++ b/lib/event-schedule.js
@@ -1,0 +1,789 @@
+/**
+ * event-schedule.js — the calendar's arithmetic, in one place and without a
+ * clock of its own.
+ *
+ * ## Why this module exists
+ *
+ * `components/calendar/MultiLangCalendar.jsx` offers a timezone picker and then
+ * ignores it on the way in. The modal wrote the chosen time against the
+ * *browser's* clock:
+ *
+ *     const combinedDate = new Date(selectedDate)
+ *     combinedDate.setHours(hours || 9, minutes || 0, 0, 0)
+ *
+ * …and the card read it back against the *selected* one:
+ *
+ *     new Intl.DateTimeFormat(locale, { timeZone: selectedTimeZone, ... }).format(d)
+ *
+ * so a user in IST who picks Tokyo and types `09:00` is shown `12:30 PM`. The
+ * `time_zone` column was written on every insert and read by nothing.
+ *
+ * Recurrence had the matching problem in the other direction:
+ *
+ *     if (evt.recurrence_rule === 'monthly' && date >= evtDate && date.getDate() === evtDate.getDate())
+ *
+ * A monthly reminder anchored on the 31st does not occur in February, April,
+ * June, September or November — it simply vanishes for those months rather than
+ * landing on the last day, which is what "every month" means to the person who
+ * set it. A 29 February anniversary appeared once every four years. And
+ * `date >= evtDate` compares a midnight-local cell against the event's real
+ * instant, so the anchor day itself failed the test for any event later than
+ * midnight; only the `isSameDay` branch above it hid that.
+ *
+ * ## The approach
+ *
+ * Every decision here is made on **calendar fields resolved in one chosen time
+ * zone**, never on raw millisecond comparisons:
+ *
+ *   1. {@link zonedFields} converts an instant into `{year, month, day, hour,
+ *      minute, weekday}` as that zone sees it, via `Intl.DateTimeFormat`.
+ *   2. {@link describeAnchor} does that **once per event**, producing a small
+ *      integer record.
+ *   3. {@link occursOn} compares two integer records. It is O(1), so a 42-cell
+ *      month costs one `Intl` pass per event rather than 43 passes over the
+ *      whole list — which is what the old `getEventsForDate` cost on every
+ *      keystroke in the modal, because the form state lives in the same
+ *      component.
+ *   4. {@link wallClockToInstant} goes the other way, so the time the user types
+ *      in the selected zone is the instant that gets stored.
+ *
+ * The module is pure: no fetch, no React, no Supabase, no `Date.now()` except
+ * where a caller passes it in. It runs unchanged in a Route Handler, a Client
+ * Component and `node scripts/test-event-schedule.js`.
+ */
+
+// ---------------------------------------------------------------------------
+// Vocabulary
+// ---------------------------------------------------------------------------
+
+/** Categories the calendar renders a colour and a badge for. */
+export const EVENT_CATEGORIES = Object.freeze(['reminder', 'habit', 'donation', 'health'])
+
+/** Recurrence rules the calendar knows how to expand. */
+export const RECURRENCE_RULES = Object.freeze(['none', 'daily', 'weekly', 'monthly', 'yearly'])
+
+/** Default category, used when the caller omits the field entirely. */
+export const DEFAULT_CATEGORY = 'reminder'
+
+/** Default recurrence, used when the caller omits the field entirely. */
+export const DEFAULT_RECURRENCE = 'none'
+
+/** Fallback zone. Matches the column default in `supabase/08_events.sql`. */
+export const DEFAULT_TIME_ZONE = 'UTC'
+
+/** `events.title` is `TEXT`; this is the product limit, enforced before the write. */
+export const MAX_TITLE_LENGTH = 120
+
+/** `events.description` is `TEXT`; same reasoning. */
+export const MAX_DESCRIPTION_LENGTH = 1000
+
+/**
+ * Ceiling on a single `GET /api/events` response.
+ *
+ * The route had no `.limit()` at all, so an account that had been adding daily
+ * reminders for two years shipped its whole history to the browser on every
+ * page load to render one month.
+ */
+export const MAX_EVENTS_RETURNED = 500
+
+/**
+ * Longest an event may last.
+ *
+ * Guards against a mistyped year in `end_time` producing a "6-hour reminder"
+ * that the UI would have to describe as lasting until 2099.
+ */
+export const MAX_DURATION_MS = 365 * 24 * 60 * 60 * 1000
+
+/** Matches a canonical RFC 4122 UUID, which is what `events.id` is. */
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+/**
+ * Matches an ISO 8601 instant.
+ *
+ * Deliberately stricter than `new Date(...)`, which accepts `"Jan 5 2026"`,
+ * `"2026"` and a pile of implementation-defined shapes that would each be
+ * interpreted differently by the browser writing them and the Postgres column
+ * receiving them.
+ */
+const ISO_INSTANT_RE = /^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}(:\d{2}(\.\d{1,6})?)?(Z|[+-]\d{2}:?\d{2})?$/
+
+/** Matches the `HH:mm` a `<input type="time">` produces. */
+const WALL_TIME_RE = /^(\d{1,2}):(\d{2})$/
+
+/** Matches a `YYYY-MM-DD` calendar day. */
+const DAY_KEY_RE = /^(\d{4})-(\d{2})-(\d{2})$/
+
+// ---------------------------------------------------------------------------
+// Time zones
+// ---------------------------------------------------------------------------
+
+/**
+ * `Intl.DateTimeFormat` construction is not free and the calendar asks the same
+ * question for every event in a month, so formatters are held per zone.
+ */
+const formatterCache = new Map()
+
+/**
+ * True when the runtime recognises `zone` as an IANA time zone.
+ *
+ * The route stored whatever string arrived, so `'Mars/Olympus'` reached the
+ * column and then threw `RangeError: Invalid time zone specified` inside the
+ * component that tried to render it.
+ *
+ * @param {unknown} zone
+ * @returns {boolean}
+ */
+export function isValidTimeZone(zone) {
+  if (typeof zone !== 'string' || zone.trim() === '') return false
+  try {
+    // eslint-disable-next-line no-new
+    new Intl.DateTimeFormat('en-CA', { timeZone: zone.trim() })
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * `zone` if the runtime accepts it, otherwise `fallback`, otherwise UTC.
+ *
+ * @param {unknown} zone
+ * @param {string} [fallback]
+ * @returns {string}
+ */
+export function resolveTimeZone(zone, fallback = DEFAULT_TIME_ZONE) {
+  if (isValidTimeZone(zone)) return zone.trim()
+  if (isValidTimeZone(fallback)) return fallback
+  return DEFAULT_TIME_ZONE
+}
+
+/**
+ * @param {string} timeZone an already-validated zone
+ * @returns {Intl.DateTimeFormat}
+ */
+function partsFormatter(timeZone) {
+  let formatter = formatterCache.get(timeZone)
+  if (!formatter) {
+    formatter = new Intl.DateTimeFormat('en-CA', {
+      timeZone,
+      hour12: false,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    })
+    formatterCache.set(timeZone, formatter)
+  }
+  return formatter
+}
+
+// ---------------------------------------------------------------------------
+// Instants and calendar fields
+// ---------------------------------------------------------------------------
+
+/**
+ * Parses an ISO 8601 instant into epoch milliseconds.
+ *
+ * @param {unknown} value
+ * @returns {number|null} `null` when the value is not an instant this app writes
+ */
+export function parseInstant(value) {
+  if (value instanceof Date) {
+    const ms = value.getTime()
+    return Number.isFinite(ms) ? ms : null
+  }
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  if (!ISO_INSTANT_RE.test(trimmed)) return null
+  const ms = Date.parse(trimmed)
+  return Number.isFinite(ms) ? ms : null
+}
+
+/**
+ * The calendar fields an instant has *in a given zone*.
+ *
+ * `weekday` is 0-6 with Sunday at 0, matching `Date.prototype.getDay` so the
+ * grid and this module can be compared directly.
+ *
+ * @param {number} instantMs
+ * @param {string} timeZone
+ * @returns {{year: number, month: number, day: number, hour: number, minute: number, second: number, weekday: number}|null}
+ */
+export function zonedFields(instantMs, timeZone) {
+  if (!Number.isFinite(instantMs)) return null
+  const zone = resolveTimeZone(timeZone)
+
+  const parts = partsFormatter(zone).formatToParts(new Date(instantMs))
+  const field = {}
+  for (const part of parts) {
+    if (part.type !== 'literal') field[part.type] = Number(part.value)
+  }
+
+  if (!Number.isFinite(field.year) || !Number.isFinite(field.month) || !Number.isFinite(field.day)) {
+    return null
+  }
+
+  return {
+    year: field.year,
+    month: field.month,
+    day: field.day,
+    hour: Number.isFinite(field.hour) ? field.hour % 24 : 0,
+    minute: Number.isFinite(field.minute) ? field.minute : 0,
+    second: Number.isFinite(field.second) ? field.second : 0,
+    weekday: weekdayOf(field.year, field.month, field.day),
+  }
+}
+
+/**
+ * Day of the week for a proleptic Gregorian date, Sunday = 0.
+ *
+ * Computed from the calendar fields rather than read back out of `Intl`,
+ * because the weekday of a `(year, month, day)` triple is a property of the
+ * calendar and does not need a second formatter pass.
+ *
+ * @param {number} year
+ * @param {number} month 1-12
+ * @param {number} day 1-31
+ * @returns {number} 0-6
+ */
+export function weekdayOf(year, month, day) {
+  return new Date(Date.UTC(year, month - 1, day)).getUTCDay()
+}
+
+/**
+ * Days in a month, leap years included.
+ *
+ * @param {number} year
+ * @param {number} month 1-12
+ * @returns {number}
+ */
+export function daysInMonth(year, month) {
+  return new Date(Date.UTC(year, month, 0)).getUTCDate()
+}
+
+/**
+ * `YYYY-MM-DD` for a calendar-field record.
+ *
+ * @param {{year: number, month: number, day: number}} fields
+ * @returns {string}
+ */
+export function dayKeyOf(fields) {
+  const mm = String(fields.month).padStart(2, '0')
+  const dd = String(fields.day).padStart(2, '0')
+  return `${fields.year}-${mm}-${dd}`
+}
+
+/**
+ * The reverse: `YYYY-MM-DD` into calendar fields, with a weekday attached.
+ *
+ * @param {string} dayKey
+ * @returns {{year: number, month: number, day: number, weekday: number}|null}
+ */
+export function parseDayKey(dayKey) {
+  if (typeof dayKey !== 'string') return null
+  const match = DAY_KEY_RE.exec(dayKey.trim())
+  if (!match) return null
+
+  const year = Number(match[1])
+  const month = Number(match[2])
+  const day = Number(match[3])
+  if (month < 1 || month > 12) return null
+  if (day < 1 || day > daysInMonth(year, month)) return null
+
+  return { year, month, day, weekday: weekdayOf(year, month, day) }
+}
+
+/**
+ * Orders two calendar-field records. Negative when `a` is earlier.
+ *
+ * @param {{year: number, month: number, day: number}} a
+ * @param {{year: number, month: number, day: number}} b
+ * @returns {number}
+ */
+export function compareDays(a, b) {
+  if (a.year !== b.year) return a.year - b.year
+  if (a.month !== b.month) return a.month - b.month
+  return a.day - b.day
+}
+
+/**
+ * The zone's UTC offset at an instant, in milliseconds.
+ *
+ * @param {number} instantMs
+ * @param {string} timeZone
+ * @returns {number}
+ */
+function offsetAt(instantMs, timeZone) {
+  const fields = zonedFields(instantMs, timeZone)
+  if (!fields) return 0
+  const asUtc = Date.UTC(fields.year, fields.month - 1, fields.day, fields.hour, fields.minute, fields.second)
+  // `instantMs` may carry milliseconds the formatter dropped; round to the
+  // second on both sides so the difference is a clean offset.
+  return asUtc - Math.floor(instantMs / 1000) * 1000
+}
+
+/**
+ * Turns a wall-clock reading in a zone into the instant it names.
+ *
+ * This is the half of the timezone fix the modal was missing. `setHours()`
+ * resolves against the browser's zone, which is the one place the user did not
+ * choose.
+ *
+ * The offset is applied twice because the offset itself depends on the instant:
+ * the first pass lands within an hour of the answer, and the second resolves
+ * that hour correctly across a DST boundary. On a spring-forward gap (a wall
+ * time that does not exist) this settles on the instant immediately after the
+ * jump, which is the conventional resolution and the one `Temporal`'s
+ * `'compatible'` disambiguation also picks.
+ *
+ * @param {{year: number, month: number, day: number, hour?: number, minute?: number}} wall
+ * @param {string} timeZone
+ * @returns {number|null} epoch milliseconds
+ */
+export function wallClockToInstant(wall, timeZone) {
+  if (!wall || !Number.isFinite(wall.year) || !Number.isFinite(wall.month) || !Number.isFinite(wall.day)) {
+    return null
+  }
+  const zone = resolveTimeZone(timeZone)
+  const hour = Number.isFinite(wall.hour) ? wall.hour : 0
+  const minute = Number.isFinite(wall.minute) ? wall.minute : 0
+
+  const naive = Date.UTC(wall.year, wall.month - 1, wall.day, hour, minute, 0, 0)
+  const firstPass = naive - offsetAt(naive, zone)
+  const secondPass = naive - offsetAt(firstPass, zone)
+  return Number.isFinite(secondPass) ? secondPass : null
+}
+
+/**
+ * Parses the `HH:mm` from a `<input type="time">`.
+ *
+ * @param {unknown} value
+ * @returns {{hour: number, minute: number}|null}
+ */
+export function parseWallTime(value) {
+  if (typeof value !== 'string') return null
+  const match = WALL_TIME_RE.exec(value.trim())
+  if (!match) return null
+  const hour = Number(match[1])
+  const minute = Number(match[2])
+  if (hour < 0 || hour > 23 || minute < 0 || minute > 59) return null
+  return { hour, minute }
+}
+
+/**
+ * Combines a calendar day and a `HH:mm` into an ISO instant, read in `timeZone`.
+ *
+ * @param {string} dayKey `YYYY-MM-DD`
+ * @param {string} wallTime `HH:mm`
+ * @param {string} timeZone
+ * @returns {string|null} an ISO 8601 string, or `null` if either part is unusable
+ */
+export function composeStartTime(dayKey, wallTime, timeZone) {
+  const day = parseDayKey(dayKey)
+  const time = parseWallTime(wallTime)
+  if (!day || !time) return null
+
+  const instant = wallClockToInstant({ ...day, hour: time.hour, minute: time.minute }, timeZone)
+  if (instant === null) return null
+  return new Date(instant).toISOString()
+}
+
+// ---------------------------------------------------------------------------
+// Recurrence
+// ---------------------------------------------------------------------------
+
+/**
+ * The integer record {@link occursOn} compares against, computed once per event.
+ *
+ * @param {{start_time?: string, end_time?: string|null, recurrence_rule?: string, time_zone?: string}} event
+ * @param {string} viewerTimeZone the zone the grid is being drawn in
+ * @returns {{startMs: number, endMs: number|null, rule: string, year: number, month: number, day: number, weekday: number, hour: number, minute: number}|null}
+ */
+export function describeAnchor(event, viewerTimeZone) {
+  if (!event) return null
+
+  const startMs = parseInstant(event.start_time)
+  if (startMs === null) return null
+
+  const zone = resolveTimeZone(viewerTimeZone)
+  const fields = zonedFields(startMs, zone)
+  if (!fields) return null
+
+  const endMs = parseInstant(event.end_time)
+  const rule = RECURRENCE_RULES.includes(event.recurrence_rule) ? event.recurrence_rule : DEFAULT_RECURRENCE
+
+  return {
+    startMs,
+    endMs: endMs !== null && endMs > startMs ? endMs : null,
+    rule,
+    year: fields.year,
+    month: fields.month,
+    day: fields.day,
+    weekday: fields.weekday,
+    hour: fields.hour,
+    minute: fields.minute,
+  }
+}
+
+/**
+ * Whether an event lands on a calendar day.
+ *
+ * The rules, in the anchor's own calendar:
+ *
+ * - **`none`** — only the anchor day.
+ * - **`daily`** — the anchor day and every day after it.
+ * - **`weekly`** — the same weekday, on or after the anchor day.
+ * - **`monthly`** — the same day-of-month, **clamped to the end of shorter
+ *   months**. An event anchored on the 31st falls on 28 (or 29) February and on
+ *   30 April. Clamping is always computed from the anchor's own day-of-month, so
+ *   February does not drag the series down to the 28th permanently.
+ * - **`yearly`** — the same month and day, with 29 February clamped to 28
+ *   February in common years for the same reason.
+ *
+ * The comparison is by calendar day, not by instant. The previous
+ * `date >= evtDate` compared a midnight-local `Date` against the event's real
+ * time, so a 09:00 daily reminder was "not yet recurring" on its own start day.
+ *
+ * @param {ReturnType<typeof describeAnchor>} anchor
+ * @param {{year: number, month: number, day: number, weekday: number}} cell
+ * @returns {boolean}
+ */
+export function occursOn(anchor, cell) {
+  if (!anchor || !cell) return false
+
+  const order = compareDays(cell, anchor)
+  if (order < 0) return false
+  if (order === 0) return true
+  if (anchor.rule === DEFAULT_RECURRENCE) return false
+
+  switch (anchor.rule) {
+    case 'daily':
+      return true
+    case 'weekly':
+      return cell.weekday === anchor.weekday
+    case 'monthly':
+      return cell.day === clampDayToMonth(anchor.day, cell.year, cell.month)
+    case 'yearly':
+      return (
+        cell.month === anchor.month &&
+        cell.day === clampDayToMonth(anchor.day, cell.year, cell.month)
+      )
+    default:
+      return false
+  }
+}
+
+/**
+ * The anchor's day-of-month, or the last day of the target month when the
+ * target month is too short to contain it.
+ *
+ * @param {number} anchorDay 1-31
+ * @param {number} year
+ * @param {number} month 1-12
+ * @returns {number}
+ */
+export function clampDayToMonth(anchorDay, year, month) {
+  const last = daysInMonth(year, month)
+  return anchorDay > last ? last : anchorDay
+}
+
+/**
+ * Groups events by the day they occur on, in one pass.
+ *
+ * `getEventsForDate` was called once per grid cell and once for the side panel —
+ * 43 full scans of the event list per render, each re-parsing every
+ * `start_time`. Here each event is parsed once and each `(event, cell)` pair
+ * costs an integer comparison.
+ *
+ * @param {object[]} events
+ * @param {string[]} dayKeys the days being rendered, `YYYY-MM-DD`
+ * @param {string} viewerTimeZone
+ * @returns {Map<string, object[]>} keyed by day; days with no events are present and empty
+ */
+export function buildOccurrenceIndex(events, dayKeys, viewerTimeZone) {
+  const zone = resolveTimeZone(viewerTimeZone)
+  const index = new Map()
+
+  const cells = []
+  for (const key of dayKeys || []) {
+    const cell = parseDayKey(key)
+    if (!cell) continue
+    index.set(key, [])
+    cells.push({ key, cell })
+  }
+
+  for (const event of events || []) {
+    const anchor = describeAnchor(event, zone)
+    if (!anchor) continue
+    for (const { key, cell } of cells) {
+      if (occursOn(anchor, cell)) index.get(key).push(event)
+    }
+  }
+
+  for (const list of index.values()) {
+    list.sort((a, b) => (parseInstant(a.start_time) ?? 0) - (parseInstant(b.start_time) ?? 0))
+  }
+
+  return index
+}
+
+/**
+ * The `YYYY-MM-DD` keys of every cell in a month grid, including the leading
+ * blanks' worth of nothing — blanks are simply absent from the list.
+ *
+ * @param {number} year
+ * @param {number} month 1-12
+ * @returns {string[]}
+ */
+export function monthDayKeys(year, month) {
+  const total = daysInMonth(year, month)
+  const keys = []
+  for (let day = 1; day <= total; day += 1) {
+    keys.push(dayKeyOf({ year, month, day }))
+  }
+  return keys
+}
+
+// ---------------------------------------------------------------------------
+// Write validation
+// ---------------------------------------------------------------------------
+
+/**
+ * A rejection, shaped so a route can hand it straight to `jsonError`.
+ *
+ * @param {string} message
+ * @param {string} field
+ * @returns {{ok: false, error: {message: string, field: string, status: number}}}
+ */
+function reject(message, field) {
+  return { ok: false, error: { message, field, status: 400 } }
+}
+
+/**
+ * Trims and length-checks a free-text field.
+ *
+ * @param {unknown} value
+ * @param {number} max
+ * @returns {{ok: true, value: string}|{ok: false}}
+ */
+function readText(value, max) {
+  if (typeof value !== 'string') return { ok: false }
+  const trimmed = value.trim()
+  if (trimmed.length > max) return { ok: false }
+  return { ok: true, value: trimmed }
+}
+
+/**
+ * True when `value` is a canonical UUID.
+ *
+ * `events.id` is `UUID`. Passing anything else made Postgres raise `22P02`,
+ * which the route reported as `500 Failed to update event` — a server fault for
+ * what is squarely a bad request.
+ *
+ * @param {unknown} value
+ * @returns {boolean}
+ */
+export function isUuid(value) {
+  return typeof value === 'string' && UUID_RE.test(value.trim())
+}
+
+/**
+ * Validates a create or update payload.
+ *
+ * Unknown enum values are **refused**, not silently rewritten. The route used
+ * to fold an unrecognised `category` into `'reminder'`, so a client sending the
+ * wrong constant got a stored event that quietly disagreed with what the user
+ * chose, and nothing anywhere reported it.
+ *
+ * @param {object} body the parsed request body
+ * @param {{partial?: boolean}} [options] `partial: true` for `PUT`, where every
+ *   field except `id` is optional and absent keys must not be written
+ * @returns {{ok: true, value: object}|{ok: false, error: {message: string, field: string, status: number}}}
+ */
+export function validateEventInput(body, options = {}) {
+  const partial = options.partial === true
+  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+    return reject('A JSON object is required', 'body')
+  }
+
+  const value = {}
+
+  if (!partial || body.title !== undefined) {
+    const title = readText(body.title, MAX_TITLE_LENGTH)
+    if (!title.ok) {
+      return reject(`Event title is required and must be ${MAX_TITLE_LENGTH} characters or fewer`, 'title')
+    }
+    if (title.value === '') return reject('Event title is required', 'title')
+    value.title = title.value
+  }
+
+  if (body.description !== undefined) {
+    if (body.description === null) {
+      value.description = ''
+    } else {
+      const description = readText(body.description, MAX_DESCRIPTION_LENGTH)
+      if (!description.ok) {
+        return reject(`Description must be ${MAX_DESCRIPTION_LENGTH} characters or fewer`, 'description')
+      }
+      value.description = description.value
+    }
+  } else if (!partial) {
+    value.description = ''
+  }
+
+  if (!partial || body.start_time !== undefined) {
+    const startMs = parseInstant(body.start_time)
+    if (startMs === null) return reject('A valid ISO 8601 start time is required', 'start_time')
+    value.start_time = new Date(startMs).toISOString()
+  }
+
+  if (body.end_time !== undefined) {
+    if (body.end_time === null || body.end_time === '') {
+      value.end_time = null
+    } else {
+      const endMs = parseInstant(body.end_time)
+      if (endMs === null) return reject('End time must be a valid ISO 8601 timestamp', 'end_time')
+      value.end_time = new Date(endMs).toISOString()
+    }
+  } else if (!partial) {
+    value.end_time = null
+  }
+
+  if (body.recurrence_rule !== undefined) {
+    if (!RECURRENCE_RULES.includes(body.recurrence_rule)) {
+      return reject(`Recurrence must be one of: ${RECURRENCE_RULES.join(', ')}`, 'recurrence_rule')
+    }
+    value.recurrence_rule = body.recurrence_rule
+  } else if (!partial) {
+    value.recurrence_rule = DEFAULT_RECURRENCE
+  }
+
+  if (body.category !== undefined) {
+    if (!EVENT_CATEGORIES.includes(body.category)) {
+      return reject(`Category must be one of: ${EVENT_CATEGORIES.join(', ')}`, 'category')
+    }
+    value.category = body.category
+  } else if (!partial) {
+    value.category = DEFAULT_CATEGORY
+  }
+
+  if (body.time_zone !== undefined) {
+    if (!isValidTimeZone(body.time_zone)) {
+      return reject('Time zone must be a valid IANA identifier, e.g. Asia/Kolkata', 'time_zone')
+    }
+    value.time_zone = body.time_zone.trim()
+  } else if (!partial) {
+    value.time_zone = DEFAULT_TIME_ZONE
+  }
+
+  const intervalError = checkInterval(value, body, partial)
+  if (intervalError) return intervalError
+
+  if (partial && Object.keys(value).length === 0) {
+    // PostgREST rejects an empty patch, which the route surfaced as a 500. An
+    // update that names nothing is a client mistake, and saying so is cheaper
+    // than a round trip that cannot succeed.
+    return reject('No updatable fields were provided', 'body')
+  }
+
+  return { ok: true, value }
+}
+
+/**
+ * Checks `start_time`/`end_time` against each other.
+ *
+ * On a partial update only one of the two may be present in the payload, so the
+ * caller may supply the other from the stored row via `body.__currentStartTime`
+ * / `body.__currentEndTime`. When neither side can be resolved the check is
+ * skipped rather than guessed at.
+ *
+ * @param {object} value the validated payload so far
+ * @param {object} body the raw body, for the stored-row hints
+ * @param {boolean} partial
+ * @returns {{ok: false, error: object}|null}
+ */
+function checkInterval(value, body, partial) {
+  const startMs =
+    value.start_time !== undefined
+      ? parseInstant(value.start_time)
+      : partial
+        ? parseInstant(body.__currentStartTime)
+        : null
+
+  const endMs =
+    value.end_time !== undefined
+      ? parseInstant(value.end_time)
+      : partial
+        ? parseInstant(body.__currentEndTime)
+        : null
+
+  if (startMs === null || endMs === null) return null
+
+  if (endMs <= startMs) {
+    return reject('End time must be after the start time', 'end_time')
+  }
+  if (endMs - startMs > MAX_DURATION_MS) {
+    return reject('An event cannot last longer than a year', 'end_time')
+  }
+  return null
+}
+
+// ---------------------------------------------------------------------------
+// Database errors
+// ---------------------------------------------------------------------------
+
+/**
+ * Maps a Supabase/Postgres error onto something a caller can act on.
+ *
+ * Nothing from the driver reaches the client: `error.message` on this table
+ * names the relation, the constraint and, on a connection fault, the pooler
+ * host.
+ *
+ * @param {{code?: string}|null} error
+ * @returns {{message: string, status: number, code: string}}
+ */
+export function describeEventError(error) {
+  const code = error && typeof error.code === 'string' ? error.code : ''
+
+  switch (code) {
+    case 'PGRST116':
+      // "JSON object requested, multiple (or no) rows returned" — with
+      // `.eq('user_id', ...)` in the query this means the event is not this
+      // user's, or is already gone.
+      return { message: 'Event not found', status: 404, code: 'EVENT_NOT_FOUND' }
+    case '22P02':
+      return { message: 'Event ID is not a valid identifier', status: 400, code: 'INVALID_EVENT_ID' }
+    case '22007':
+    case '22008':
+      return { message: 'Event times must be valid timestamps', status: 400, code: 'INVALID_TIMESTAMP' }
+    case '22001':
+      return { message: 'Event title or description is too long', status: 400, code: 'VALUE_TOO_LONG' }
+    case '23503':
+      return { message: 'This account is not set up yet, please reload and try again', status: 409, code: 'MISSING_USER' }
+    case '23514':
+      return { message: 'The calendar has not been migrated on this deployment yet', status: 503, code: 'SCHEMA_DRIFT' }
+    case '42P01':
+      return { message: 'The calendar is not available on this deployment yet', status: 503, code: 'MISSING_TABLE' }
+    default:
+      return { message: 'Could not save the calendar event', status: 500, code: 'EVENT_WRITE_FAILED' }
+  }
+}
+
+/**
+ * Reads the row count Supabase reports for a delete.
+ *
+ * `DELETE` answered `Event deleted successfully` whether or not a row matched,
+ * so deleting an id that was already gone — or somebody else's — looked
+ * identical to a real deletion and the calendar refetched into the same state
+ * without explanation.
+ *
+ * @param {{count?: number|null}} result
+ * @returns {{deleted: boolean, count: number}}
+ */
+export function readDeleteResult(result) {
+  const count = Number(result?.count)
+  const deleted = Number.isFinite(count) && count > 0
+  return { deleted, count: Number.isFinite(count) ? count : 0 }
+}

--- a/scripts/test-event-schedule.js
+++ b/scripts/test-event-schedule.js
@@ -1,0 +1,521 @@
+/**
+ * Regression suite for lib/event-schedule.js.
+ *
+ * The bugs this is part of fixing, in `components/calendar/MultiLangCalendar.jsx`
+ * and `app/api/events/route.js`:
+ *
+ *  1. The timezone picker was decorative. The modal wrote the chosen time with
+ *     `setHours()` (the browser's zone) and the card read it back with
+ *     `Intl.DateTimeFormat({ timeZone: selectedTimeZone })`, so picking Tokyo
+ *     in IST and typing 09:00 produced a card reading 12:30 PM.
+ *
+ *  2. Monthly and yearly recurrences vanished in short months:
+ *
+ *         if (evt.recurrence_rule === 'monthly' && date >= evtDate &&
+ *             date.getDate() === evtDate.getDate()) return true
+ *
+ *     A reminder anchored on the 31st does not exist in February, April, June,
+ *     September or November.
+ *
+ *  3. The API accepted `end_time` before `start_time`, silently rewrote an
+ *     unknown `category` to `reminder`, stored any string as a `time_zone`, and
+ *     reported `500` for a non-UUID id and `Event deleted successfully` for a
+ *     delete that matched no row.
+ *
+ *   node scripts/test-event-schedule.js
+ */
+
+import {
+  DEFAULT_TIME_ZONE,
+  EVENT_CATEGORIES,
+  MAX_DESCRIPTION_LENGTH,
+  MAX_EVENTS_RETURNED,
+  MAX_TITLE_LENGTH,
+  RECURRENCE_RULES,
+  buildOccurrenceIndex,
+  clampDayToMonth,
+  compareDays,
+  composeStartTime,
+  dayKeyOf,
+  daysInMonth,
+  describeAnchor,
+  describeEventError,
+  isUuid,
+  isValidTimeZone,
+  monthDayKeys,
+  occursOn,
+  parseDayKey,
+  parseInstant,
+  parseWallTime,
+  readDeleteResult,
+  resolveTimeZone,
+  validateEventInput,
+  wallClockToInstant,
+  weekdayOf,
+  zonedFields,
+} from '../lib/event-schedule.js'
+
+let passed = 0
+let failed = 0
+
+function check(actual, expected, label) {
+  if (Object.is(actual, expected)) {
+    passed += 1
+    return
+  }
+  failed += 1
+  console.error(`FAIL ${label}\n  expected: ${String(expected)}\n  actual:   ${String(actual)}`)
+}
+
+function checkTrue(value, label) {
+  check(value === true, true, label)
+}
+
+function checkFalse(value, label) {
+  check(value === false, true, label)
+}
+
+function section(name) {
+  console.log(`\n— ${name}`)
+}
+
+const IST = 'Asia/Kolkata'
+const TOKYO = 'Asia/Tokyo'
+const NEW_YORK = 'America/New_York'
+
+/** A calendar cell, the way the grid produces one. */
+function cell(dayKey) {
+  return parseDayKey(dayKey)
+}
+
+/** A stored event row. */
+function event(overrides = {}) {
+  return {
+    id: '3f7c1b2e-9a44-4a1e-8b2d-0c6f5d3e2a11',
+    title: 'Iron supplement',
+    description: '',
+    start_time: '2026-01-31T03:30:00.000Z',
+    end_time: null,
+    recurrence_rule: 'none',
+    category: 'reminder',
+    time_zone: IST,
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+section('Calendar primitives')
+// ---------------------------------------------------------------------------
+
+check(daysInMonth(2026, 1), 31, 'January has 31 days')
+check(daysInMonth(2026, 2), 28, 'February 2026 has 28 days')
+check(daysInMonth(2028, 2), 29, 'February 2028 has 29 days (leap)')
+check(daysInMonth(2100, 2), 28, 'February 2100 has 28 days (century, not leap)')
+check(daysInMonth(2000, 2), 29, 'February 2000 has 29 days (400-year rule)')
+check(daysInMonth(2026, 4), 30, 'April has 30 days')
+
+check(weekdayOf(2026, 8, 29), 6, '29 August 2026 is a Saturday')
+check(weekdayOf(2026, 1, 1), 4, '1 January 2026 is a Thursday')
+
+check(dayKeyOf({ year: 2026, month: 3, day: 7 }), '2026-03-07', 'day key zero-pads')
+check(parseDayKey('2026-02-30'), null, 'parseDayKey rejects 30 February')
+check(parseDayKey('2026-13-01'), null, 'parseDayKey rejects month 13')
+check(parseDayKey('not-a-date'), null, 'parseDayKey rejects free text')
+check(parseDayKey('2028-02-29').day, 29, 'parseDayKey accepts 29 February in a leap year')
+check(parseDayKey('2026-02-29'), null, 'parseDayKey rejects 29 February in a common year')
+
+check(compareDays({ year: 2026, month: 1, day: 5 }, { year: 2026, month: 1, day: 5 }), 0, 'compareDays equal')
+checkTrue(compareDays({ year: 2025, month: 12, day: 31 }, { year: 2026, month: 1, day: 1 }) < 0, 'compareDays across a year boundary')
+checkTrue(compareDays({ year: 2026, month: 3, day: 1 }, { year: 2026, month: 2, day: 28 }) > 0, 'compareDays across a month boundary')
+
+check(monthDayKeys(2026, 2).length, 28, 'February 2026 yields 28 keys')
+check(monthDayKeys(2028, 2).at(-1), '2028-02-29', 'leap February ends on the 29th')
+
+// ---------------------------------------------------------------------------
+section('Time zones')
+// ---------------------------------------------------------------------------
+
+checkTrue(isValidTimeZone(IST), 'Asia/Kolkata is a real zone')
+checkTrue(isValidTimeZone('UTC'), 'UTC is a real zone')
+checkFalse(isValidTimeZone('Mars/Olympus'), 'an invented zone is refused')
+checkFalse(isValidTimeZone(''), 'the empty string is not a zone')
+checkFalse(isValidTimeZone(null), 'null is not a zone')
+checkFalse(isValidTimeZone(42), 'a number is not a zone')
+
+check(resolveTimeZone('Mars/Olympus', IST), IST, 'an invalid zone falls back')
+check(resolveTimeZone('Mars/Olympus', 'Also/Invalid'), DEFAULT_TIME_ZONE, 'a bad fallback lands on UTC')
+check(resolveTimeZone(`  ${TOKYO}  `), TOKYO, 'a valid zone is trimmed and kept')
+
+// 2026-01-31T03:30:00Z is 09:00 on 31 January in IST (+05:30) and 12:30 in Tokyo.
+const probe = Date.parse('2026-01-31T03:30:00.000Z')
+check(dayKeyOf(zonedFields(probe, IST)), '2026-01-31', 'IST sees 31 January')
+check(zonedFields(probe, IST).hour, 9, 'IST sees 09:00')
+check(zonedFields(probe, TOKYO).hour, 12, 'Tokyo sees 12:00')
+check(zonedFields(probe, TOKYO).minute, 30, 'Tokyo sees :30')
+check(zonedFields(probe, 'UTC').hour, 3, 'UTC sees 03:00')
+
+// A late-evening instant in IST is still the previous day in UTC — the day a
+// cell belongs to has to come from the zone, not from the raw instant.
+const lateIst = Date.parse('2026-01-31T19:30:00.000Z') // 01:00 on 1 Feb in IST
+check(dayKeyOf(zonedFields(lateIst, IST)), '2026-02-01', 'IST has already rolled over')
+check(dayKeyOf(zonedFields(lateIst, 'UTC')), '2026-01-31', 'UTC has not')
+
+check(zonedFields(Number.NaN, IST), null, 'a non-finite instant has no fields')
+
+// ---------------------------------------------------------------------------
+section('Wall clock to instant — the timezone-picker fix')
+// ---------------------------------------------------------------------------
+
+// This is the assertion the old `setHours()` could not satisfy: the same wall
+// clock in two zones is two different instants, five and a half hours apart
+// minus the four-hour IST/JST gap.
+const nineAmIst = wallClockToInstant({ year: 2026, month: 1, day: 31, hour: 9, minute: 0 }, IST)
+const nineAmTokyo = wallClockToInstant({ year: 2026, month: 1, day: 31, hour: 9, minute: 0 }, TOKYO)
+check(new Date(nineAmIst).toISOString(), '2026-01-31T03:30:00.000Z', '09:00 IST is 03:30Z')
+check(new Date(nineAmTokyo).toISOString(), '2026-01-31T00:00:00.000Z', '09:00 JST is 00:00Z')
+checkTrue(nineAmIst !== nineAmTokyo, 'the same wall clock in two zones is two instants')
+
+// And the round trip closes: what was typed is what is displayed.
+check(zonedFields(nineAmTokyo, TOKYO).hour, 9, 'Tokyo reads back the 9 that was typed')
+check(zonedFields(nineAmIst, IST).hour, 9, 'IST reads back the 9 that was typed')
+check(dayKeyOf(zonedFields(nineAmTokyo, TOKYO)), '2026-01-31', 'Tokyo reads back the day that was typed')
+
+// DST. New York is UTC-5 in January and UTC-4 in July; a fixed-offset
+// implementation gets exactly one of these right.
+const janNy = wallClockToInstant({ year: 2026, month: 1, day: 15, hour: 9, minute: 0 }, NEW_YORK)
+const julNy = wallClockToInstant({ year: 2026, month: 7, day: 15, hour: 9, minute: 0 }, NEW_YORK)
+check(new Date(janNy).toISOString(), '2026-01-15T14:00:00.000Z', '09:00 EST is 14:00Z')
+check(new Date(julNy).toISOString(), '2026-07-15T13:00:00.000Z', '09:00 EDT is 13:00Z')
+check(zonedFields(julNy, NEW_YORK).hour, 9, 'the July round trip closes across DST')
+
+// The hour after a spring-forward gap: 02:30 on 8 March 2026 does not exist in
+// New York. Landing on the instant just after the jump is the conventional
+// resolution; what matters is that it is finite and inside that day.
+const gap = wallClockToInstant({ year: 2026, month: 3, day: 8, hour: 2, minute: 30 }, NEW_YORK)
+checkTrue(Number.isFinite(gap), 'a non-existent wall time still resolves to an instant')
+check(dayKeyOf(zonedFields(gap, NEW_YORK)), '2026-03-08', 'and stays on the intended day')
+
+check(wallClockToInstant(null, IST), null, 'a missing wall clock has no instant')
+check(wallClockToInstant({ year: Number.NaN, month: 1, day: 1 }, IST), null, 'a non-finite year has no instant')
+
+// ---------------------------------------------------------------------------
+section('Parsing')
+// ---------------------------------------------------------------------------
+
+check(parseInstant('2026-01-31T03:30:00.000Z'), Date.parse('2026-01-31T03:30:00.000Z'), 'a full ISO instant parses')
+check(parseInstant('2026-01-31T03:30'), Date.parse('2026-01-31T03:30'), 'a local ISO instant parses')
+check(parseInstant('2026-01-31T09:00:00+05:30'), Date.parse('2026-01-31T09:00:00+05:30'), 'an offset instant parses')
+check(parseInstant('Jan 5 2026'), null, 'a loose date string is refused')
+check(parseInstant('2026'), null, 'a bare year is refused')
+check(parseInstant('2026-01-31'), null, 'a bare day is not an instant')
+check(parseInstant('tomorrow'), null, 'free text is refused')
+check(parseInstant(null), null, 'null is refused')
+check(parseInstant(1738294200000), null, 'a raw number is refused')
+check(parseInstant(new Date('2026-01-31T03:30:00Z')), Date.parse('2026-01-31T03:30:00Z'), 'a Date is accepted')
+check(parseInstant(new Date('nope')), null, 'an Invalid Date is refused')
+
+check(parseWallTime('09:00').hour, 9, 'HH:mm parses the hour')
+check(parseWallTime('9:05').minute, 5, 'H:mm parses the minute')
+check(parseWallTime('24:00'), null, 'hour 24 is refused')
+check(parseWallTime('09:60'), null, 'minute 60 is refused')
+check(parseWallTime('0900'), null, 'a missing colon is refused')
+check(parseWallTime(null), null, 'null is not a time')
+
+check(composeStartTime('2026-01-31', '09:00', TOKYO), '2026-01-31T00:00:00.000Z', 'compose uses the given zone')
+check(composeStartTime('2026-02-30', '09:00', IST), null, 'compose refuses an impossible day')
+check(composeStartTime('2026-01-31', '25:00', IST), null, 'compose refuses an impossible time')
+
+check(isUuid('3f7c1b2e-9a44-4a1e-8b2d-0c6f5d3e2a11'), true, 'a v4 UUID is a UUID')
+check(isUuid('  3f7c1b2e-9a44-4a1e-8b2d-0c6f5d3e2a11  '), true, 'surrounding space is tolerated')
+check(isUuid('not-a-uuid'), false, 'free text is not a UUID')
+check(isUuid('3f7c1b2e9a444a1e8b2d0c6f5d3e2a11'), false, 'an unhyphenated string is not accepted')
+check(isUuid("1' OR '1'='1"), false, 'an injection attempt is not a UUID')
+check(isUuid(null), false, 'null is not a UUID')
+
+// ---------------------------------------------------------------------------
+section('Recurrence — the month-length bug')
+// ---------------------------------------------------------------------------
+
+check(clampDayToMonth(31, 2026, 2), 28, '31 clamps to 28 in February 2026')
+check(clampDayToMonth(31, 2028, 2), 29, '31 clamps to 29 in February 2028')
+check(clampDayToMonth(31, 2026, 4), 30, '31 clamps to 30 in April')
+check(clampDayToMonth(31, 2026, 3), 31, '31 stays 31 in March')
+check(clampDayToMonth(15, 2026, 2), 15, 'a mid-month day never clamps')
+
+// Anchored 09:00 IST on 31 January 2026, repeating monthly.
+const monthly = describeAnchor(event({ recurrence_rule: 'monthly' }), IST)
+check(monthly.day, 31, 'the anchor day is read in the viewer zone')
+check(monthly.hour, 9, 'the anchor hour is read in the viewer zone')
+
+checkTrue(occursOn(monthly, cell('2026-01-31')), 'monthly occurs on its own anchor day')
+checkFalse(occursOn(monthly, cell('2026-01-30')), 'monthly does not occur before the anchor')
+checkTrue(occursOn(monthly, cell('2026-02-28')), 'monthly falls on the last day of February — the old code skipped it')
+checkFalse(occursOn(monthly, cell('2026-02-27')), 'and not on the 27th')
+checkTrue(occursOn(monthly, cell('2026-03-31')), 'March still gets the 31st')
+checkFalse(occursOn(monthly, cell('2026-03-28')), 'March does not also get the 28th — no drift after a clamp')
+checkTrue(occursOn(monthly, cell('2026-04-30')), 'April falls on the 30th')
+checkTrue(occursOn(monthly, cell('2028-02-29')), 'a leap February gets the 29th')
+checkFalse(occursOn(monthly, cell('2028-02-28')), 'and not the 28th as well')
+
+// The pre-fix behaviour, spelled out: over a year, a 31st-of-the-month reminder
+// used to exist in 7 months out of 12.
+const twelveMonths = [
+  '2026-01-31', '2026-02-28', '2026-03-31', '2026-04-30', '2026-05-31', '2026-06-30',
+  '2026-07-31', '2026-08-31', '2026-09-30', '2026-10-31', '2026-11-30', '2026-12-31',
+]
+check(twelveMonths.filter((d) => occursOn(monthly, cell(d))).length, 12, 'a monthly reminder occurs in all twelve months')
+
+// Yearly on 29 February.
+const yearly = describeAnchor(
+  event({ recurrence_rule: 'yearly', start_time: '2028-02-29T03:30:00.000Z' }),
+  IST
+)
+checkTrue(occursOn(yearly, cell('2028-02-29')), 'the leap-day anchor occurs')
+checkTrue(occursOn(yearly, cell('2029-02-28')), 'and lands on 28 February the following year')
+checkFalse(occursOn(yearly, cell('2029-03-01')), 'not on 1 March')
+checkTrue(occursOn(yearly, cell('2032-02-29')), 'and back on the 29th four years later')
+checkFalse(occursOn(yearly, cell('2029-01-28')), 'the month still has to match')
+
+// Daily and weekly.
+const daily = describeAnchor(event({ recurrence_rule: 'daily' }), IST)
+checkTrue(occursOn(daily, cell('2026-01-31')), 'daily occurs on its anchor day')
+checkTrue(occursOn(daily, cell('2026-02-01')), 'daily occurs the next day')
+checkTrue(occursOn(daily, cell('2027-06-14')), 'daily keeps going')
+checkFalse(occursOn(daily, cell('2026-01-30')), 'daily does not occur before the anchor')
+
+const weekly = describeAnchor(event({ recurrence_rule: 'weekly' }), IST)
+check(weekly.weekday, weekdayOf(2026, 1, 31), 'weekly remembers its weekday')
+checkTrue(occursOn(weekly, cell('2026-02-07')), 'weekly repeats seven days later')
+checkFalse(occursOn(weekly, cell('2026-02-06')), 'and not six days later')
+
+const once = describeAnchor(event(), IST)
+checkTrue(occursOn(once, cell('2026-01-31')), 'a one-off occurs on its day')
+checkFalse(occursOn(once, cell('2026-02-28')), 'and never again')
+
+// The anchor-day comparison. `date >= evtDate` compared a midnight cell against
+// the event's real time, so a 09:00 event failed its own day.
+const evening = describeAnchor(
+  event({ recurrence_rule: 'daily', start_time: '2026-01-31T18:00:00.000Z' }),
+  'UTC'
+)
+checkTrue(occursOn(evening, cell('2026-01-31')), 'an 18:00 event occurs on its own day')
+
+// Zone-sensitivity: the same instant anchors on different days in different zones.
+const rollover = event({ recurrence_rule: 'none', start_time: '2026-01-31T19:30:00.000Z' })
+check(dayKeyOf(describeAnchor(rollover, IST)), '2026-02-01', 'IST anchors on 1 February')
+check(dayKeyOf(describeAnchor(rollover, 'UTC')), '2026-01-31', 'UTC anchors on 31 January')
+
+check(describeAnchor(event({ start_time: 'nonsense' }), IST), null, 'an unparseable start has no anchor')
+check(describeAnchor(null, IST), null, 'a missing event has no anchor')
+check(describeAnchor(event({ recurrence_rule: 'fortnightly' }), IST).rule, 'none', 'an unknown rule degrades to one-off')
+checkFalse(occursOn(null, cell('2026-01-31')), 'a null anchor never occurs')
+checkFalse(occursOn(monthly, null), 'a null cell never matches')
+
+// `end_time` only counts when it is actually after `start_time`.
+check(describeAnchor(event({ end_time: '2026-01-31T04:30:00.000Z' }), IST).endMs, Date.parse('2026-01-31T04:30:00.000Z'), 'a later end time is kept')
+check(describeAnchor(event({ end_time: '2026-01-30T00:00:00.000Z' }), IST).endMs, null, 'an end time before the start is discarded')
+
+// ---------------------------------------------------------------------------
+section('Occurrence index')
+// ---------------------------------------------------------------------------
+
+const feb = monthDayKeys(2026, 2)
+const index = buildOccurrenceIndex(
+  [
+    event({ id: 'a', recurrence_rule: 'monthly' }),
+    event({ id: 'b', recurrence_rule: 'daily', start_time: '2026-02-10T03:30:00.000Z' }),
+    event({ id: 'c', recurrence_rule: 'none', start_time: '2026-02-14T03:30:00.000Z' }),
+    event({ id: 'd', start_time: 'garbage' }),
+    null,
+  ],
+  feb,
+  IST
+)
+
+check(index.size, 28, 'every day of the month is present in the index')
+check(index.get('2026-02-01').length, 0, 'a quiet day is present and empty')
+check(index.get('2026-02-28').map((e) => e.id).join(','), 'a,b', 'the clamped monthly and the daily both land on the 28th')
+check(index.get('2026-02-14').map((e) => e.id).join(','), 'b,c', 'the one-off shares its day with the daily')
+check(index.get('2026-02-09').length, 0, 'the daily has not started on the 9th')
+checkFalse(feb.some((d) => index.get(d).some((e) => e.id === 'd')), 'an event with an unparseable start is skipped everywhere')
+
+// Ordering within a day is by start time, not by insertion.
+const ordered = buildOccurrenceIndex(
+  [
+    event({ id: 'late', start_time: '2026-02-14T18:00:00.000Z' }),
+    event({ id: 'early', start_time: '2026-02-14T01:00:00.000Z' }),
+  ],
+  ['2026-02-14'],
+  IST
+)
+check(ordered.get('2026-02-14').map((e) => e.id).join(','), 'early,late', 'a day’s events come back in time order')
+
+const empty = buildOccurrenceIndex(null, ['2026-02-14'], IST)
+check(empty.get('2026-02-14').length, 0, 'a null event list yields empty days')
+check(buildOccurrenceIndex([event()], ['not-a-day'], IST).size, 0, 'an unparseable day key is dropped from the index')
+
+// ---------------------------------------------------------------------------
+section('Write validation')
+// ---------------------------------------------------------------------------
+
+const good = validateEventInput({
+  title: '  Iron supplement  ',
+  description: '  with food  ',
+  start_time: '2026-01-31T03:30:00.000Z',
+  end_time: '2026-01-31T04:00:00.000Z',
+  recurrence_rule: 'monthly',
+  category: 'health',
+  time_zone: IST,
+})
+checkTrue(good.ok, 'a complete payload is accepted')
+check(good.value.title, 'Iron supplement', 'the title is trimmed')
+check(good.value.description, 'with food', 'the description is trimmed')
+check(good.value.start_time, '2026-01-31T03:30:00.000Z', 'the start time is normalised to ISO')
+check(good.value.category, 'health', 'the category is preserved')
+
+// The interval check the route never had.
+const backwards = validateEventInput({
+  title: 'Backwards',
+  start_time: '2026-01-31T04:00:00.000Z',
+  end_time: '2026-01-31T03:00:00.000Z',
+})
+checkFalse(backwards.ok, 'an event that ends before it starts is refused')
+check(backwards.error.field, 'end_time', 'and the offending field is named')
+check(backwards.error.status, 400, 'as a 400, not a 500')
+
+const identical = validateEventInput({
+  title: 'Zero length',
+  start_time: '2026-01-31T04:00:00.000Z',
+  end_time: '2026-01-31T04:00:00.000Z',
+})
+checkFalse(identical.ok, 'a zero-length event is refused')
+
+const tooLong = validateEventInput({
+  title: 'Forever',
+  start_time: '2026-01-31T04:00:00.000Z',
+  end_time: '2030-01-31T04:00:00.000Z',
+})
+checkFalse(tooLong.ok, 'an event lasting four years is refused')
+
+// Enums are refused, not silently rewritten. The route folded an unknown
+// category into `reminder`, so a client bug became stored data.
+const badCategory = validateEventInput({ title: 'x', start_time: '2026-01-31T04:00:00.000Z', category: 'urgent' })
+checkFalse(badCategory.ok, 'an unknown category is refused rather than rewritten')
+check(badCategory.error.field, 'category', 'and named')
+
+const badRule = validateEventInput({ title: 'x', start_time: '2026-01-31T04:00:00.000Z', recurrence_rule: 'fortnightly' })
+checkFalse(badRule.ok, 'an unknown recurrence is refused rather than rewritten')
+
+const badZone = validateEventInput({ title: 'x', start_time: '2026-01-31T04:00:00.000Z', time_zone: 'Mars/Olympus' })
+checkFalse(badZone.ok, 'an invented time zone is refused')
+check(badZone.error.field, 'time_zone', 'and named')
+
+checkFalse(validateEventInput({ title: '   ', start_time: '2026-01-31T04:00:00.000Z' }).ok, 'a whitespace title is refused')
+checkFalse(validateEventInput({ start_time: '2026-01-31T04:00:00.000Z' }).ok, 'a missing title is refused')
+checkFalse(validateEventInput({ title: 'x' }).ok, 'a missing start time is refused')
+checkFalse(validateEventInput({ title: 'x', start_time: 'tomorrow' }).ok, 'a loose start time is refused')
+checkFalse(validateEventInput({ title: 'x'.repeat(MAX_TITLE_LENGTH + 1), start_time: '2026-01-31T04:00:00.000Z' }).ok, 'an over-long title is refused')
+checkFalse(validateEventInput({ title: 'x', description: 'y'.repeat(MAX_DESCRIPTION_LENGTH + 1), start_time: '2026-01-31T04:00:00.000Z' }).ok, 'an over-long description is refused')
+checkFalse(validateEventInput(null).ok, 'a null body is refused')
+checkFalse(validateEventInput([]).ok, 'an array body is refused')
+checkFalse(validateEventInput('string').ok, 'a string body is refused')
+
+// Defaults only apply on create.
+const defaults = validateEventInput({ title: 'x', start_time: '2026-01-31T04:00:00.000Z' })
+check(defaults.value.category, 'reminder', 'create defaults the category')
+check(defaults.value.recurrence_rule, 'none', 'create defaults the recurrence')
+check(defaults.value.time_zone, DEFAULT_TIME_ZONE, 'create defaults the zone')
+check(defaults.value.end_time, null, 'create defaults the end time to null')
+check(defaults.value.description, '', 'create defaults the description to empty')
+
+// ---------------------------------------------------------------------------
+section('Partial updates')
+// ---------------------------------------------------------------------------
+
+const patch = validateEventInput({ id: 'x', title: 'Renamed' }, { partial: true })
+checkTrue(patch.ok, 'a one-field patch is accepted')
+check(Object.keys(patch.value).join(','), 'title', 'and touches only that field')
+check(patch.value.start_time, undefined, 'an absent start time is not written')
+check(patch.value.category, undefined, 'an absent category is not defaulted over')
+check(patch.value.time_zone, undefined, 'an absent zone is not defaulted over')
+
+// PostgREST rejects an empty patch; the route surfaced that as a 500.
+const nothing = validateEventInput({ id: 'x' }, { partial: true })
+checkFalse(nothing.ok, 'a patch naming no fields is refused')
+check(nothing.error.status, 400, 'as a 400')
+
+// The interval is still enforced when only one side is in the payload.
+const halfPatch = validateEventInput(
+  { id: 'x', end_time: '2026-01-31T02:00:00.000Z', __currentStartTime: '2026-01-31T04:00:00.000Z' },
+  { partial: true }
+)
+checkFalse(halfPatch.ok, 'a new end time before the stored start is refused')
+
+const okPatch = validateEventInput(
+  { id: 'x', end_time: '2026-01-31T05:00:00.000Z', __currentStartTime: '2026-01-31T04:00:00.000Z' },
+  { partial: true }
+)
+checkTrue(okPatch.ok, 'a new end time after the stored start is accepted')
+check(okPatch.value.__currentStartTime, undefined, 'the stored-row hint never reaches the write payload')
+
+const clearEnd = validateEventInput({ id: 'x', end_time: null }, { partial: true })
+checkTrue(clearEnd.ok, 'clearing the end time is expressible')
+check(clearEnd.value.end_time, null, 'and writes null')
+
+// ---------------------------------------------------------------------------
+section('Database error mapping')
+// ---------------------------------------------------------------------------
+
+check(describeEventError({ code: 'PGRST116' }).status, 404, 'a missing row is a 404, not a 500')
+check(describeEventError({ code: '22P02' }).status, 400, 'a malformed UUID is a 400')
+check(describeEventError({ code: '22007' }).status, 400, 'a malformed timestamp is a 400')
+check(describeEventError({ code: '22001' }).status, 400, 'an over-long value is a 400')
+check(describeEventError({ code: '23503' }).status, 409, 'a missing parent user is a 409')
+check(describeEventError({ code: '42P01' }).status, 503, 'a missing table is a 503')
+check(describeEventError({ code: '08006' }).status, 500, 'an unrecognised code stays a 500')
+check(describeEventError(null).status, 500, 'a null error is a 500')
+
+// Nothing from the driver may reach the client.
+const leaky = {
+  code: '08006',
+  message: 'could not connect to server: db.abcdefgh.supabase.co:6543 relation "public.events" constraint "events_pkey"',
+}
+const described = describeEventError(leaky)
+checkFalse(described.message.includes('supabase.co'), 'the pooler host does not leak')
+checkFalse(described.message.includes('public.events'), 'the relation name does not leak')
+checkFalse(described.message.includes('events_pkey'), 'the constraint name does not leak')
+
+for (const code of ['PGRST116', '22P02', '22007', '22008', '22001', '23503', '23514', '42P01', 'XX000', '']) {
+  const result = describeEventError({ code })
+  checkTrue(
+    typeof result.message === 'string' && result.message.length > 0 &&
+      Number.isInteger(result.status) && typeof result.code === 'string' && result.code.length > 0,
+    `every branch is fully described (${code || 'empty'})`
+  )
+}
+
+// ---------------------------------------------------------------------------
+section('Delete results')
+// ---------------------------------------------------------------------------
+
+// `DELETE` answered "Event deleted successfully" whether or not a row matched,
+// so removing an id that was already gone looked identical to a real deletion.
+check(readDeleteResult({ count: 1 }).deleted, true, 'one deleted row is a deletion')
+check(readDeleteResult({ count: 0 }).deleted, false, 'zero rows is not a deletion')
+check(readDeleteResult({ count: null }).deleted, false, 'a null count is not a deletion')
+check(readDeleteResult({}).deleted, false, 'a missing count is not a deletion')
+check(readDeleteResult(null).deleted, false, 'a null result is not a deletion')
+check(readDeleteResult({ count: 0 }).count, 0, 'the count is reported')
+
+// ---------------------------------------------------------------------------
+section('Contract constants')
+// ---------------------------------------------------------------------------
+
+check(EVENT_CATEGORIES.join(','), 'reminder,habit,donation,health', 'the categories match supabase/08_events.sql')
+check(RECURRENCE_RULES.join(','), 'none,daily,weekly,monthly,yearly', 'the recurrence rules match the column comment')
+checkTrue(Object.isFrozen(EVENT_CATEGORIES), 'the category list cannot be mutated at runtime')
+checkTrue(Object.isFrozen(RECURRENCE_RULES), 'the recurrence list cannot be mutated at runtime')
+checkTrue(MAX_EVENTS_RETURNED > 0 && Number.isInteger(MAX_EVENTS_RETURNED), 'the GET ceiling is a positive integer')
+
+console.log(`\n${failed === 0 ? 'PASS' : 'FAIL'} ${passed} passed, ${failed} failed`)
+process.exit(failed === 0 ? 0 : 1)

--- a/supabase/11_events_integrity.sql
+++ b/supabase/11_events_integrity.sql
@@ -1,0 +1,100 @@
+-- Migration 11: calendar event integrity
+--
+-- `supabase/08_events.sql` created `public.events` with the accepted values for
+-- `recurrence_rule` and `category` written down as a trailing comment:
+--
+--   recurrence_rule TEXT DEFAULT 'none', -- 'none' | 'daily' | 'weekly' | ...
+--   category        TEXT DEFAULT 'reminder', -- 'reminder' | 'habit' | ...
+--
+-- A comment is not a constraint. `app/api/events/route.js` folded anything it
+-- did not recognise into the default instead of refusing it, so a client
+-- sending the wrong constant produced a stored event that quietly disagreed
+-- with what the user picked, and nothing anywhere reported it.
+--
+-- `end_time` had no relationship to `start_time` at all: an event that ended
+-- before it began was a valid row.
+--
+-- Idempotent — safe to run against a database that already has the table, and
+-- safe to run twice. `CREATE TABLE IF NOT EXISTS` cannot add a constraint to an
+-- existing table, which is why these are separate ALTER statements.
+
+-- --------------------------------------------------------------------------
+-- 1. Normalise any rows that predate the constraints, so the ALTERs can pass.
+-- --------------------------------------------------------------------------
+
+UPDATE public.events
+   SET recurrence_rule = 'none'
+ WHERE recurrence_rule IS NULL
+    OR recurrence_rule NOT IN ('none', 'daily', 'weekly', 'monthly', 'yearly');
+
+UPDATE public.events
+   SET category = 'reminder'
+ WHERE category IS NULL
+    OR category NOT IN ('reminder', 'habit', 'donation', 'health');
+
+UPDATE public.events
+   SET time_zone = 'UTC'
+ WHERE time_zone IS NULL
+    OR btrim(time_zone) = '';
+
+-- An end time that is not after the start time carries no information; drop it
+-- rather than guess at what was meant.
+UPDATE public.events
+   SET end_time = NULL
+ WHERE end_time IS NOT NULL
+   AND end_time <= start_time;
+
+UPDATE public.events
+   SET title = left(btrim(title), 120)
+ WHERE length(btrim(title)) > 120
+    OR title <> btrim(title);
+
+UPDATE public.events
+   SET description = left(btrim(coalesce(description, '')), 1000)
+ WHERE description IS NULL
+    OR length(btrim(description)) > 1000
+    OR description <> btrim(description);
+
+-- --------------------------------------------------------------------------
+-- 2. The constraints themselves.
+-- --------------------------------------------------------------------------
+
+ALTER TABLE public.events DROP CONSTRAINT IF EXISTS events_recurrence_rule_check;
+ALTER TABLE public.events
+  ADD CONSTRAINT events_recurrence_rule_check
+  CHECK (recurrence_rule IN ('none', 'daily', 'weekly', 'monthly', 'yearly'));
+
+ALTER TABLE public.events DROP CONSTRAINT IF EXISTS events_category_check;
+ALTER TABLE public.events
+  ADD CONSTRAINT events_category_check
+  CHECK (category IN ('reminder', 'habit', 'donation', 'health'));
+
+-- The interval rule. NULL is still a valid `end_time`; what is refused is an
+-- end that does not come after the beginning.
+ALTER TABLE public.events DROP CONSTRAINT IF EXISTS events_interval_check;
+ALTER TABLE public.events
+  ADD CONSTRAINT events_interval_check
+  CHECK (end_time IS NULL OR end_time > start_time);
+
+ALTER TABLE public.events DROP CONSTRAINT IF EXISTS events_title_length_check;
+ALTER TABLE public.events
+  ADD CONSTRAINT events_title_length_check
+  CHECK (length(title) BETWEEN 1 AND 120);
+
+ALTER TABLE public.events DROP CONSTRAINT IF EXISTS events_description_length_check;
+ALTER TABLE public.events
+  ADD CONSTRAINT events_description_length_check
+  CHECK (description IS NULL OR length(description) <= 1000);
+
+ALTER TABLE public.events ALTER COLUMN time_zone SET DEFAULT 'UTC';
+
+-- --------------------------------------------------------------------------
+-- 3. The index the list query reads.
+--
+-- `GET /api/events` orders by `start_time` within one `user_id` and is now
+-- bounded by a LIMIT; without this index that is a sort over the whole
+-- partition on every page load.
+-- --------------------------------------------------------------------------
+
+CREATE INDEX IF NOT EXISTS events_user_start_idx
+  ON public.events (user_id, start_time DESC);


### PR DESCRIPTION
## Linked Issue
Fixes #796

## Description

The calendar has a timezone picker. It changes what the cards say and nothing else.

The modal built `start_time` with the **browser's** clock:

```js
const [hours, minutes] = formTime.split(':').map(Number)
const combinedDate = new Date(selectedDate)
combinedDate.setHours(hours || 9, minutes || 0, 0, 0)
```

and the card read it back with the **selected** zone:

```js
new Intl.DateTimeFormat(..., { timeZone: selectedTimeZone, ... }).format(d)
```

`setHours()` resolves against the one zone the user did not choose. Pick *Japan Standard Time* while your machine is on IST, type `09:00`, save — the card comes back reading **12:30 PM**. `time_zone` was written on every insert and read by nothing.

### The modal has no date field

It has a title, a description, a category, a recurrence and a time. `handleSaveEvent` builds `start_time` from `selectedDate` on **both** the create and the edit path. So opening an event from the side panel while a different day is highlighted and changing only its title relocates the event to the highlighted day — silently, under a green "Event updated!" toast.

### Monthly recurrences skip five months a year

```js
if (evt.recurrence_rule === 'monthly' && date >= evtDate && date.getDate() === evtDate.getDate()) return true
```

A reminder anchored on the 31st does not exist in February, April, June, September or November. Anchored on the 30th, it does not exist in February. A yearly event on 29 February appears once every four years. For a period-tracking app, "every month on the 30th" quietly missing months is the wrong failure.

The same expression compares a midnight-local grid cell against the event's real instant, so `date >= evtDate` is false for the anchor day itself for any event later than midnight; only the `isSameDay` branch above it hid that.

### 43 full scans per keystroke

`getEventsForDate` was called once per grid cell (up to 42) plus once for the side panel. Each call filtered the whole event list and re-parsed every `start_time` with `parseISO`. Nothing was memoised, and the modal's form state lives in the same component — so **every character typed into the title field** paid for all 43 passes.

### The API accepted what the database could not store, and reported success for writes that did not happen

| Input | Before | After |
|---|---|---|
| `end_time` before `start_time` | stored | `400` |
| `id` that is not a UUID (`events.id` is `UUID`) | `500 Failed to update event` (Postgres `22P02`) | `400` |
| `PUT` on a missing or foreign event | `500` (PostgREST `PGRST116` through `.single()`) | `404` |
| `DELETE` on a missing or foreign event | `200 Event deleted successfully` | `404` |
| `PUT` with only an `id` | `500` (PostgREST rejects an empty patch) | `400` |
| `category: 'urgent'` | silently stored as `'reminder'` | `400` |
| `time_zone: 'Mars/Olympus'` | stored, then thrown by `Intl` on read | `400` |
| 40 KB `title` | `500` (`22001`) | `400` |
| `GET` | every event the account has ever created | 500 most recent, with `truncated` |

## The fix

**`lib/event-schedule.js` (new)** holds every decision, and makes all of them on calendar fields resolved in **one** zone rather than on raw millisecond comparisons:

- `zonedFields(instant, zone)` — what a zone sees, via `Intl.DateTimeFormat`.
- `wallClockToInstant(wall, zone)` — the missing half of the picker. The offset is applied twice, because the offset depends on the instant; that is what makes it correct across a DST boundary rather than at one fixed offset.
- `describeAnchor` runs `Intl` **once per event**; `occursOn` is then integer comparison, so a 42-cell month costs one pass per event instead of 43 passes over the list.
- `clampDayToMonth` gives monthly recurrence the behaviour the word implies: the 31st falls on 28 (or 29) February and 30 April, and clamping is always computed from the **anchor's** day-of-month, so February does not drag the series down to the 28th permanently.

**The route validates rather than rewrites.** An unrecognised `category` was folded into `reminder`, which turns a client bug into stored data that disagrees with what the user picked, reported by nothing. It is now a `400` that names the field.

**`PUT` reads the stored row first**, so `end_time > start_time` is still enforceable when the payload carries only one of the two — and so a missing row is a `404` before an update is attempted rather than a `PGRST116` after it.

**`DELETE` counts rows.** Without `{ count: 'exact' }` it reported success for a row it had not touched, and the calendar refetched into an unchanged state under a green toast.

**`supabase/11_events_integrity.sql` (new)** turns `08_events.sql`'s trailing comments into constraints. A comment is not a constraint:

```sql
recurrence_rule TEXT DEFAULT 'none', -- 'none' | 'daily' | 'weekly' | 'monthly' | 'yearly'
```

It is idempotent, and normalises pre-existing rows before adding each CHECK so it converges a database that already has data.

### Response envelope

`GET` moves from `{ success, events }` to the project's standard `jsonSuccess` envelope, `{ success, data: { events, truncated, limit } }`, matching `/api/cycles`, `/api/profile` and `/api/weight`. `MultiLangCalendar` is the only consumer and is updated in the same commit.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (clean code updates, no behavior modifications)
- [ ] Documentation update
- [x] Performance optimization
- [ ] Security patch

## Files Modified

| File | Change |
|------|--------|
| `lib/event-schedule.js` | **New.** Zoned calendar fields, wall-clock↔instant, recurrence expansion with month-end clamping, write validation, PG error mapping |
| `scripts/test-event-schedule.js` | **New.** 198 assertions |
| `supabase/11_events_integrity.sql` | **New.** Idempotent CHECKs for the enums and the interval, plus the list index |
| `app/api/events/route.js` | Validation instead of coercion; UUID gate; 404 for untouched rows; counted deletes; bounded GET; no driver messages |
| `components/calendar/MultiLangCalendar.jsx` | Date field in the modal; the selected zone drives reads *and* writes; one memoised occurrence index; load failures surface |

## Testing

```bash
node scripts/test-event-schedule.js
# PASS 198 passed, 0 failed

npx next build --webpack
# ✓ Compiled successfully

npx eslint components/calendar/MultiLangCalendar.jsx lib/event-schedule.js app/api/events/route.js
# clean
```

The suite pins the things that were actually wrong. It asserts that `09:00` in Tokyo and `09:00` in IST are **two different instants** and that each reads back as `9` in its own zone — the round trip the old code could not close. It runs the New York conversion in both January and July, so a fixed-offset implementation fails one of them. It walks all twelve months of a 31st-anchored monthly reminder and requires **twelve** occurrences (the old expression produced seven), checks that March still gets the 31st after February clamped to the 28th so the series does not drift, and follows a 29 February anniversary through 2029 and back to 2032. It asserts an event with an unparseable `start_time` is skipped rather than crashing the index, that no Postgres branch leaks the pooler host, the relation name or the constraint name, and that a partial update never writes the `__currentStartTime` hint it was given.

Manual, against a local database with `supabase/11_events_integrity.sql` applied:

1. Select *Japan Standard Time*, create an event at `09:00` → the card reads **9:00 AM**, not 12:30 PM.
2. Select a different day, edit that event's title, save → it stays on its own day.
3. Create a monthly reminder on 31 January → it appears on 28 February, 31 March and 30 April.
4. `curl -X DELETE '.../api/events?id=not-a-uuid'` → `400`, not `500`.
5. `curl -X DELETE '.../api/events?id=<a valid but foreign uuid>'` → `404`, not "Event deleted successfully".
6. `curl -X PUT ... -d '{"id":"<uuid>"}'` → `400 No updatable fields were provided`, not `500`.
7. Run the migration twice → no error.

## Screenshots (if UI changes are made)
The modal gains one field — a **Date** input beside the existing **Time** input, with a line underneath reading which zone the event will be saved in. Nothing else about the calendar's layout changes.

## Checklist
- [x] This PR is submitted under ECSOC.
- [x] Added the required **ECSoc26** label to this Pull Request.
- [x] Linked issue using `Fixes #796`.
- [x] Tested locally.
- [x] `npm run build` completes successfully.
- [x] No breaking changes introduced.
- [x] Documentation updated if required.
